### PR TITLE
Fixes for nightly, switch to liquid

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 /target
+/build
+
+.DS_Store

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,4 @@
 language: rust
 
 rust:
-  - 0.11.0
-  - 0.12.0
-  - 1.0.0-alpha.2
   - nightly

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2,11 +2,28 @@
 name = "cobalt"
 version = "0.0.1"
 dependencies = [
- "rust-mustache 0.3.0 (git+https://github.com/tsurai/rust-mustache)",
+ "liquid 0.0.1 (git+https://github.com/cobalt-org/liquid-rust)",
 ]
 
 [[package]]
-name = "rust-mustache"
-version = "0.3.0"
-source = "git+https://github.com/tsurai/rust-mustache#ac1eca765639284c10f7a278661cfe2e7075d1cd"
+name = "liquid"
+version = "0.0.1"
+source = "git+https://github.com/cobalt-org/liquid-rust#58268dbd13c703f34a030cf08250127e03059823"
+dependencies = [
+ "regex 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex_macros 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "regex"
+version = "0.1.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "regex_macros"
+version = "0.1.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "regex 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,5 +4,5 @@ name = "cobalt"
 version = "0.0.1"
 authors = ["Benny Klotz <r3qnbenni@gmail.com>", "Johann Hofmann"]
 
-[dependencies.rust-mustache]
-git = "https://github.com/tsurai/rust-mustache"
+[dependencies.liquid]
+git = "https://github.com/cobalt-org/liquid-rust"

--- a/README.md
+++ b/README.md
@@ -1,12 +1,6 @@
-#![Cobalt](https://raw.githubusercontent.com/cobalt-org/logos/master/cobald.logo.02.resize.png)
+#![Cobalt](https://raw.githubusercontent.com/cobalt-org/logos/master/cobald.logo.02.resize.png) [![](https://travis-ci.org/cobalt-org/cobalt.rs.svg?branch=master)](https://travis-ci.org/cobalt-org/cobalt.rs)
 
 A static site generator written in [Rust](http://www.rust-lang.org/).
-
-## NOTE:
-
-Needs to be updated to rust 1.0.0
-
-[![Build Status](https://travis-ci.org/cobalt-org/cobalt.rs.svg?branch=master)](https://travis-ci.org/cobalt-org/cobalt.rs)
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 #![Cobalt](https://raw.githubusercontent.com/cobalt-org/logos/master/cobald.logo.02.resize.png)
 
-A static site generator written in [rust](http://www.rust-lang.org/).
+A static site generator written in [Rust](http://www.rust-lang.org/).
 
 ## NOTE:
 
@@ -10,15 +10,15 @@ Needs to be updated to rust 1.0.0
 
 ## Usage
 
-### Layout / Design
+### Layouts
 
-You can have a custom layout in the ```_layouts``` Directory.
+You can have custom layouts in the ```_layouts``` directory.
 
-Same as Post files Layout files are written as [mustache](https://github.com/erickt/rust-mustache) templates.
+Layouts will be compiled as [liquid](https://github.com/cobalt-org/liquid-rust) templates.
 
 ### Posts
 
-Posts live in ```_posts``` and are written in .tpl format and use mustache under the hood.
+Posts live in ```_posts```.
 
 Example:
 
@@ -33,14 +33,25 @@ Hey there this is my first blogpost and this is super awesome.
 My Blog is lorem ipsum like, yes it is..
 ```
 
-The content before ```---``` are meta attributes and accessible via their key.
+The content before ```---``` are meta attributes made accessible to the template via their key (see below).
 
-Via ```@extends``` attribute you speficy which layout will be used.
+The ```@extends``` attribute specifies which layout will be used.
 
-In the specific layout file title is accessible via ```{{ title }}``` and the date via ```{{ date }}``` (Attributes are also accessible in the post content itself).
+### Other files
 
-Also there is one standard attribute which is named statically - ```{{ content }}``` which is the whole text under the ```---``` block.
+Any file with the .tpl file extension will be parsed for metadata and compiled using liquid, like a post.
 
+Unlike posts, files outside the ``_posts`` directory will not be indexed as blog posts and not passed to the index file in the list of contents.
+
+All other files and directories in the source folder will be recursively added to your destination folder.
+
+### Attributes
+
+All template files have access to a set of attributes.
+
+In example above _title_ is accessible via ```{{ title }}``` and _date_ via ```{{ date }}```, for the layout template as well as the post template.
+
+There is one special attribute accessible only to layouts which is named ```{{ content }}``` and is the whole text under the ```---``` block of the post.
 
 ### Generate
 
@@ -64,5 +75,9 @@ Cobalt will generate:
                 * 2014-08-24-my-first-blogpost.html
                 * 2014-09-05-my-second-blogpost.html
 
-README will be completed soon...
+TODO:
+
+- [ ] Improve Documention
+- [ ] Fill index file with post list
+- [ ] Draft Support
 

--- a/README.md
+++ b/README.md
@@ -65,3 +65,4 @@ Cobalt will generate:
                 * 2014-09-05-my-second-blogpost.html
 
 README will be completed soon...
+

--- a/example/_layouts/default.tpl
+++ b/example/_layouts/default.tpl
@@ -6,7 +6,7 @@
     <body>
         <h1>{{ name }}</h1>
 
-        {{{ content }}}
+        {{ content }}
     </body>
 </html>
 

--- a/example/_layouts/posts.tpl
+++ b/example/_layouts/posts.tpl
@@ -1,11 +1,12 @@
 <!DOCTYPE html>
 <html>
     <head>
-        <title>Post test</title>
+        <title>My blog - {{ title }}</title>
     </head>
     <body>
         <h1>{{ name }}</h1>
 
-        {{{ content }}}
+        {{ content }}
     </body>
 </html>
+

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,9 @@
-extern crate mustache;
+#![feature(path_ext)]
+#![feature(fs_walk)]
+#![feature(core)]
+#![feature(path_relative_from)]
+
+extern crate liquid;
 
 // without this main.rs would have to use cobalt::cobalt
 // with this approach you can explicitly say which part of a module is public and which not

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,18 +1,20 @@
+#![feature(rustc_private)]
+#![feature(collections)]
+
 extern crate cobalt;
 extern crate getopts;
 
 use getopts::{optopt, optflag, getopts, usage};
-use std::os;
+use std::env;
+use std::path::PathBuf;
 
 fn print_version() {
-    // parse this from Cargo.toml
-    let version = vec!["0", "0", "1"];
-
-    println!("{}", version.connect("."));
+    // TODO parse this from Cargo.toml
+    println!("0.0.1");
 }
 
 fn main() {
-    let args: Vec<String> = os::args();
+    let args: Vec<String> = env::args().collect();
 
     let opts = [
         optopt("s", "source", "Build from example/folder", "[example/folder]"),
@@ -21,25 +23,33 @@ fn main() {
         optflag("v", "version", "Display version")
     ];
 
-    let matches = match getopts(args.tail(), opts) {
+    let matches = match getopts(args.tail(), &opts) {
         Ok(m) => { m }
         Err(f) => { panic!(f.to_string()) }
     };
 
-    let source = if matches.opt_present("s") {
-        Path::new(matches.opt_str("s").unwrap())
+    let mut source_buf = PathBuf::new();
+
+    if matches.opt_present("s") {
+        source_buf.push(&matches.opt_str("s").unwrap())
     } else {
-        Path::new(".".to_string())
+        source_buf.push("./")
     };
 
-    let dest   = if matches.opt_present("d") {
-        Path::new(matches.opt_str("d").unwrap())
+    let source = source_buf.as_path();
+
+    let mut dest_buf = PathBuf::new();
+
+    if matches.opt_present("d") {
+        dest_buf.push(&matches.opt_str("d").unwrap())
     } else {
-        Path::new(".".to_string())
+        dest_buf.push("./")
     };
+
+    let dest = dest_buf.as_path();
 
     if matches.opt_present("h") {
-        println!("{}", usage("\n\tcobalt build", opts));
+        println!("{}", usage("\n\tcobalt build", &opts));
         return;
     }
 
@@ -51,21 +61,21 @@ fn main() {
     let command = if !matches.free.is_empty() {
         matches.free[0].clone()
     } else {
-        println!("{}", usage("\n\tcobalt build", opts));
+        println!("{}", usage("\n\tcobalt build", &opts));
         return;
     };
 
-    match command.as_slice() {
+    match command.as_ref() {
         "build" => {
             println!("building from {} into {}", source.display(), dest.display());
             match cobalt::build(&source, &dest){
                 Ok(_) => {},
-                Err(e) => panic!("{}", e)
+                Err(e) => println!("Error: {}", e)
             };
         },
 
         _ => {
-            println!("{}", usage("\n\tcobalt build", opts));
+            println!("{}", usage("\n\tcobalt build", &opts));
             return;
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -69,7 +69,7 @@ fn main() {
         "build" => {
             println!("building from {} into {}", source.display(), dest.display());
             match cobalt::build(&source, &dest){
-                Ok(_) => {},
+                Ok(_) => println!("Build successful"),
                 Err(e) => println!("Error: {}", e)
             };
         },


### PR DESCRIPTION
Basically the whole thing rewritten, since unfortunately for us Rust's io module got completely overhauled.

Cobalt now uses our very own liquid template engine, which is still very unstable but will do its job of filling in attributes in templates just fine. Working on adding more tags like a proper ``for`` loop.

Still much TODO, ideas are at the bottom of the readme for now.