### PR TITLE
Liquid date filter

### DIFF
--- a/src/document.rs
+++ b/src/document.rs
@@ -115,7 +115,7 @@ impl Document {
         // TODO: make this a regex to support lines of any length
         if content.contains("---") {
             let content2 = content.clone();
-            let mut content_splits = content2.split("---");
+            let mut content_splits = content2.splitn(2, "---");
 
             // above the split are the attributes
             let attribute_string = content_splits.next().unwrap_or("");


### PR DESCRIPTION
The PR contains one feature and one fix. I can split it up into two PRs if you like, but I feel like the fix is too small for a separate PR.

The feature is a new `date` filter so that one can do `post.date | date:"%d/%m/%y"` in liquid templates (example usage: https://github.com/kstep/kstep.github.com/blob/master/src/index.liquid#L17). Although it seems like liquid parser contains another bug: it doesn't parse filter arguments correctly, so I can't use spaces in the `date` filter arguments (I worked it around by using `&nbsp;` entity instead).

The fix is the incorrect YAML header splitting from markdown files. It splits files by all instances of `---` separator, while it should use the first one only. The fix is pretty obvious and self-explanatory.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cobalt-org/cobalt.rs/115)
<!-- Reviewable:end -->
