### PR TITLE
Better error handling (fixes #34)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ authors = ["Benny Klotz <r3qnbenni@gmail.com>", "Johann Hofmann"]
 [dependencies]
 getopts = "0.2.14"
 markdown = "0.1"
-liquid = "0.1"
+liquid = "0.2"
 walkdir = "0.1"
 crossbeam = "0.1.5"
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,78 @@
+use std::result;
+use std::io;
+use std::error;
+use std::fmt;
+use walkdir;
+use liquid;
+
+// type alias because we always want to deal with CobaltErrors
+pub type Result<T> = result::Result<T, Error>;
+
+#[derive(Debug)]
+pub enum Error {
+    Io(io::Error),
+    Liquid(liquid::Error),
+    WalkDir(walkdir::Error),
+    Other(String),
+}
+
+impl From<io::Error> for Error {
+    fn from(err: io::Error) -> Error {
+        Error::Io(err)
+    }
+}
+
+impl From<liquid::Error> for Error {
+    fn from(err: liquid::Error) -> Error {
+        Error::Liquid(err)
+    }
+}
+
+impl From<walkdir::Error> for Error {
+    fn from(err: walkdir::Error) -> Error {
+        Error::WalkDir(err)
+    }
+}
+
+impl From<String> for Error {
+    fn from(err: String) -> Error {
+        Error::Other(err)
+    }
+}
+
+impl<'a> From<&'a str> for Error {
+    fn from(err: &'a str) -> Error {
+        Error::Other(err.to_owned())
+    }
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            Error::Io(ref err) => write!(f, "IO error: {}", err),
+            Error::Liquid(ref err) => write!(f, "Liquid error: {}", err),
+            Error::WalkDir(ref err) => write!(f, "walkdir error: {}", err),
+            Error::Other(ref err) => write!(f, "error: {}", err),
+        }
+    }
+}
+
+impl error::Error for Error {
+    fn description(&self) -> &str {
+        match *self {
+            Error::Io(ref err) => err.description(),
+            Error::Liquid(ref err) => err.description(),
+            Error::WalkDir(ref err) => err.description(),
+            Error::Other(ref err) => err,
+        }
+    }
+
+    fn cause(&self) -> Option<&error::Error> {
+        match *self {
+            Error::Io(ref err) => Some(err),
+            Error::Liquid(ref err) => Some(err),
+            Error::WalkDir(ref err) => Some(err),
+            Error::Other(_) => None,
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,10 +5,10 @@ extern crate markdown;
 extern crate walkdir;
 extern crate crossbeam;
 
-// without this main.rs would have to use cobalt::cobalt
-// with this approach you can explicitly say which part of a module is public and which not
 pub use cobalt::build;
+pub use error::Error;
 
 // modules
 mod cobalt;
+mod error;
 mod document;

--- a/tests/fixtures/liquid_error/_layouts/default.tpl
+++ b/tests/fixtures/liquid_error/_layouts/default.tpl
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>test</title>
+    </head>
+    <body>
+        <h1>{{ name }}</h1>
+
+        {{ content }}
+    </body>
+</html>
+

--- a/tests/fixtures/liquid_error/_layouts/posts.tpl
+++ b/tests/fixtures/liquid_error/_layouts/posts.tpl
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>My blog - {{ title }}</title>
+    </head>
+    <body>
+        {{ content }}
+    </body>
+</html>
+

--- a/tests/fixtures/liquid_error/_posts/2014-08-24-my-first-blogpost.md
+++ b/tests/fixtures/liquid_error/_posts/2014-08-24-my-first-blogpost.md
@@ -1,0 +1,10 @@
+@extends: posts.tpl
+
+title:   My first Blogpost
+date:    24/08/2014 at 15:36
+---
+# {{ title }}
+
+Hey there this is my first blogpost and this is super awesome.
+
+My Blog is lorem ipsum like, yes it is..

--- a/tests/fixtures/liquid_error/index.tpl
+++ b/tests/fixtures/liquid_error/index.tpl
@@ -1,0 +1,7 @@
+@extends: default.tpl
+---
+This is my Index page!
+
+{% for post in posts %}
+ {{ post.title }}
+{{{{{}}}}% endfor %}

--- a/tests/fixtures/no_extends_error/_layouts/default.tpl
+++ b/tests/fixtures/no_extends_error/_layouts/default.tpl
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>test</title>
+    </head>
+    <body>
+        <h1>{{ name }}</h1>
+
+        {{ content }}
+    </body>
+</html>
+

--- a/tests/fixtures/no_extends_error/_layouts/posts.tpl
+++ b/tests/fixtures/no_extends_error/_layouts/posts.tpl
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>My blog - {{ title }}</title>
+    </head>
+    <body>
+        {{ content }}
+    </body>
+</html>
+

--- a/tests/fixtures/no_extends_error/_posts/2014-08-24-my-first-blogpost.md
+++ b/tests/fixtures/no_extends_error/_posts/2014-08-24-my-first-blogpost.md
@@ -1,0 +1,8 @@
+title:   My first Blogpost
+date:    24/08/2014 at 15:36
+---
+# {{ title }}
+
+Hey there this is my first blogpost and this is super awesome.
+
+My Blog is lorem ipsum like, yes it is..

--- a/tests/fixtures/no_extends_error/index.tpl
+++ b/tests/fixtures/no_extends_error/index.tpl
@@ -1,0 +1,7 @@
+@extends: default.tpl
+---
+This is my Index page!
+
+{% for post in posts %}
+ {{ post.title }}
+{% endfor %}

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -6,39 +6,56 @@ use std::path::Path;
 use std::fs::{self, File};
 use std::io::Read;
 use walkdir::WalkDir;
+use std::error::Error;
 
-fn run_test(name: &str) {
+fn run_test(name: &str) -> Result<(), cobalt::Error> {
     let source = format!("tests/fixtures/{}/", name);
     let target = format!("tests/target/{}/", name);
     let dest = format!("tests/tmp/{}/", name);
 
-    match cobalt::build(&Path::new(&source), &Path::new(&dest), "_layouts", "_posts") {
-        Ok(_) => println!("Build successful"),
-        Err(e) => panic!("Error: {}", e),
+    let result = cobalt::build(&Path::new(&source), &Path::new(&dest), "_layouts", "_posts");
+
+    if result.is_ok() {
+        let walker = WalkDir::new(&target).into_iter();
+
+        // walk through fixture and created tmp directory and compare files
+        for entry in walker.filter_map(|e| e.ok()).filter(|e| e.file_type().is_file()) {
+            let relative = entry.path().to_str().unwrap().split(&target).last().unwrap();
+
+            let mut original = String::new();
+            File::open(entry.path()).unwrap().read_to_string(&mut original).unwrap();
+
+            let mut created = String::new();
+            File::open(&Path::new(&dest).join(&relative))
+                .unwrap()
+                .read_to_string(&mut created)
+                .unwrap();
+
+            difference::assert_diff(&original, &created, " ", 0);
+        }
+
+        // clean up
+        fs::remove_dir_all(dest).expect("Cleanup failed");
     }
 
-    let walker = WalkDir::new(&target).into_iter();
-
-    // walk through fixture and created tmp directory and compare files
-    for entry in walker.filter_map(|e| e.ok()).filter(|e| e.file_type().is_file()) {
-        let relative = entry.path().to_str().unwrap().split(&target).last().unwrap();
-
-        let mut original = String::new();
-        File::open(entry.path()).unwrap().read_to_string(&mut original).unwrap();
-
-        println!("{:?}", &Path::new(&dest).join(&relative));
-        let mut created = String::new();
-        File::open(&Path::new(&dest).join(&relative)).unwrap().read_to_string(&mut created).unwrap();
-
-        difference::assert_diff(&original, &created, " ", 0);
-    }
-
-    // clean up
-    fs::remove_dir_all(dest).unwrap();
+    result
 }
 
 #[test]
 pub fn example() {
-    run_test("example");
+    assert!(run_test("example").is_ok());
 }
 
+#[test]
+pub fn liquid_error() {
+    let err = run_test("liquid_error");
+    assert!(err.is_err());
+    assert_eq!(err.unwrap_err().description(), "{{{ is not a valid identifier");
+}
+
+#[test]
+pub fn no_extends_error() {
+    let err = run_test("no_extends_error");
+    assert!(err.is_err());
+    assert_eq!(err.unwrap_err().description(), "No @extends line creating _posts/2014-08-24-my-first-blogpost.md");
+}


### PR DESCRIPTION
- Uses liquid 0.2, which does better error handling
- Introduces a cobalt::Error that converts from the different error
  types and enables much conciser and safer code
- Transitions all panics and unwraps to use the new error system