### PR TITLE
Add ignore config

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ pulldown-cmark = "0.0.7"
 nickel = "0.8"
 notify = "^2.5.0"
 ghp = "0.1"
+glob = "0.2.11"
 
 [dev-dependencies]
 difference = "0.4"

--- a/src/config.rs
+++ b/src/config.rs
@@ -2,6 +2,7 @@ use std::default::Default;
 use std::path::Path;
 use std::fs::File;
 use std::io::Read;
+use glob::Pattern;
 use error::Result;
 use yaml_rust::YamlLoader;
 
@@ -16,6 +17,7 @@ pub struct Config {
     pub name: Option<String>,
     pub description: Option<String>,
     pub link: Option<String>,
+    pub ignore: Vec<Pattern>,
 }
 
 impl Default for Config {
@@ -30,6 +32,7 @@ impl Default for Config {
             name: None,
             description: None,
             link: None,
+            ignore: vec![],
         }
     }
 }
@@ -83,6 +86,13 @@ impl Config {
                 link = link + "/";
             }
             config.link = Some(link);
+        };
+
+        if let Some(patterns) = yaml["ignore"].as_vec() {
+            config.ignore = patterns.iter()
+                                    .filter_map(|k| k.as_str())
+                                    .filter_map(|k| Pattern::new(k).ok())
+                                    .collect();
         };
 
         Ok(config)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@ extern crate crossbeam;
 extern crate chrono;
 extern crate yaml_rust;
 extern crate rss;
+extern crate glob;
 
 #[macro_use]
 extern crate log;

--- a/tests/fixtures/ignore_files/.cobalt.yml
+++ b/tests/fixtures/ignore_files/.cobalt.yml
@@ -1,0 +1,3 @@
+ignore:
+  - "README"
+  - "**/*.scss"

--- a/tests/fixtures/ignore_files/README
+++ b/tests/fixtures/ignore_files/README
@@ -1,0 +1,1 @@
+Readme file

--- a/tests/fixtures/ignore_files/_layouts/default.liquid
+++ b/tests/fixtures/ignore_files/_layouts/default.liquid
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>test</title>
+    </head>
+    <body>
+        <h1>{{ name }}</h1>
+
+        {{ content }}
+    </body>
+</html>
+

--- a/tests/fixtures/ignore_files/_layouts/posts.liquid
+++ b/tests/fixtures/ignore_files/_layouts/posts.liquid
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>My blog - {{ title }}</title>
+    </head>
+    <body>
+        {{ content }}
+    </body>
+</html>
+

--- a/tests/fixtures/ignore_files/_posts/2014-08-24-my-first-blogpost.md
+++ b/tests/fixtures/ignore_files/_posts/2014-08-24-my-first-blogpost.md
@@ -1,0 +1,10 @@
+extends: posts.liquid
+
+title:   My first Blogpost
+date:    24/08/2014 at 15:36
+---
+# {{ title }}
+
+Hey there this is my first blogpost and this is super awesome.
+
+My Blog is lorem ipsum like, yes it is..

--- a/tests/fixtures/ignore_files/index.liquid
+++ b/tests/fixtures/ignore_files/index.liquid
@@ -1,0 +1,7 @@
+extends: default.liquid
+---
+This is my Index page!
+
+{% for post in posts %}
+ <a href="{{post.path}}">{{ post.title }}</a>
+{% endfor %}

--- a/tests/fixtures/ignore_files/some.js
+++ b/tests/fixtures/ignore_files/some.js
@@ -1,0 +1,1 @@
+var test = require('test');

--- a/tests/fixtures/ignore_files/style/blog.css
+++ b/tests/fixtures/ignore_files/style/blog.css
@@ -1,0 +1,3 @@
+.body {
+	width: 30px;
+}

--- a/tests/fixtures/ignore_files/style/blog.scss
+++ b/tests/fixtures/ignore_files/style/blog.scss
@@ -1,0 +1,3 @@
+.body {
+	width: 30px;
+}

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -99,6 +99,11 @@ pub fn copy_files() {
 }
 
 #[test]
+pub fn ignore_files() {
+    run_test("ignore_files").unwrap();
+}
+
+#[test]
 pub fn yaml_error() {
     let err = run_test("yaml_error");
     assert!(err.is_err());

--- a/tests/target/ignore_files/_posts/2014-08-24-my-first-blogpost.html
+++ b/tests/target/ignore_files/_posts/2014-08-24-my-first-blogpost.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>My blog - My first Blogpost</title>
+    </head>
+    <body>
+        <h1>My first Blogpost</h1>
+<p>Hey there this is my first blogpost and this is super awesome.</p>
+<p>My Blog is lorem ipsum like, yes it is..</p>
+
+    </body>
+</html>
+

--- a/tests/target/ignore_files/index.html
+++ b/tests/target/ignore_files/index.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>test</title>
+    </head>
+    <body>
+        <h1>index</h1>
+
+        
+This is my Index page!
+
+
+ <a href="_posts/2014-08-24-my-first-blogpost.html">My first Blogpost</a>
+
+
+    </body>
+</html>
+

--- a/tests/target/ignore_files/some.js
+++ b/tests/target/ignore_files/some.js
@@ -1,0 +1,1 @@
+var test = require('test');

--- a/tests/target/ignore_files/style/blog.css
+++ b/tests/target/ignore_files/style/blog.css
@@ -1,0 +1,3 @@
+.body {
+	width: 30px;
+}


### PR DESCRIPTION
I have added an extra config parameter to ignore files in the files walker
(this helps to exclude files to not publish things accidentally). This can help
to fix the watch infinite loop adding to ignore config the "*.html" glob (#84).
In the future I can add --ignore parameter or --ignore-file parameter to add
ignore patterns in the current run.