### PR TITLE
Sort posts and parse front matter as yaml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ liquid = "0.2"
 walkdir = "0.1"
 crossbeam = "0.1.5"
 yaml-rust = "0.2.2"
+chrono = "0.2"
 
 [dev-dependencies]
 difference = "0.4"

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Example:
 extends: posts.tpl
 
 title:   My first Blogpost
-date:    24/08/2014 at 15:36
+date:    01 Jan 2016 21:00:00 +0100
 ---
 Hey there this is my first blogpost and this is super awesome.
 
@@ -50,6 +50,8 @@ My Blog is lorem ipsum like, yes it is..
 The content before ```---``` are meta attributes made accessible to the template via their key (see below).
 
 The ```extends``` attribute specifies which layout will be used.
+
+The ```date``` attribute will be used to sort blog posts (from last to first). ```date``` must have the format `%dd %Mon %YYYY %HH:%MM:%SS %zzzz`, so for example `27 May 2016 21:00:30 +0100`.
 
 ### Other files
 
@@ -73,4 +75,10 @@ In example above _title_ is accessible via ```{{ title }}``` and _date_ via ```{
 
 #### posts
 
-`{{ posts }}` is a list of the attributes of all templates in the `_posts` directory. Example:
+`{{ posts }}` is a list of the attributes of all templates in the `_posts` directory. Example usage on a page listing all blog posts:
+
+```
+{% for post in posts %}
+ <a href="blog/{{post.name}}.html">{{ post.title }}</a>
+{% endfor %}
+```

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Posts live in ```_posts```.
 Example:
 
 ```text
-@extends: posts.tpl
+extends: posts.tpl
 
 title:   My first Blogpost
 date:    24/08/2014 at 15:36
@@ -49,7 +49,7 @@ My Blog is lorem ipsum like, yes it is..
 
 The content before ```---``` are meta attributes made accessible to the template via their key (see below).
 
-The ```@extends``` attribute specifies which layout will be used.
+The ```extends``` attribute specifies which layout will be used.
 
 ### Other files
 

--- a/src/cobalt.rs
+++ b/src/cobalt.rs
@@ -199,7 +199,6 @@ fn parse_document(path: &Path, source: &Path) -> Result<Document> {
     let source_str = try!(source.to_str()
                                 .ok_or(format!("Cannot convert pathname {:?} to UTF-8", source)));
 
-
     let new_path = try!(path_str.split(source_str)
                                 .last()
                                 .ok_or(format!("Empty path")));

--- a/src/document.rs
+++ b/src/document.rs
@@ -4,6 +4,7 @@ use std::path::{Path, PathBuf};
 use std::default::Default;
 use std::io::Write;
 use error::Result;
+use chrono::{DateTime, Local};
 
 use liquid::{Renderable, LiquidOptions, Context, Value};
 
@@ -15,6 +16,8 @@ pub struct Document {
     pub name: String,
     pub attributes: HashMap<String, String>,
     pub content: String,
+    pub is_post: bool,
+    pub date: Option<DateTime<Local>>,
     markdown: bool,
 }
 
@@ -22,12 +25,16 @@ impl Document {
     pub fn new(name: String,
                attributes: HashMap<String, String>,
                content: String,
+               is_post: bool,
+               date: Option<DateTime<Local>>,
                markdown: bool)
                -> Document {
         Document {
             name: name,
             attributes: attributes,
             content: content,
+            is_post: is_post,
+            date: date,
             markdown: markdown,
         }
     }
@@ -68,8 +75,8 @@ impl Document {
         let file_path = file_path_buf.as_path();
 
         let layout_path = try!(self.attributes
-                                   .get(&"@extends".to_owned())
-                                   .ok_or(format!("No @extends line creating {}", self.name)));
+                                   .get(&"extends".to_owned())
+                                   .ok_or(format!("No extends property creating {}", self.name)));
 
         let layout = try!(layouts.get(layout_path)
                                  .ok_or(format!("No layout path {} creating {}",

--- a/src/document.rs
+++ b/src/document.rs
@@ -4,7 +4,7 @@ use std::path::{Path, PathBuf};
 use std::default::Default;
 use std::io::Write;
 use error::Result;
-use chrono::{DateTime, Local};
+use chrono::{DateTime, FixedOffset};
 
 use liquid::{Renderable, LiquidOptions, Context, Value};
 
@@ -17,7 +17,7 @@ pub struct Document {
     pub attributes: HashMap<String, String>,
     pub content: String,
     pub is_post: bool,
-    pub date: Option<DateTime<Local>>,
+    pub date: Option<DateTime<FixedOffset>>,
     markdown: bool,
 }
 
@@ -26,7 +26,7 @@ impl Document {
                attributes: HashMap<String, String>,
                content: String,
                is_post: bool,
-               date: Option<DateTime<Local>>,
+               date: Option<DateTime<FixedOffset>>,
                markdown: bool)
                -> Document {
         Document {

--- a/src/error.rs
+++ b/src/error.rs
@@ -2,6 +2,7 @@ use std::result;
 use std::io;
 use std::error;
 use std::fmt;
+use yaml_rust::scanner;
 use walkdir;
 use liquid;
 
@@ -13,6 +14,7 @@ pub enum Error {
     Io(io::Error),
     Liquid(liquid::Error),
     WalkDir(walkdir::Error),
+    Yaml(scanner::ScanError),
     Other(String),
 }
 
@@ -34,6 +36,12 @@ impl From<walkdir::Error> for Error {
     }
 }
 
+impl From<scanner::ScanError> for Error {
+    fn from(err: scanner::ScanError) -> Error {
+        Error::Yaml(err)
+    }
+}
+
 impl From<String> for Error {
     fn from(err: String) -> Error {
         Error::Other(err)
@@ -52,6 +60,7 @@ impl fmt::Display for Error {
             Error::Io(ref err) => write!(f, "IO error: {}", err),
             Error::Liquid(ref err) => write!(f, "Liquid error: {}", err),
             Error::WalkDir(ref err) => write!(f, "walkdir error: {}", err),
+            Error::Yaml(ref err) => write!(f, "yaml parsing error: {}", err),
             Error::Other(ref err) => write!(f, "error: {}", err),
         }
     }
@@ -63,6 +72,7 @@ impl error::Error for Error {
             Error::Io(ref err) => err.description(),
             Error::Liquid(ref err) => err.description(),
             Error::WalkDir(ref err) => err.description(),
+            Error::Yaml(ref err) => err.description(),
             Error::Other(ref err) => err,
         }
     }
@@ -72,6 +82,7 @@ impl error::Error for Error {
             Error::Io(ref err) => Some(err),
             Error::Liquid(ref err) => Some(err),
             Error::WalkDir(ref err) => Some(err),
+            Error::Yaml(ref err) => Some(err),
             Error::Other(_) => None,
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,11 +4,13 @@ extern crate liquid;
 extern crate markdown;
 extern crate walkdir;
 extern crate crossbeam;
+extern crate chrono;
+extern crate yaml_rust;
 
 pub use cobalt::build;
 pub use error::Error;
 
 // modules
 mod cobalt;
-mod error;
+pub mod error;
 mod document;

--- a/tests/fixtures/config_example/_my_posts/2014-08-24-my-first-blogpost.md
+++ b/tests/fixtures/config_example/_my_posts/2014-08-24-my-first-blogpost.md
@@ -1,5 +1,4 @@
-@extends: posts.tpl
-
+extends: posts.tpl
 title:   My first Blogpost
 date:    24/08/2014 at 15:36
 ---

--- a/tests/fixtures/config_example/index.tpl
+++ b/tests/fixtures/config_example/index.tpl
@@ -1,4 +1,4 @@
-@extends: default.tpl
+extends: default.tpl
 ---
 This is my Index page!
 

--- a/tests/fixtures/dotfiles/_posts/2014-08-24-my-first-blogpost.md
+++ b/tests/fixtures/dotfiles/_posts/2014-08-24-my-first-blogpost.md
@@ -1,4 +1,4 @@
-@extends: posts.tpl
+extends: posts.tpl
 
 title:   My first Blogpost
 date:    24/08/2014 at 15:36

--- a/tests/fixtures/dotfiles/index.tpl
+++ b/tests/fixtures/dotfiles/index.tpl
@@ -1,4 +1,4 @@
-@extends: default.tpl
+extends: default.tpl
 ---
 This is my Index page!
 

--- a/tests/fixtures/example/_posts/2014-08-24-my-first-blogpost.md
+++ b/tests/fixtures/example/_posts/2014-08-24-my-first-blogpost.md
@@ -1,4 +1,4 @@
-@extends: posts.tpl
+extends: posts.tpl
 
 title:   My first Blogpost
 date:    24/08/2014 at 15:36

--- a/tests/fixtures/example/index.tpl
+++ b/tests/fixtures/example/index.tpl
@@ -1,4 +1,4 @@
-@extends: default.tpl
+extends: default.tpl
 ---
 This is my Index page!
 

--- a/tests/fixtures/liquid_error/_posts/2014-08-24-my-first-blogpost.md
+++ b/tests/fixtures/liquid_error/_posts/2014-08-24-my-first-blogpost.md
@@ -1,4 +1,4 @@
-@extends: posts.tpl
+extends: posts.tpl
 
 title:   My first Blogpost
 date:    24/08/2014 at 15:36

--- a/tests/fixtures/liquid_error/index.tpl
+++ b/tests/fixtures/liquid_error/index.tpl
@@ -1,4 +1,4 @@
-@extends: default.tpl
+extends: default.tpl
 ---
 This is my Index page!
 

--- a/tests/fixtures/no_extends_error/index.tpl
+++ b/tests/fixtures/no_extends_error/index.tpl
@@ -1,4 +1,4 @@
-@extends: default.tpl
+extends: default.tpl
 ---
 This is my Index page!
 

--- a/tests/fixtures/sort_posts/_layouts/default.tpl
+++ b/tests/fixtures/sort_posts/_layouts/default.tpl
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>test</title>
+    </head>
+    <body>
+        <h1>{{ name }}</h1>
+
+        {{ content }}
+    </body>
+</html>
+

--- a/tests/fixtures/sort_posts/_layouts/posts.tpl
+++ b/tests/fixtures/sort_posts/_layouts/posts.tpl
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>My blog - {{ title }}</title>
+    </head>
+    <body>
+        {{ content }}
+    </body>
+</html>
+

--- a/tests/fixtures/sort_posts/_posts/my-first-blogpost.md
+++ b/tests/fixtures/sort_posts/_posts/my-first-blogpost.md
@@ -1,0 +1,10 @@
+extends: posts.tpl
+
+title:   My first Blogpost
+date:    01 Jan 2016 21:00:00 +0100
+---
+# {{ title }}
+
+Hey there this is my first blogpost and this is super awesome.
+
+My Blog is lorem ipsum like, yes it is..

--- a/tests/fixtures/sort_posts/_posts/my-fourth-blogpost.md
+++ b/tests/fixtures/sort_posts/_posts/my-fourth-blogpost.md
@@ -1,0 +1,10 @@
+extends: posts.tpl
+
+title:   My fourth Blogpost
+date:    29 May 2016 23:00:00 +0100
+---
+# {{ title }}
+
+Hey there this is my first blogpost and this is super awesome.
+
+My Blog is lorem ipsum like, yes it is..

--- a/tests/fixtures/sort_posts/_posts/my-second-blogpost.md
+++ b/tests/fixtures/sort_posts/_posts/my-second-blogpost.md
@@ -1,0 +1,10 @@
+extends: posts.tpl
+
+title:   My second Blogpost
+date:    02 Jan 2016 10:00:00 +0100
+---
+# {{ title }}
+
+Hey there this is my first blogpost and this is super awesome.
+
+My Blog is lorem ipsum like, yes it is..

--- a/tests/fixtures/sort_posts/_posts/my-third-blogpost.md
+++ b/tests/fixtures/sort_posts/_posts/my-third-blogpost.md
@@ -1,0 +1,10 @@
+extends: posts.tpl
+
+title:   My third Blogpost
+date:    27 May 2016 23:00:00 +0100
+---
+# {{ title }}
+
+Hey there this is my first blogpost and this is super awesome.
+
+My Blog is lorem ipsum like, yes it is..

--- a/tests/fixtures/sort_posts/index.tpl
+++ b/tests/fixtures/sort_posts/index.tpl
@@ -1,0 +1,7 @@
+extends: default.tpl
+---
+This is my Index page!
+
+{% for post in posts %}
+ <a href="_posts/{{post.name}}.html">{{ post.title }}</a>
+{% endfor %}

--- a/tests/fixtures/yaml_error/_layouts/default.tpl
+++ b/tests/fixtures/yaml_error/_layouts/default.tpl
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>test</title>
+    </head>
+    <body>
+        <h1>{{ name }}</h1>
+
+        {{ content }}
+    </body>
+</html>
+

--- a/tests/fixtures/yaml_error/_layouts/posts.tpl
+++ b/tests/fixtures/yaml_error/_layouts/posts.tpl
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>My blog - {{ title }}</title>
+    </head>
+    <body>
+        {{ content }}
+    </body>
+</html>
+

--- a/tests/fixtures/yaml_error/_posts/2014-08-24-my-first-blogpost.md
+++ b/tests/fixtures/yaml_error/_posts/2014-08-24-my-first-blogpost.md
@@ -1,0 +1,10 @@
+extends: posts.tpl
+
+title:   My first Blogpost
+date:    24/08/2014 at 15:36
+---
+# {{ title }}
+
+Hey there this is my first blogpost and this is super awesome.
+
+My Blog is lorem ipsum like, yes it is..

--- a/tests/fixtures/yaml_error/index.tpl
+++ b/tests/fixtures/yaml_error/index.tpl
@@ -1,0 +1,7 @@
+@
+---
+This is my Index page!
+
+{% for post in posts %}
+ {{ post.title }}
+{% endfor %}

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -52,6 +52,11 @@ pub fn dotfiles() {
 }
 
 #[test]
+pub fn sort_posts() {
+    assert!(run_test("sort_posts").is_ok());
+}
+
+#[test]
 pub fn liquid_error() {
     let err = run_test("liquid_error");
     assert!(err.is_err());

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -64,6 +64,13 @@ pub fn liquid_error() {
 }
 
 #[test]
+pub fn yaml_error() {
+    let err = run_test("yaml_error");
+    assert!(err.is_err());
+    assert_eq!(err.unwrap_err().description(), "unexpected character: `@'");
+}
+
+#[test]
 pub fn no_extends_error() {
     let err = run_test("no_extends_error");
     assert!(err.is_err());

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -62,5 +62,5 @@ pub fn liquid_error() {
 pub fn no_extends_error() {
     let err = run_test("no_extends_error");
     assert!(err.is_err());
-    assert_eq!(err.unwrap_err().description(), "No @extends line creating _posts/2014-08-24-my-first-blogpost.md");
+    assert_eq!(err.unwrap_err().description(), "No extends property creating _posts/2014-08-24-my-first-blogpost.md");
 }

--- a/tests/target/sort_posts/_posts/my-first-blogpost.html
+++ b/tests/target/sort_posts/_posts/my-first-blogpost.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>My blog - My first Blogpost</title>
+    </head>
+    <body>
+        <h1 id='my_first_blogpost'>My first Blogpost</h1>
+
+<p>Hey there this is my first blogpost and this is super awesome.</p>
+
+<p>My Blog is lorem ipsum like, yes it is..</p>
+
+    </body>
+</html>
+

--- a/tests/target/sort_posts/_posts/my-fourth-blogpost.html
+++ b/tests/target/sort_posts/_posts/my-fourth-blogpost.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>My blog - My fourth Blogpost</title>
+    </head>
+    <body>
+        <h1 id='my_fourth_blogpost'>My fourth Blogpost</h1>
+
+<p>Hey there this is my first blogpost and this is super awesome.</p>
+
+<p>My Blog is lorem ipsum like, yes it is..</p>
+
+    </body>
+</html>
+

--- a/tests/target/sort_posts/_posts/my-second-blogpost.html
+++ b/tests/target/sort_posts/_posts/my-second-blogpost.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>My blog - My second Blogpost</title>
+    </head>
+    <body>
+        <h1 id='my_second_blogpost'>My second Blogpost</h1>
+
+<p>Hey there this is my first blogpost and this is super awesome.</p>
+
+<p>My Blog is lorem ipsum like, yes it is..</p>
+
+    </body>
+</html>
+

--- a/tests/target/sort_posts/_posts/my-third-blogpost.html
+++ b/tests/target/sort_posts/_posts/my-third-blogpost.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>My blog - My third Blogpost</title>
+    </head>
+    <body>
+        <h1 id='my_third_blogpost'>My third Blogpost</h1>
+
+<p>Hey there this is my first blogpost and this is super awesome.</p>
+
+<p>My Blog is lorem ipsum like, yes it is..</p>
+
+    </body>
+</html>
+

--- a/tests/target/sort_posts/index.html
+++ b/tests/target/sort_posts/index.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>test</title>
+    </head>
+    <body>
+        <h1>index</h1>
+
+        
+This is my Index page!
+
+
+ <a href="_posts/my-fourth-blogpost.html">My fourth Blogpost</a>
+
+ <a href="_posts/my-third-blogpost.html">My third Blogpost</a>
+
+ <a href="_posts/my-second-blogpost.html">My second Blogpost</a>
+
+ <a href="_posts/my-first-blogpost.html">My first Blogpost</a>
+
+
+    </body>
+</html>
+


### PR DESCRIPTION
The primary goal of this is to sort posts by date (latest first). On that occasion I also changed the front-matter parsing to use yaml-rust instead of our own hacky parsing function.

This is a backwards-incompatible change, as `@extends` is an invalid
identifier in yaml (specifically the @ part). I changed it to `extends`,
which doesn't seem bad.

Posts are now sorted by date by default. Dates have to have the format
`%d %B %Y %H:%M:%S %z`, e.g. `29 May 2016 23:00:00 +0100` to be
successfully parsed. If no dates are provided or the parsing fails, it
falls back to 1970.