### PR TITLE
Fix build not successful on a new site

### DIFF
--- a/src/new.rs
+++ b/src/new.rs
@@ -20,7 +20,7 @@ const default_liquid: &'static [u8] = b"<!DOCTYPE html>
     <body>
     <div>
       {% if is_post %}
-        {% include '_layouts/post.liquid' %}
+        {% include _layouts/post.liquid %}
       {% else %}
         {{ content }}
       {% endif %}


### PR DESCRIPTION
`cobalt build` using fresh install in a site just created using `cobalt new` would throw a "Liquid error: Parsing error: Expected Identifier, found Some(StringLiteral("_layouts/post.liquid"))" and cause a build to fail.