### PR TITLE
Implemented proper cli behaviour

### DIFF
--- a/src/cobalt.rs
+++ b/src/cobalt.rs
@@ -15,15 +15,12 @@ impl Runner {
         let documents_path = source_path.join("_posts");
         let layout_path    = source_path.join("_layouts");
         let index_path     = source_path.join("index.tpl");
-        let build_path     = dest_path.join("build");
-
-        // println!("Generating site in {}\n", dest_path.display());
 
         let index     = Runner::parse_document(&index_path);
         let posts     = Runner::parse_documents(&documents_path);
-        let post_path = Runner::create_dirs(&build_path);
+        let post_path = Runner::create_dirs(&dest_path);
 
-        Runner::create_files(&build_path, &post_path, &layout_path, index, posts);
+        Runner::create_files(&dest_path, &post_path, &layout_path, index, posts);
     }
 
     fn parse_documents(path: &Path) -> Vec<Document> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -59,7 +59,7 @@ fn main() {
 
     match command.as_slice() {
         "build" => {
-            println!("building from {} into {}", source.display(), dest.join("build").display());
+            println!("building from {} into {}", source.display(), dest.display());
             Runner::build(source, dest);
         },
 


### PR DESCRIPTION
## New behaviour:

Available commands: build

Available options: -s / --source , -d / --destination

If a user executes `cobalt build` per default source and destination path are set to `.` (current directory)
