### PR TITLE
Fix for watch command recursive call

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,7 @@ extern crate cobalt;
 extern crate getopts;
 extern crate env_logger;
 extern crate notify;
+extern crate glob;
 extern crate ghp;
 
 #[macro_use]
@@ -20,6 +21,7 @@ use log::{LogRecord, LogLevelFilter};
 use env_logger::LogBuilder;
 use nickel::{Nickel, Options as NickelOptions, StaticFilesHandler};
 use ghp::import_dir;
+use glob::Pattern;
 
 use notify::{RecommendedWatcher, Error, Watcher};
 use std::sync::mpsc::channel;
@@ -195,14 +197,16 @@ fn main() {
                                         let rel_path = path.strip_prefix(&cwd).unwrap_or(&cwd);
 
                                         // check if path starts with the build folder.
-                                        if !rel_path.starts_with(&config.dest) {
+                                        if !&config.ignore.iter().any(|pattern| Pattern::matches_path(
+                                            pattern,
+                                            rel_path)) {
                                             build(&config);
                                         }
 
                                     } else {
                                         // check if path starts with build folder.
                                         // TODO: may want to check if it starts `./`
-                                        if path.to_str() != Some(&config.dest) {
+                                        if !&config.ignore.iter().any(|pattern| Pattern::matches_path(pattern, &path)) {
                                             build(&config);
                                         }
                                     }


### PR DESCRIPTION
This should fix the watch command recursively calling itself on mac. We will have to check with the notify crate to check how the other file notifiers notify what file is changed. This is a fix for #84.