### PR TITLE
Implement better logging (closes #39)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,8 @@ walkdir = "0.1"
 crossbeam = "0.1.5"
 yaml-rust = "0.2.2"
 chrono = "0.2"
+log = "0.3"
+env_logger = "0.3"
 
 [dev-dependencies]
 difference = "0.4"

--- a/src/document.rs
+++ b/src/document.rs
@@ -113,7 +113,7 @@ impl Document {
         let res = try!(template.render(&mut data)).unwrap_or(String::new());
 
         try!(file.write_all(&res.into_bytes()));
-        println!("Created {}", file_path.display());
+        info!("Created {}", file_path.display());
         Ok(())
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,9 @@ extern crate crossbeam;
 extern crate chrono;
 extern crate yaml_rust;
 
+#[macro_use]
+extern crate log;
+
 pub use cobalt::build;
 pub use error::Error;
 


### PR DESCRIPTION
This commit implements logging using the log and env_logger crates. The
lib part of cobalt strictly relies on using only log! macros to be
friendly to usage by other consumers.

main.rs uses env_logger to set different logging levels based on command
line flags, not environment variables.

The default log level is info. Optional log levels are debug and trace.
Logging can be turned of completely by passing --silent.

Feel free to litter the code with trace! and occasional debug! calls.