### PR TITLE
Add Watch command

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ log = "0.3"
 env_logger = "0.3"
 rss = "0.3.1"
 pulldown-cmark = "0.0.7"
-nickel = "0.7.3"
+nickel = "0.8"
 notify = "^2.5.0"
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ env_logger = "0.3"
 rss = "0.3.1"
 pulldown-cmark = "0.0.7"
 nickel = "0.7.3"
+notify = "^2.5.0"
 
 [dev-dependencies]
 difference = "0.4"

--- a/src/config.rs
+++ b/src/config.rs
@@ -71,7 +71,9 @@ impl Config {
 
         if let Some(extensions) = yaml["template_extensions"].as_vec() {
             config.template_extensions = extensions.iter()
-                                                   .filter_map(|k| k.as_str().map(|k| k.to_owned()))
+                                                   .filter_map(|k| {
+                                                       k.as_str().map(|k| k.to_owned())
+                                                   })
                                                    .collect();
         };
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -29,8 +29,14 @@ fn main() {
 
     opts.optopt("s", "source", "Source folder, Default: ./", "");
     opts.optopt("d", "destination", "Destination folder, Default: ./", "");
-    opts.optopt("c", "config", "Config file to use, Default: .cobalt.yml", "");
-    opts.optopt("l", "layouts", "\tLayout templates folder, Default: _layouts/", "");
+    opts.optopt("c",
+                "config",
+                "Config file to use, Default: .cobalt.yml",
+                "");
+    opts.optopt("l",
+                "layouts",
+                "\tLayout templates folder, Default: _layouts/",
+                "");
     opts.optopt("p", "posts", "Posts folder, Default: _posts/", "");
 
     opts.optflag("", "debug", "Log verbose (debug level) information");
@@ -123,24 +129,17 @@ fn main() {
 
     match command.as_ref() {
         "build" => {
-            info!("Building from {} into {}", config.source, config.dest);
-            match cobalt::build(&config) {
-                Ok(_) => info!("Build successful"),
-                Err(e) => {
-                    error!("{}", e);
-                    error!("Build not successful");
-                    std::process::exit(1);
-                }
-            }
+            build(&config);
         }
 
         "serve" => {
-            info!("Serving {} through static file server", config.dest);
-            let mut server = Nickel::new();
+            build(&config);
+            serve(&config);
+        }
 
-            server.utilize(StaticFilesHandler::new(&config.dest));
-
-            server.listen("127.0.0.1:3000");
+        "watch" => {
+            build(&config);
+            serve(&config);
         }
 
         _ => {
@@ -148,4 +147,26 @@ fn main() {
             return;
         }
     }
+}
+
+
+fn build(config: &Config) {
+    info!("Building from {} into {}", config.source, config.dest);
+    match cobalt::build(&config) {
+        Ok(_) => info!("Build successful"),
+        Err(e) => {
+            error!("{}", e);
+            error!("Build not successful");
+            std::process::exit(1);
+        }
+    };
+}
+
+fn serve(config: &Config) {
+    info!("Serving {} through static file server", config.dest);
+    let mut server = Nickel::new();
+
+    server.utilize(StaticFilesHandler::new(&config.dest));
+
+    server.listen("127.0.0.1:3000");
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,6 +27,11 @@ fn print_version() {
     println!("0.2.0");
 }
 
+fn print_usage(opts: Options) {
+    println!("{}",
+             opts.usage("\n\tcobalt build\n\tcobalt watch\n\tcobalt serve"));
+}
+
 fn main() {
     let args: Vec<String> = env::args().collect();
 
@@ -56,7 +61,7 @@ fn main() {
     };
 
     if matches.opt_present("h") {
-        println!("{}", opts.usage("\n\tcobalt build"));
+        print_usage(opts);
         return;
     }
 
@@ -175,7 +180,7 @@ fn main() {
         }
 
         _ => {
-            println!("{}", opts.usage("\n\tcobalt build"));
+            print_usage(opts);
             return;
         }
     }
@@ -194,7 +199,6 @@ fn build(config: &Config) {
     };
 }
 
-// TODO: make this just take dest so we can move just a copy of that and call this in another thread
 fn serve(dest: &str) {
     info!("Serving {} through static file server", dest);
     let mut server = Nickel::new();

--- a/src/main.rs
+++ b/src/main.rs
@@ -156,9 +156,6 @@ fn main() {
             });
 
             let (tx, rx) = channel();
-
-            // Automatically select the best implementation for your platform.
-            // You can also access each implementation directly e.g. INotifyWatcher.
             let w: Result<RecommendedWatcher, Error> = Watcher::new(tx);
 
             match w {
@@ -169,13 +166,13 @@ fn main() {
                     loop {
                         match rx.recv() {
                             _ => {
-                                info!("Rebuilding...");
+                                info!("Rebuilding cobalt site...");
                                 build(&config);
                             }
                         }
                     }
                 }
-                Err(_) => error!("Error"),
+                Err(e) => error!("[Notify]: {}", e),
             }
         }
 


### PR DESCRIPTION
Adds watch command and other things:

TODO:
- [x] `Serve` command now builds the site before serving it
- [x] `Watch` command builds the site then serves it then waits to see if a file has changed in the source dir and will rebuild on change #51 
- [x] Add `--port` flag to pass a port to the server #76 
- [x] Simple usage message for `build`, `watch`, and `serve`

Let me know if there is anything else that should be added/changed.