### PR TITLE
Switch to pulldown-cmark for markdown parsing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,6 @@ authors = ["Benny Klotz <r3qnbenni@gmail.com>", "Johann Hofmann"]
 
 [dependencies]
 getopts = "0.2.14"
-markdown = "0.1"
 liquid = "0.4"
 walkdir = "0.1"
 crossbeam = "0.1.5"
@@ -15,6 +14,7 @@ chrono = "0.2"
 log = "0.3"
 env_logger = "0.3"
 rss = "0.3.1"
+pulldown-cmark = "0.0.7"
 
 [dev-dependencies]
 difference = "0.4"

--- a/src/document.rs
+++ b/src/document.rs
@@ -9,7 +9,7 @@ use rss;
 
 use liquid::{Renderable, LiquidOptions, Context, Value};
 
-use markdown;
+use pulldown_cmark as cmark;
 use liquid;
 
 #[derive(Debug)]
@@ -115,7 +115,12 @@ impl Document {
         let mut html = try!(self.as_html(post_data));
 
         if self.markdown {
-            html = markdown::to_html(&html);
+            html = {
+                let mut buf = String::new();
+                let parser = cmark::Parser::new(&html);
+                cmark::html::push_html(&mut buf, parser);
+                buf
+            };
         }
 
         data.set_val("content", Value::Str(html));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 #![deny(warnings)]
 
 extern crate liquid;
-extern crate markdown;
+extern crate pulldown_cmark;
 extern crate walkdir;
 extern crate crossbeam;
 extern crate chrono;

--- a/tests/target/custom_template_extensions/_posts/2014-08-24-my-first-blogpost.html
+++ b/tests/target/custom_template_extensions/_posts/2014-08-24-my-first-blogpost.html
@@ -4,10 +4,8 @@
         <title>My blog - My first Blogpost</title>
     </head>
     <body>
-        <h1 id='my_first_blogpost'>My first Blogpost</h1>
-
+        <h1>My first Blogpost</h1>
 <p>Hey there this is my first blogpost and this is super awesome.</p>
-
 <p>My Blog is lorem ipsum like, yes it is..</p>
 
     </body>

--- a/tests/target/dotfiles/_posts/2014-08-24-my-first-blogpost.html
+++ b/tests/target/dotfiles/_posts/2014-08-24-my-first-blogpost.html
@@ -4,10 +4,8 @@
         <title>My blog - My first Blogpost</title>
     </head>
     <body>
-        <h1 id='my_first_blogpost'>My first Blogpost</h1>
-
+        <h1>My first Blogpost</h1>
 <p>Hey there this is my first blogpost and this is super awesome.</p>
-
 <p>My Blog is lorem ipsum like, yes it is..</p>
 
     </body>

--- a/tests/target/example/_posts/2014-08-24-my-first-blogpost.html
+++ b/tests/target/example/_posts/2014-08-24-my-first-blogpost.html
@@ -4,10 +4,8 @@
         <title>My blog - My first Blogpost</title>
     </head>
     <body>
-        <h1 id='my_first_blogpost'>My first Blogpost</h1>
-
+        <h1>My first Blogpost</h1>
 <p>Hey there this is my first blogpost and this is super awesome.</p>
-
 <p>My Blog is lorem ipsum like, yes it is..</p>
 
     </body>

--- a/tests/target/rss/_posts/my-fifth-blogpost.html
+++ b/tests/target/rss/_posts/my-fifth-blogpost.html
@@ -1,10 +1,10 @@
 <!DOCTYPE html>
 <html>
     <head>
-        <title>My blog - My first Blogpost</title>
+        <title>My blog - My fifth Blogpost!</title>
     </head>
     <body>
-        <h1>My first Blogpost</h1>
+        <h1>My fifth Blogpost!</h1>
 <p>Hey there this is my first blogpost and this is super awesome.</p>
 <p>My Blog is lorem ipsum like, yes it is..</p>
 

--- a/tests/target/rss/_posts/my-first-blogpost.html
+++ b/tests/target/rss/_posts/my-first-blogpost.html
@@ -4,10 +4,8 @@
         <title>My blog - My first Blogpost</title>
     </head>
     <body>
-        <h1 id='my_first_blogpost'>My first Blogpost</h1>
-
+        <h1>My first Blogpost</h1>
 <p>Hey there this is my first blogpost and this is super awesome.</p>
-
 <p>My Blog is lorem ipsum like, yes it is..</p>
 
     </body>

--- a/tests/target/rss/_posts/my-fourth-blogpost.html
+++ b/tests/target/rss/_posts/my-fourth-blogpost.html
@@ -4,10 +4,8 @@
         <title>My blog - My fourth Blogpost</title>
     </head>
     <body>
-        <h1 id='my_fourth_blogpost'>My fourth Blogpost</h1>
-
+        <h1>My fourth Blogpost</h1>
 <p>Hey there this is my first blogpost and this is super awesome.</p>
-
 <p>My Blog is lorem ipsum like, yes it is..</p>
 
     </body>

--- a/tests/target/rss/_posts/my-second-blogpost.html
+++ b/tests/target/rss/_posts/my-second-blogpost.html
@@ -4,10 +4,8 @@
         <title>My blog - My second Blogpost</title>
     </head>
     <body>
-        <h1 id='my_second_blogpost'>My second Blogpost</h1>
-
+        <h1>My second Blogpost</h1>
 <p>Hey there this is my first blogpost and this is super awesome.</p>
-
 <p>My Blog is lorem ipsum like, yes it is..</p>
 
     </body>

--- a/tests/target/rss/_posts/my-third-blogpost.html
+++ b/tests/target/rss/_posts/my-third-blogpost.html
@@ -4,10 +4,8 @@
         <title>My blog - My third Blogpost</title>
     </head>
     <body>
-        <h1 id='my_third_blogpost'>My third Blogpost</h1>
-
+        <h1>My third Blogpost</h1>
 <p>Hey there this is my first blogpost and this is super awesome.</p>
-
 <p>My Blog is lorem ipsum like, yes it is..</p>
 
     </body>

--- a/tests/target/sort_posts/_posts/my-first-blogpost.html
+++ b/tests/target/sort_posts/_posts/my-first-blogpost.html
@@ -4,10 +4,8 @@
         <title>My blog - My first Blogpost</title>
     </head>
     <body>
-        <h1 id='my_first_blogpost'>My first Blogpost</h1>
-
+        <h1>My first Blogpost</h1>
 <p>Hey there this is my first blogpost and this is super awesome.</p>
-
 <p>My Blog is lorem ipsum like, yes it is..</p>
 
     </body>

--- a/tests/target/sort_posts/_posts/my-fourth-blogpost.html
+++ b/tests/target/sort_posts/_posts/my-fourth-blogpost.html
@@ -4,10 +4,8 @@
         <title>My blog - My fourth Blogpost</title>
     </head>
     <body>
-        <h1 id='my_fourth_blogpost'>My fourth Blogpost</h1>
-
+        <h1>My fourth Blogpost</h1>
 <p>Hey there this is my first blogpost and this is super awesome.</p>
-
 <p>My Blog is lorem ipsum like, yes it is..</p>
 
     </body>

--- a/tests/target/sort_posts/_posts/my-second-blogpost.html
+++ b/tests/target/sort_posts/_posts/my-second-blogpost.html
@@ -4,10 +4,8 @@
         <title>My blog - My second Blogpost</title>
     </head>
     <body>
-        <h1 id='my_second_blogpost'>My second Blogpost</h1>
-
+        <h1>My second Blogpost</h1>
 <p>Hey there this is my first blogpost and this is super awesome.</p>
-
 <p>My Blog is lorem ipsum like, yes it is..</p>
 
     </body>

--- a/tests/target/sort_posts/_posts/my-third-blogpost.html
+++ b/tests/target/sort_posts/_posts/my-third-blogpost.html
@@ -4,10 +4,8 @@
         <title>My blog - My third Blogpost</title>
     </head>
     <body>
-        <h1 id='my_third_blogpost'>My third Blogpost</h1>
-
+        <h1>My third Blogpost</h1>
 <p>Hey there this is my first blogpost and this is super awesome.</p>
-
 <p>My Blog is lorem ipsum like, yes it is..</p>
 
     </body>


### PR DESCRIPTION
This commit removes the dependency on markdown.rs for now, as
pulldown_cmark offers more compatibility and stability. However,
depending on how the two libraries turn out, we might want to consider
switching back again. None of the alternatives for Rust markdown parsing
is in a great state, currently.