### PR TITLE
Add basic CLI tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,8 @@ version = "0.9"
 default-features = false
 
 [dev-dependencies]
+assert_cli = "0.3"
+lazy_static = "0.1"
 difference = "0.4"
 
 [features]

--- a/src/cobalt.rs
+++ b/src/cobalt.rs
@@ -184,7 +184,7 @@ pub fn build(config: &Config) -> Result<()> {
                 try!(fs::create_dir_all(&dest.join(relative)));
                 debug!("Created new directory {:?}", dest.join(relative));
             } else {
-                if let Some(ref parent) = Path::new(relative).parent() {
+                if let Some(parent) = Path::new(relative).parent() {
                     try!(fs::create_dir_all(&dest.join(parent)));
                 }
 

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -1,0 +1,67 @@
+#[macro_use] extern crate assert_cli;
+#[macro_use] extern crate lazy_static;
+
+use std::env;
+use std::str;
+use std::path::{Path, PathBuf};
+
+static EMPTY : &'static [&'static str] = &[];
+lazy_static! {
+    static ref _CWD: PathBuf = env::current_dir().unwrap();
+    static ref CWD: &'static Path = _CWD.as_path();
+    static ref _BIN: PathBuf = CWD.join("target/debug/cobalt");
+    static ref BIN: &'static str = _BIN.to_str().unwrap();
+}
+
+macro_rules! assert_contains {
+    ($utf8: expr, $vec: expr) => {
+        let text = str::from_utf8($utf8).unwrap();
+        println!("{}", text);
+        assert!(text.contains($vec))
+    }
+}
+
+macro_rules! assert_contains_not {
+    ($utf8: expr, $vec: expr) => {
+        let text = str::from_utf8($utf8).unwrap();
+        println!("{}", text);
+        assert!(!text.contains($vec))
+    }
+}
+
+#[test]
+pub fn invalid_calls() {
+    env::set_current_dir(CWD.join("tests/fixtures/example")).unwrap();
+
+    let output = assert_cli!(&BIN, EMPTY => Error 1).unwrap();
+    assert_contains!(&output.stderr, "requires a subcommand");
+
+    let output = assert_cli!(&BIN, &["--nonexistent-argument"] => Error 1).unwrap();
+    assert_contains!(&output.stderr, r"Found argument '--nonexistent-argument' which wasn't expected");
+}
+
+#[test]
+pub fn log_levels() {
+    env::set_current_dir(CWD.join("tests/fixtures/example")).unwrap();
+
+    let output1 = assert_cli!(&BIN, &["build", "--trace"] => Success).unwrap();
+    assert_contains!(&output1.stderr, "[trace]");
+    assert_contains!(&output1.stderr, "[debug]");
+    assert_contains!(&output1.stderr, "[info]");
+
+    let output2 = assert_cli!(&BIN, &["build", "-L", "trace"] => Success).unwrap();
+    assert_eq!(output1.stderr, output2.stderr);
+
+    let output = assert_cli!(&BIN, &["build", "-L", "debug"] => Success).unwrap();
+    assert_contains_not!(&output.stderr, "[trace]");
+    assert_contains!(&output.stderr, "[debug]");
+    assert_contains!(&output.stderr, "[info]");
+
+    let output = assert_cli!(&BIN, &["build", "-L", "info"] => Success).unwrap();
+    assert_contains_not!(&output.stderr, "[trace]");
+    assert_contains_not!(&output.stderr, "[debug]");
+    assert_contains!(&output.stderr, "[info]");
+
+    assert_cli!(&BIN, &["build", "--silent"] => Success, "").unwrap();
+}
+


### PR DESCRIPTION
This adds a CLI testing mechanism around [assert_cli](https://github.com/killercup/assert_cli) that we should use to add more CLI tests.