### PR TITLE
replace unwrap() with expect(format!(...))

### DIFF
--- a/src/document.rs
+++ b/src/document.rs
@@ -66,8 +66,8 @@ impl Document {
 
         let file_path = file_path_buf.as_path();
 
-        let layout_path = self.attributes.get(&"@extends".to_string()).unwrap();
-        let layout = layouts.get(layout_path).unwrap();
+        let layout_path = self.attributes.get(&"@extends".to_string()).expect(&format!("No @extends line creating {:?}", self.name));
+        let layout = layouts.get(layout_path).expect(&format!("No layout path {:?} creating {:?}", layout_path, self.name));
 
         // create target directories if any exist
         match file_path.parent() {


### PR DESCRIPTION
`unwrap()` produces panics with no explanation, and on some platforms there are no line numbers in the backtrace even in debug builds (rust-lang/rust#24346). `expect()` with an informative message is a much better user experience.

before:

    $ ag -Q 'unwrap(' src | wc -l
      15

after:

    $ ag -Q 'unwrap(' src | wc -l
       0

I made my best guess for an explanation at each error location, but they should be audited by someone who knows how the code works!