### PR TITLE
watch should never rebuild on changes that are ignored

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -290,16 +290,13 @@ fn main() {
                                     // get where process was run from
                                     let cwd = std::env::current_dir().unwrap_or(PathBuf::new());
 
-                                    // the final goal is to have a relative path
-                                    // without corner-case prefixes like "./"
-                                    let abs_path = match path.is_absolute() {
-                                        true => path.clone(),
-                                        false => {
-                                            // let path::Path handle corner cases like `./rel/path`
-                                            let mut abs_path = cwd.clone();
-                                            abs_path.push(path.clone());
-                                            abs_path
-                                        }
+                                    // The final goal is to have a relative path. If we already
+                                    // have a relative path, we still convert it to an abs path
+                                    // first to handle prefix "./" correctly.
+                                    let abs_path = if path.is_absolute() {
+                                        path.clone()
+                                    } else {
+                                        cwd.join(&path)
                                     };
                                     let rel_path = abs_path.strip_prefix(&cwd).unwrap_or(&path);
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -287,28 +287,29 @@ fn main() {
                             Ok(val) => {
                                 trace!("file changed {:?}", val);
                                 if let Some(path) = val.path {
-                                    if path.is_absolute() {
-                                        // get where process was run from
-                                        let cwd = std::env::current_dir().unwrap_or(PathBuf::new());
-                                        // strip absolute path
-                                        let rel_path = path.strip_prefix(&cwd).unwrap_or(&cwd);
+                                    // get where process was run from
+                                    let cwd = std::env::current_dir().unwrap_or(PathBuf::new());
 
-                                        let path_starts_with_build =
-                                            &config.ignore.iter().any(|pattern| {
-                                                Pattern::matches_path(pattern, rel_path)
-                                            });
-                                        if !path_starts_with_build {
-                                            build(&config);
+                                    // the final goal is to have a relative path
+                                    // without corner-case prefixes like "./"
+                                    let abs_path = match path.is_absolute() {
+                                        true => path.clone(),
+                                        false => {
+                                            // let path::Path handle corner cases like `./rel/path`
+                                            let mut abs_path = cwd.clone();
+                                            abs_path.push(path.clone());
+                                            abs_path
                                         }
+                                    };
+                                    let rel_path = abs_path.strip_prefix(&cwd).unwrap_or(&path);
 
-                                    } else {
-                                        // check if path starts with build folder.
-                                        // TODO: may want to check if it starts `./`
-                                        if !&config.ignore
-                                            .iter()
-                                            .any(|pattern| Pattern::matches_path(pattern, &path)) {
-                                            build(&config);
-                                        }
+                                    // check whether this path has been marked as ignored in config
+                                    let rel_path_matches =
+                                        |pattern| Pattern::matches_path(pattern, rel_path);
+                                    let path_ignored = &config.ignore.iter().any(rel_path_matches);
+
+                                    if !path_ignored {
+                                        build(&config);
                                     }
                                 }
                             }


### PR DESCRIPTION
There was a bug when `path` contained `./` as prefix (e.g. `./build/index.html`). Now `path::PathBuf` takes care of corner cases like this.

The bug described above meant there was an infinite rebuild loop in `cobalt watch` even when `build` directory was marked as ignored:

* on each rebuild some files in `build` directory were updated
* `inotify` started new rebuilds on these updates