### PR TITLE
includes posts recursively into `post_data'

### DIFF
--- a/src/cobalt.rs
+++ b/src/cobalt.rs
@@ -34,6 +34,13 @@ fn compare_paths(a: &Path, b: &Path) -> bool {
     }
 }
 
+fn contain_path(a: &Path, b: &Path) -> bool {
+    match (fs::canonicalize(a), fs::canonicalize(b)) {
+        (Ok(p1), Ok(p2)) => p1.starts_with(p2),
+        _ => false,
+    }
+}
+
 /// The primary build function that transforms a directory into a site
 pub fn build(config: &Config) -> Result<()> {
     trace!("Build configuration: {:?}", config);
@@ -76,8 +83,7 @@ pub fn build(config: &Config) -> Result<()> {
         let extension = &entry_path.extension().unwrap_or(OsStr::new(""));
         if template_extensions.contains(extension) {
             // if the document is in the posts folder it's considered a post
-            let is_post = entry_path.parent().map(|p| compare_paths(p, posts)).unwrap_or(false);
-
+            let is_post = entry_path.parent().map(|p| contain_path(p, posts)).unwrap_or(false);
             let new_path = entry_path.strip_prefix(source).expect("Entry not in source folder");
 
             let doc = try!(Document::parse(&entry_path, new_path, is_post, &config.post_path));

--- a/tests/fixtures/subdirectory_posts/.cobalt.yml
+++ b/tests/fixtures/subdirectory_posts/.cobalt.yml
@@ -1,0 +1,6 @@
+name: cobalt blog for subpost testing
+source: "."
+dest: "build"
+ignore:
+  - .git/*
+  - build/*

--- a/tests/fixtures/subdirectory_posts/_layouts/default.liquid
+++ b/tests/fixtures/subdirectory_posts/_layouts/default.liquid
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        {% if is_post %}
+          <title>{{ title }}</title>
+        {% else %}
+       	  <title>Cobalt.rs Blog</title>
+        {% endif %}
+    </head>
+    <body>
+    <div>
+      {% if is_post %}
+        {% include '_layouts/post.liquid' %}
+      {% else %}
+        {{ content }}
+      {% endif %}
+    </div>
+  </body>
+</html>

--- a/tests/fixtures/subdirectory_posts/_layouts/post.liquid
+++ b/tests/fixtures/subdirectory_posts/_layouts/post.liquid
@@ -1,0 +1,6 @@
+<div>
+  <h2>{{ title }}</h2>
+  <p>
+    {{content}}
+  </p>
+</div>

--- a/tests/fixtures/subdirectory_posts/index.liquid
+++ b/tests/fixtures/subdirectory_posts/index.liquid
@@ -1,0 +1,14 @@
+extends: default.liquid
+---
+<div >
+  <h2>Blog!</h2>
+  <!--<br />-->
+  <div>
+    {% for post in posts %}
+      <div>
+        <h4>{{post.title}}</h4>
+        <h4><a href="{{post.path}}">{{ post.title }}</a></h4>
+      </div>
+    {% endfor %}
+  </div>
+</div>

--- a/tests/fixtures/subdirectory_posts/posts/articles/ocaml/sub-post-2.md
+++ b/tests/fixtures/subdirectory_posts/posts/articles/ocaml/sub-post-2.md
@@ -1,0 +1,9 @@
+extends: default.liquid
+
+title: a post inside posts/articles/ocaml
+date: 14 January 2016 21:00:30 -0500
+---
+
+# A Post inside a subdirectory to `posts`
+
+It should appear in the index.html

--- a/tests/fixtures/subdirectory_posts/posts/articles/rust/sub-post-3.md
+++ b/tests/fixtures/subdirectory_posts/posts/articles/rust/sub-post-3.md
@@ -1,0 +1,9 @@
+extends: default.liquid
+
+title: a post inside posts/articles/rust
+date: 14 January 2016 21:00:30 -0500
+---
+
+# A Post inside a subdirectory to `posts`
+
+It should appear in the index.html

--- a/tests/fixtures/subdirectory_posts/posts/articles/sub-post-1.md
+++ b/tests/fixtures/subdirectory_posts/posts/articles/sub-post-1.md
@@ -1,0 +1,9 @@
+extends: default.liquid
+
+title: a post inside posts/articles
+date: 14 January 2016 21:00:30 -0500
+---
+
+# A Post inside a subdirectory to `posts`
+
+It should appear in the index.html

--- a/tests/fixtures/subdirectory_posts/posts/blogs/sub-post-4.md
+++ b/tests/fixtures/subdirectory_posts/posts/blogs/sub-post-4.md
@@ -1,0 +1,9 @@
+extends: default.liquid
+
+title: a post inside posts/blogs
+date: 14 January 2016 21:00:30 -0500
+---
+
+# A Post inside a subdirectory to `posts`
+
+It should appear in the index.html

--- a/tests/fixtures/subdirectory_posts/posts/post-1.md
+++ b/tests/fixtures/subdirectory_posts/posts/post-1.md
@@ -1,0 +1,9 @@
+extends: default.liquid
+
+title: First Post
+date: 14 January 2016 21:00:30 -0500
+---
+
+# This is our first Post!
+
+Welcome to the first post ever on cobalt.rs!

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -186,3 +186,20 @@ pub fn yaml_error() {
     assert!(err.is_err());
     assert_eq!(err.unwrap_err().description(), "unexpected character: `@'");
 }
+
+#[test]
+pub fn subdirectory_posts() {
+    let config = configure("subdirectory_posts").expect("configure error");
+    setup("subdirectory_posts", &config).expect("build error");
+    let index_html = "tests/tmp/subdirectory_posts/index.html";
+    let mut index_file = File::open(index_html).expect("cannot open index.html");
+    let mut content = String::new();
+    index_file.read_to_string(&mut content).expect("cannot read index.html");
+
+    assert!(content.find("sub-post-1.html") != None);
+    assert!(content.find("sub-post-2.html") != None);
+    assert!(content.find("sub-post-3.html") != None);
+    assert!(content.find("sub-post-4.html") != None);
+
+    cleanup(&config);
+}

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -9,14 +9,21 @@ use walkdir::WalkDir;
 use std::error::Error;
 use cobalt::Config;
 
-fn run_test(name: &str) -> Result<(), cobalt::Error> {
-    let target = format!("tests/target/{}/", name);
+fn configure(name: &str) -> Result<Config, cobalt::Error> {
     let mut config = Config::from_file(format!("tests/fixtures/{}/.cobalt.yml", name))
                          .unwrap_or(Default::default());
 
     config.source = format!("tests/fixtures/{}/", name);
     config.dest = format!("tests/tmp/{}/", name);
+    Ok(config)
+}
 
+fn get_target(name: &str) -> String {
+    format!("tests/target/{}/", name)
+}
+
+fn setup(name: &str, config: &Config) -> Result<(), cobalt::Error> {
+    let target = &get_target(name);
     // try to create the target directory, ignore errors
     fs::create_dir_all(&config.dest).is_ok();
 
@@ -66,8 +73,17 @@ fn run_test(name: &str) -> Result<(), cobalt::Error> {
         }
     }
 
-    // clean up
+    result
+}
+
+fn cleanup(config: &Config) {
     fs::remove_dir_all(&config.dest).is_ok();
+}
+
+fn run_test(name: &str) -> Result<(), cobalt::Error> {
+    let config = try!(configure(name));
+    let result = setup(name, &config);
+    cleanup(&config);
 
     result
 }

--- a/tests/target/subdirectory_posts/index.html
+++ b/tests/target/subdirectory_posts/index.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        
+       	  <title>Cobalt.rs Blog</title>
+        
+    </head>
+    <body>
+    <div>
+      
+        
+<div >
+  <h2>Blog!</h2>
+  <!--<br />-->
+  <div>
+    
+      <div>
+        <h4>First Post</h4>
+        <h4><a href="posts/post-1.html">First Post</a></h4>
+      </div>
+    
+      <div>
+        <h4>a post inside posts/articles/rust</h4>
+        <h4><a href="posts/articles/rust/sub-post-3.html">a post inside posts/articles/rust</a></h4>
+      </div>
+    
+      <div>
+        <h4>a post inside posts/articles/ocaml</h4>
+        <h4><a href="posts/articles/ocaml/sub-post-2.html">a post inside posts/articles/ocaml</a></h4>
+      </div>
+    
+      <div>
+        <h4>a post inside posts/articles</h4>
+        <h4><a href="posts/articles/sub-post-1.html">a post inside posts/articles</a></h4>
+      </div>
+    
+      <div>
+        <h4>a post inside posts/blogs</h4>
+        <h4><a href="posts/blogs/sub-post-4.html">a post inside posts/blogs</a></h4>
+      </div>
+    
+  </div>
+</div>
+
+      
+    </div>
+  </body>
+</html>

--- a/tests/target/subdirectory_posts/posts/articles/ocaml/sub-post-2.html
+++ b/tests/target/subdirectory_posts/posts/articles/ocaml/sub-post-2.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        
+          <title>a post inside posts/articles/ocaml</title>
+        
+    </head>
+    <body>
+    <div>
+      
+        <div>
+  <h2>a post inside posts/articles/ocaml</h2>
+  <p>
+    <h1>A Post inside a subdirectory to <code>posts</code></h1>
+<p>It should appear in the index.html</p>
+
+  </p>
+</div>
+
+      
+    </div>
+  </body>
+</html>

--- a/tests/target/subdirectory_posts/posts/articles/rust/sub-post-3.html
+++ b/tests/target/subdirectory_posts/posts/articles/rust/sub-post-3.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        
+          <title>a post inside posts/articles/rust</title>
+        
+    </head>
+    <body>
+    <div>
+      
+        <div>
+  <h2>a post inside posts/articles/rust</h2>
+  <p>
+    <h1>A Post inside a subdirectory to <code>posts</code></h1>
+<p>It should appear in the index.html</p>
+
+  </p>
+</div>
+
+      
+    </div>
+  </body>
+</html>

--- a/tests/target/subdirectory_posts/posts/articles/sub-post-1.html
+++ b/tests/target/subdirectory_posts/posts/articles/sub-post-1.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        
+          <title>a post inside posts/articles</title>
+        
+    </head>
+    <body>
+    <div>
+      
+        <div>
+  <h2>a post inside posts/articles</h2>
+  <p>
+    <h1>A Post inside a subdirectory to <code>posts</code></h1>
+<p>It should appear in the index.html</p>
+
+  </p>
+</div>
+
+      
+    </div>
+  </body>
+</html>

--- a/tests/target/subdirectory_posts/posts/blogs/sub-post-4.html
+++ b/tests/target/subdirectory_posts/posts/blogs/sub-post-4.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        
+          <title>a post inside posts/blogs</title>
+        
+    </head>
+    <body>
+    <div>
+      
+        <div>
+  <h2>a post inside posts/blogs</h2>
+  <p>
+    <h1>A Post inside a subdirectory to <code>posts</code></h1>
+<p>It should appear in the index.html</p>
+
+  </p>
+</div>
+
+      
+    </div>
+  </body>
+</html>

--- a/tests/target/subdirectory_posts/posts/post-1.html
+++ b/tests/target/subdirectory_posts/posts/post-1.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        
+          <title>First Post</title>
+        
+    </head>
+    <body>
+    <div>
+      
+        <div>
+  <h2>First Post</h2>
+  <p>
+    <h1>This is our first Post!</h1>
+<p>Welcome to the first post ever on cobalt.rs!</p>
+
+  </p>
+</div>
+
+      
+    </div>
+  </body>
+</html>


### PR DESCRIPTION
Hi, all

Currently, posts in subdirectories of `./posts' are missing in the post list in index.html. This patch helps fix this problem.

I've just tried cobalt a few days. Hope it's a valid fixing.

Thanks guys
