### PR TITLE
Add Jekyll-like excerpts

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ A static site generator written in [Rust](http://www.rust-lang.org/).
   - [Layouts](#layouts)
   - [Posts](#posts)
   - [Other Files](#other-files)
+  - [Excerpts](#excerpts)
   - [Attributes](#attributes)
   - [RSS](#rss)
   - [Import](#import)
@@ -132,6 +133,31 @@ author: johann
 path: /:author/:year/:month/:day/title
 ```
 -> `/johann/2016/01/01/title/index.html`
+
+### Excerpts
+
+Each post automatically takes the first block of text, from the beginning of the content to the first occurrence of `excerpt_separator`, and sets it as the `post.excerpt`. Perhaps you want to include a little hint about the post’s content by adding the first paragraph of each of your posts:
+
+```
+<ul>
+  {% for post in posts %}
+    <li>
+      <a href="{{ post.path }}">{{ post.title }}</a>
+      {{ post.excerpt }}
+    </li>
+  {% endfor %}
+</ul>
+```
+
+If you don't like the automatically-generated post excerpt, it can be explicitly overridden by adding an `excerpt` attribute to your post’s document. Alternatively, you can choose to define a custom `excerpt_separator` attribute:
+
+```
+excerpt_separator: <!--more-->
+---
+Excerpt
+<!--more-->
+Out-of-excerpt
+```
 
 ### Attributes
 

--- a/src/document.rs
+++ b/src/document.rs
@@ -100,6 +100,14 @@ fn format_path(p: &str,
     Ok(path_buf.to_string_lossy().into_owned())
 }
 
+/// Renders markdown document into an HTML string.
+fn render_markdown(markdown: &str) -> String {
+    let mut html = String::new();
+    let parser = cmark::Parser::new(markdown);
+    cmark::html::push_html(&mut html, parser);
+    html
+}
+
 impl Document {
     pub fn new(path: String,
                attributes: HashMap<String, Value>,
@@ -252,10 +260,7 @@ impl Document {
         }
 
         if markdown {
-            let mut excerpt_html = String::new();
-            let parser = cmark::Parser::new(&excerpt);
-            cmark::html::push_html(&mut excerpt_html, parser);
-            excerpt_html
+            render_markdown(&excerpt)
         } else {
             excerpt
         }
@@ -301,12 +306,7 @@ impl Document {
         let mut html = try!(template.render(&mut data)).unwrap_or(String::new());
 
         if self.markdown {
-            html = {
-                let mut buf = String::new();
-                let parser = cmark::Parser::new(&html);
-                cmark::html::push_html(&mut buf, parser);
-                buf
-            };
+            html = render_markdown(&html);
         }
 
         let options = LiquidOptions { file_system: Some(source.to_owned()), ..Default::default() };

--- a/src/document.rs
+++ b/src/document.rs
@@ -180,6 +180,11 @@ impl Document {
 
         let layout = attributes.get("extends").and_then(|l| l.as_str()).map(|x| x.to_owned());
 
+        if is_post {
+            let excerpt = Document::get_excerpt(&content, markdown, &attributes);
+            attributes.insert("excerpt".to_owned(), Value::Str(excerpt));
+        }
+
         let mut path_buf = PathBuf::from(new_path);
         path_buf.set_extension("html");
 
@@ -213,6 +218,48 @@ impl Document {
                          markdown))
     }
 
+    /// Extracts post excerpt out of content.
+    ///
+    /// * Takes the first block of text from contents of a markdown post.
+    /// * If `"excerpt"` attribute is explicitly set, the function takes it instead.
+    /// * If `"excerpt"` attribute is not set and the post isn't in markdown,
+    ///   empty string is returned.
+    /// * Excerpt separator can be overriden by attribute `"excerpt_separator"`.
+    /// * Default excerpt separator is `"\n\n"`.
+    fn get_excerpt(content: &str, markdown: bool, attributes: &HashMap<String, Value>) -> String {
+        static DEFAULT_EXCERPT: &'static str = "";
+        static DEFAULT_EXCERPT_SEPARATOR: &'static str = "\n\n";
+
+        let excerpt;
+
+        if let Some(excerpt_str) = attributes.get("excerpt").and_then(|attr| attr.as_str()) {
+            excerpt = excerpt_str.to_string();
+        } else if !markdown {
+            // If it's not a markdown document and we don't have an explicit excerpt attribute,
+            // we don't know how to split excerpt. Let's just return an empty String in this case.
+            excerpt = DEFAULT_EXCERPT.to_string();
+        } else {
+            let excerpt_separator = attributes.get("excerpt_separator")
+                .and_then(|attr| attr.as_str())
+                .unwrap_or(DEFAULT_EXCERPT_SEPARATOR);
+            let content_splits = content.split(excerpt_separator);
+            // above the split is excerpt
+            excerpt = content_splits
+                .filter(|chunk| !chunk.is_empty())
+                .next() // first non-empty chunk
+                .map(|s| s.to_string())
+                .unwrap_or(content.to_string());
+        }
+
+        if markdown {
+            let mut excerpt_html = String::new();
+            let parser = cmark::Parser::new(&excerpt);
+            cmark::html::push_html(&mut excerpt_html, parser);
+            excerpt_html
+        } else {
+            excerpt
+        }
+    }
 
     /// Metadata for generating RSS feeds
     pub fn to_rss(&self, root_url: &str) -> rss::Item {

--- a/tests/fixtures/excerpts/.cobalt.yml
+++ b/tests/fixtures/excerpts/.cobalt.yml
@@ -1,0 +1,6 @@
+name: cobalt blog
+source: "."
+dest: "build"
+ignore:
+  - .git/*
+  - build/*

--- a/tests/fixtures/excerpts/_layouts/default.liquid
+++ b/tests/fixtures/excerpts/_layouts/default.liquid
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        {% if is_post %}
+          <title>{{ title }}</title>
+        {% else %}
+       	  <title>Cobalt.rs Blog</title>
+        {% endif %}
+    </head>
+    <body>
+    <div>
+      {% if is_post %}
+        {% include '_layouts/post.liquid' %}
+      {% else %}
+        {{ content }}
+      {% endif %}
+    </div>
+  </body>
+</html>

--- a/tests/fixtures/excerpts/_layouts/post.liquid
+++ b/tests/fixtures/excerpts/_layouts/post.liquid
@@ -1,0 +1,6 @@
+<div>
+  <h2>{{ title }}</h2>
+  <p>
+    {{content}}
+  </p>
+</div>

--- a/tests/fixtures/excerpts/index.liquid
+++ b/tests/fixtures/excerpts/index.liquid
@@ -1,0 +1,14 @@
+extends: default.liquid
+---
+<div >
+  <h2>Blog!</h2>
+  <!--<br />-->
+  <div>
+    {% for post in posts %}
+      <div>
+        <h4>{{post.title}}</h4>
+        <h4><a href="{{post.path}}">{{ post.title }}</a></h4>
+      </div>
+    {% endfor %}
+  </div>
+</div>

--- a/tests/fixtures/excerpts/index.liquid
+++ b/tests/fixtures/excerpts/index.liquid
@@ -8,6 +8,7 @@ extends: default.liquid
       <div>
         <h4>{{post.title}}</h4>
         <h4><a href="{{post.path}}">{{ post.title }}</a></h4>
+        {{ post.excerpt }}
       </div>
     {% endfor %}
   </div>

--- a/tests/fixtures/excerpts/posts/post-1.md
+++ b/tests/fixtures/excerpts/posts/post-1.md
@@ -1,0 +1,9 @@
+extends: default.liquid
+
+title: First Post
+date: 14 January 2016 21:00:30 -0500
+---
+
+# This is our first Post!
+
+Welcome to the first post ever on cobalt.rs!

--- a/tests/fixtures/excerpts/posts/post-1.md
+++ b/tests/fixtures/excerpts/posts/post-1.md
@@ -1,6 +1,6 @@
 extends: default.liquid
 
-title: First Post
+title: First block is an excerpt
 date: 14 January 2016 21:00:30 -0500
 ---
 

--- a/tests/fixtures/excerpts/posts/post-2.md
+++ b/tests/fixtures/excerpts/posts/post-2.md
@@ -1,0 +1,5 @@
+extends: default.liquid
+
+title: An empty post means an empty excerpt
+date: 14 January 2016 21:01:30 -0500
+---

--- a/tests/fixtures/excerpts/posts/post-3.md
+++ b/tests/fixtures/excerpts/posts/post-3.md
@@ -1,0 +1,10 @@
+extends: default.liquid
+
+title: Explicit `excerpt`
+date: 14 January 2016 21:02:30 -0500
+excerpt: Is in `markdown`
+---
+
+# This is our third Post!
+
+Welcome to the third post ever on cobalt.rs!

--- a/tests/fixtures/excerpts/posts/post-4.md
+++ b/tests/fixtures/excerpts/posts/post-4.md
@@ -1,0 +1,13 @@
+extends: default.liquid
+
+title: Custom excerpt separator
+date: 14 January 2016 21:03:30 -0500
+excerpt_separator: <!-- more -->
+---
+
+# Custom excerpt separator
+
+Welcome to the 4th post on cobalt.rs!
+<!-- more -->
+
+Something below the separator.

--- a/tests/fixtures/excerpts/posts/post-5.md
+++ b/tests/fixtures/excerpts/posts/post-5.md
@@ -1,0 +1,14 @@
+extends: default.liquid
+
+title: Both excerpt and excerpt separator are there
+date: 14 January 2016 21:04:30 -0500
+excerpt: "`excerpt` wins"
+excerpt_separator: <!-- more -->
+---
+
+# Both excerpt and excerpt separator are there
+
+Welcome to the 5th post on cobalt.rs!
+<!-- more -->
+
+Something below the separator.

--- a/tests/fixtures/excerpts/posts/post-6.liquid
+++ b/tests/fixtures/excerpts/posts/post-6.liquid
@@ -1,0 +1,13 @@
+extends: default.liquid
+
+title: Implicit excepts work only in markdown
+date: 14 January 2016 21:05:30 -0500
+excerpt_separator: <!-- more -->
+---
+
+<h1>Custom excerpt separator</h1>
+
+<p>Welcome to the 6th post on cobalt.rs!</p>
+<!-- more -->
+
+<p>Something below the separator.</p>

--- a/tests/fixtures/excerpts/posts/post-7.liquid
+++ b/tests/fixtures/excerpts/posts/post-7.liquid
@@ -1,0 +1,14 @@
+extends: default.liquid
+
+title: Explicit excepts work even in liquid
+date: 14 January 2016 21:06:30 -0500
+excerpt: <strong>explicit</strong> excerpt
+excerpt_separator: <!-- more -->
+---
+
+<h1>Custom excerpt separator</h1>
+
+<p>Welcome to the 7th post on cobalt.rs!</p>
+<!-- more -->
+
+<p>Something below the separator.</p>

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -170,3 +170,8 @@ pub fn yaml_error() {
     assert!(err.is_err());
     assert_eq!(err.unwrap_err().description(), "unexpected character: `@'");
 }
+
+#[test]
+pub fn excerpts() {
+    run_test("excerpts").unwrap();
+}

--- a/tests/target/excerpts/index.html
+++ b/tests/target/excerpts/index.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        
+       	  <title>Cobalt.rs Blog</title>
+        
+    </head>
+    <body>
+    <div>
+      
+        
+<div >
+  <h2>Blog!</h2>
+  <!--<br />-->
+  <div>
+    
+      <div>
+        <h4>First Post</h4>
+        <h4><a href="posts/post-1.html">First Post</a></h4>
+      </div>
+    
+  </div>
+</div>
+
+      
+    </div>
+  </body>
+</html>

--- a/tests/target/excerpts/index.html
+++ b/tests/target/excerpts/index.html
@@ -15,8 +15,38 @@
   <div>
     
       <div>
-        <h4>First Post</h4>
-        <h4><a href="posts/post-1.html">First Post</a></h4>
+        <h4>Both excerpt and excerpt separator are there</h4>
+        <h4><a href="posts/post-5.html">Both excerpt and excerpt separator are there</a></h4>
+        <p><code>excerpt</code> wins</p>
+
+      </div>
+    
+      <div>
+        <h4>Custom excerpt separator</h4>
+        <h4><a href="posts/post-4.html">Custom excerpt separator</a></h4>
+        <h1>Custom excerpt separator</h1>
+<p>Welcome to the 4th post on cobalt.rs!</p>
+
+      </div>
+    
+      <div>
+        <h4>Explicit `excerpt`</h4>
+        <h4><a href="posts/post-3.html">Explicit `excerpt`</a></h4>
+        <p>Is in <code>markdown</code></p>
+
+      </div>
+    
+      <div>
+        <h4>An empty post means an empty excerpt</h4>
+        <h4><a href="posts/post-2.html">An empty post means an empty excerpt</a></h4>
+        
+      </div>
+    
+      <div>
+        <h4>First block is an excerpt</h4>
+        <h4><a href="posts/post-1.html">First block is an excerpt</a></h4>
+        <h1>This is our first Post!</h1>
+
       </div>
     
   </div>

--- a/tests/target/excerpts/index.html
+++ b/tests/target/excerpts/index.html
@@ -15,6 +15,18 @@
   <div>
     
       <div>
+        <h4>Explicit excepts work even in liquid</h4>
+        <h4><a href="posts/post-7.html">Explicit excepts work even in liquid</a></h4>
+        <strong>explicit</strong> excerpt
+      </div>
+    
+      <div>
+        <h4>Implicit excepts work only in markdown</h4>
+        <h4><a href="posts/post-6.html">Implicit excepts work only in markdown</a></h4>
+        
+      </div>
+    
+      <div>
         <h4>Both excerpt and excerpt separator are there</h4>
         <h4><a href="posts/post-5.html">Both excerpt and excerpt separator are there</a></h4>
         <p><code>excerpt</code> wins</p>

--- a/tests/target/excerpts/posts/post-1.html
+++ b/tests/target/excerpts/posts/post-1.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        
+          <title>First Post</title>
+        
+    </head>
+    <body>
+    <div>
+      
+        <div>
+  <h2>First Post</h2>
+  <p>
+    <h1>This is our first Post!</h1>
+<p>Welcome to the first post ever on cobalt.rs!</p>
+
+  </p>
+</div>
+
+      
+    </div>
+  </body>
+</html>

--- a/tests/target/excerpts/posts/post-1.html
+++ b/tests/target/excerpts/posts/post-1.html
@@ -2,14 +2,14 @@
 <html>
     <head>
         
-          <title>First Post</title>
+          <title>First block is an excerpt</title>
         
     </head>
     <body>
     <div>
       
         <div>
-  <h2>First Post</h2>
+  <h2>First block is an excerpt</h2>
   <p>
     <h1>This is our first Post!</h1>
 <p>Welcome to the first post ever on cobalt.rs!</p>

--- a/tests/target/excerpts/posts/post-2.html
+++ b/tests/target/excerpts/posts/post-2.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        
+          <title>An empty post means an empty excerpt</title>
+        
+    </head>
+    <body>
+    <div>
+      
+        <div>
+  <h2>An empty post means an empty excerpt</h2>
+  <p>
+    
+  </p>
+</div>
+
+      
+    </div>
+  </body>
+</html>

--- a/tests/target/excerpts/posts/post-3.html
+++ b/tests/target/excerpts/posts/post-3.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        
+          <title>Explicit `excerpt`</title>
+        
+    </head>
+    <body>
+    <div>
+      
+        <div>
+  <h2>Explicit `excerpt`</h2>
+  <p>
+    <h1>This is our third Post!</h1>
+<p>Welcome to the third post ever on cobalt.rs!</p>
+
+  </p>
+</div>
+
+      
+    </div>
+  </body>
+</html>

--- a/tests/target/excerpts/posts/post-4.html
+++ b/tests/target/excerpts/posts/post-4.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        
+          <title>Custom excerpt separator</title>
+        
+    </head>
+    <body>
+    <div>
+      
+        <div>
+  <h2>Custom excerpt separator</h2>
+  <p>
+    <h1>Custom excerpt separator</h1>
+<p>Welcome to the 4th post on cobalt.rs!</p>
+<!-- more -->
+<p>Something below the separator.</p>
+
+  </p>
+</div>
+
+      
+    </div>
+  </body>
+</html>

--- a/tests/target/excerpts/posts/post-5.html
+++ b/tests/target/excerpts/posts/post-5.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        
+          <title>Both excerpt and excerpt separator are there</title>
+        
+    </head>
+    <body>
+    <div>
+      
+        <div>
+  <h2>Both excerpt and excerpt separator are there</h2>
+  <p>
+    <h1>Both excerpt and excerpt separator are there</h1>
+<p>Welcome to the 5th post on cobalt.rs!</p>
+<!-- more -->
+<p>Something below the separator.</p>
+
+  </p>
+</div>
+
+      
+    </div>
+  </body>
+</html>

--- a/tests/target/excerpts/posts/post-6.html
+++ b/tests/target/excerpts/posts/post-6.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        
+          <title>Implicit excepts work only in markdown</title>
+        
+    </head>
+    <body>
+    <div>
+      
+        <div>
+  <h2>Implicit excepts work only in markdown</h2>
+  <p>
+    
+
+<h1>Custom excerpt separator</h1>
+
+<p>Welcome to the 6th post on cobalt.rs!</p>
+<!-- more -->
+
+<p>Something below the separator.</p>
+
+  </p>
+</div>
+
+      
+    </div>
+  </body>
+</html>

--- a/tests/target/excerpts/posts/post-7.html
+++ b/tests/target/excerpts/posts/post-7.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        
+          <title>Explicit excepts work even in liquid</title>
+        
+    </head>
+    <body>
+    <div>
+      
+        <div>
+  <h2>Explicit excepts work even in liquid</h2>
+  <p>
+    
+
+<h1>Custom excerpt separator</h1>
+
+<p>Welcome to the 7th post on cobalt.rs!</p>
+<!-- more -->
+
+<p>Something below the separator.</p>
+
+  </p>
+</div>
+
+      
+    </div>
+  </body>
+</html>


### PR DESCRIPTION
This PR adds Jekyll-like excerpts. Please see [Jekyll docs](https://jekyllrb.com/docs/posts/#post-excerpts) for details.

What hasn't been implemented yet:

* site-wide `excerpt_separator` defined in `.cobalt.yml`
* disabling excerpts by setting `excerpt_separator` to `""` (either per post or globally in `.cobalt.yml`)