### PR TITLE
Implement template rendering across directories

### DIFF
--- a/src/document.rs
+++ b/src/document.rs
@@ -1,6 +1,7 @@
 use std::fmt;
 use std::io;
 use std::collections::HashMap;
+use std::io::fs;
 use std::io::File;
 use std::io::IoResult;
 
@@ -9,15 +10,15 @@ use mustache;
 pub struct Document {
     pub attributes: HashMap<String, String>,
     pub content: String,
-    pub filename: String,
+    pub path: Path,
 }
 
 impl Document {
-    pub fn new(attributes: HashMap<String, String>, content: String, filename: String) -> Document {
+    pub fn new(attributes: HashMap<String, String>, content: String, path: Path) -> Document {
         Document {
             attributes: attributes,
             content: content,
-            filename: filename,
+            path: path,
         }
     }
 
@@ -37,11 +38,14 @@ impl Document {
         w.unwrap().into_ascii().into_string()
     }
 
-    pub fn create_file(&self, path: &Path, layout_root: &Path) -> IoResult<()>{
+    pub fn create_file(&self, dest: &Path, layout_root: &Path) -> IoResult<()>{
         let layout_path = layout_root.join(self.attributes.get_copy(&"@extends".to_string()));
         // TODO this is super inefficient
         let layout      = File::open(&layout_path).read_to_string().unwrap();
-        let file_path   = path.join(self.filename.as_slice());
+        let file_path   = dest.join(&self.path);
+
+        // create target directories
+        try!(fs::mkdir_recursive(&file_path.dir_path(), io::USER_RWX));
 
         let mut file = File::create(&file_path);
         let mut data = HashMap::new();
@@ -58,13 +62,13 @@ impl Document {
         // TODO: wrap with try!, mustache.rs uses its own error format :/
         template.render(&mut file, &data);
 
-        println!("Created {}/{}", path.display(), self.filename);
+        println!("Created {}", file_path.display());
         Ok(())
     }
 }
 
 impl fmt::Show for Document {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "Attributes: {}\nContent: {}\n\nFilename: {}", self.attributes, self.content, self.filename)
+        write!(f, "Attributes: {}\nContent: {}\n\nFilename: {}", self.attributes, self.content, self.path.display())
     }
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -10,7 +10,7 @@ pub fn copy_recursive_filter(source: &Path, dest: &Path, valid: |&Path| -> bool)
             if entry.is_dir() {
                 if valid(entry) {
                     let new_dest = &dest.join(entry.path_relative_from(source).unwrap());
-                    try!(fs::mkdir(new_dest, io::USER_READ));
+                    try!(fs::mkdir_recursive(new_dest, io::USER_RWX));
                     try!(copy_recursive_filter(entry, new_dest, |p| valid(p)));
                 }
             } else {


### PR DESCRIPTION
This partly solves #10, directories are walked and all files with a corresponding filename extension are compiled.

Now we need config file support for settings the extension and the posts folder(s).
