### PR TITLE
Fix style issue reported by cargo fmt

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -293,10 +293,11 @@ fn main() {
                                         // strip absolute path
                                         let rel_path = path.strip_prefix(&cwd).unwrap_or(&cwd);
 
-                                        // check if path starts with the build folder.
-                                        if !&config.ignore.iter().any(|pattern| {
-                                            Pattern::matches_path(pattern, rel_path)
-                                        }) {
+                                        let path_starts_with_build =
+                                            &config.ignore.iter().any(|pattern| {
+                                                Pattern::matches_path(pattern, rel_path)
+                                            });
+                                        if !path_starts_with_build {
                                             build(&config);
                                         }
 


### PR DESCRIPTION
All the PRs to master are currently red due to style issues:

```
$ cargo fmt -- --write-mode=diff &&
travis-cargo build &&
travis-cargo test

Diff in /home/travis/build/cobalt-org/cobalt.rs/src/main.rs at line 294:
                                         let rel_path = path.strip_prefix(&cwd).unwrap_or(&cwd);⏎
 ⏎
                                         // check if path starts with the build folder.⏎
-                                        if !&config.ignore.iter().any(|pattern| {⏎
-                                            Pattern::matches_path(pattern, rel_path)⏎
-                                        }) {⏎
+                                        if ⏎
+                                               !&config.ignore⏎
+                                            .iter()⏎
+                                            .any(|pattern| Pattern::matches_path(pattern, rel_path)) {⏎
                                             build(&config);⏎
                                         }⏎
 ⏎
Rustfmt failed at /home/travis/build/cobalt-org/cobalt.rs/src/main.rs:300: line exceeded maximum length (sorry)
Rustfmt failed at /home/travis/build/cobalt-org/cobalt.rs/src/main.rs:297: left behind trailing whitespace (sorry)
```

When I was testing my changes I noticed that build dir check doesn't work properly on my machine (both before and after the fix). I get an infinite loop unless I specify build dir outside of the project root.

However I'd like this style fix to be merged to master ASAP in order to unblock other PRs in Travis.