### PR TITLE
Refactor methods for rendering documents, add excerpts and fix content attributes

### DIFF
--- a/src/cobalt.rs
+++ b/src/cobalt.rs
@@ -136,6 +136,7 @@ pub fn build(config: &Config) -> Result<()> {
 
         let mut context = post.get_render_context(&simple_posts_data);
 
+        try!(post.render_excerpt(&mut context, &source, &config.excerpt_separator));
         let post_html = try!(post.render(&mut context, &source, &layouts));
         try!(create_document_file(&post_html, &post.path, dest));
     }

--- a/src/cobalt.rs
+++ b/src/cobalt.rs
@@ -134,10 +134,10 @@ pub fn build(config: &Config) -> Result<()> {
     for mut post in &mut posts {
         trace!("Generating {}", post.path);
 
-        let content = try!(post.as_html(&source, &simple_posts_data, &layouts));
-        try!(create_document_file(&content, &post.path, dest));
+        let mut context = post.get_render_context(&simple_posts_data);
 
-        post.attributes.insert("content".to_owned(), Value::Str(content));
+        let post_html = try!(post.render(&mut context, &source, &layouts));
+        try!(create_document_file(&post_html, &post.path, dest));
     }
 
     // during post rendering additional attributes such as content were
@@ -147,11 +147,12 @@ pub fn build(config: &Config) -> Result<()> {
         .collect();
 
     trace!("Generating other documents");
-    for doc in documents {
+    for mut doc in documents {
         trace!("Generating {}", doc.path);
 
-        let content = try!(doc.as_html(&source, &posts_data, &layouts));
-        try!(create_document_file(&content, &doc.path, dest));
+        let mut context = doc.get_render_context(&posts_data);
+        let doc_html = try!(doc.render(&mut context, &source, &layouts));
+        try!(create_document_file(&doc_html, &doc.path, dest));
     }
 
     // copy all remaining files in the source to the destination

--- a/src/cobalt.rs
+++ b/src/cobalt.rs
@@ -1,4 +1,5 @@
 use std::fs::{self, File};
+use std::collections::HashMap;
 use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::ffi::OsStr;
@@ -48,6 +49,7 @@ pub fn build(config: &Config) -> Result<()> {
 
     let layouts = source.join(&config.layouts);
     let layouts = layouts.as_path();
+    let mut layouts_cache = HashMap::new();
     let posts_path = source.join(&config.posts);
     let posts_path = posts_path.as_path();
 
@@ -137,7 +139,7 @@ pub fn build(config: &Config) -> Result<()> {
         let mut context = post.get_render_context(&simple_posts_data);
 
         try!(post.render_excerpt(&mut context, &source, &config.excerpt_separator));
-        let post_html = try!(post.render(&mut context, &source, &layouts));
+        let post_html = try!(post.render(&mut context, &source, &layouts, &mut layouts_cache));
         try!(create_document_file(&post_html, &post.path, dest));
     }
 
@@ -152,7 +154,7 @@ pub fn build(config: &Config) -> Result<()> {
         trace!("Generating {}", doc.path);
 
         let mut context = doc.get_render_context(&posts_data);
-        let doc_html = try!(doc.render(&mut context, &source, &layouts));
+        let doc_html = try!(doc.render(&mut context, &source, &layouts, &mut layouts_cache));
         try!(create_document_file(&doc_html, &doc.path, dest));
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -21,6 +21,7 @@ pub struct Config {
     pub description: Option<String>,
     pub link: Option<String>,
     pub ignore: Vec<Pattern>,
+    pub excerpt_separator: String,
 }
 
 impl Default for Config {
@@ -39,6 +40,7 @@ impl Default for Config {
             description: None,
             link: None,
             ignore: vec![],
+            excerpt_separator: "\n\n".to_owned(),
         }
     }
 }
@@ -107,6 +109,10 @@ impl Config {
                 .filter_map(|k| Pattern::new(k).ok()) {
                 config.ignore.push(pattern);
             }
+        };
+
+        if let Some(excerpt_separator) = yaml["excerpt_separator"].as_str() {
+            config.excerpt_separator = excerpt_separator.to_owned();
         };
 
         Ok(config)

--- a/src/document.rs
+++ b/src/document.rs
@@ -133,9 +133,9 @@ impl Document {
         let content = try!(read_file(file_path));
 
         // if there is front matter, split the file and parse it
-        // TODO: make this a regex to support lines of any length
-        let content = if content.contains("---") {
-            let mut splits = content.splitn(2, "---");
+        let splitter = Regex::new(r"---\s*\r?\n").unwrap();
+        let content = if splitter.is_match(&content) {
+            let mut splits = splitter.splitn(&content, 2);
 
             // above the split are the attributes
             let attribute_split = splits.next().unwrap_or("");

--- a/src/document.rs
+++ b/src/document.rs
@@ -260,6 +260,37 @@ impl Document {
         Ok(html.to_owned())
     }
 
+    /// Renders excerpt and adds it to attributes of the document.
+    pub fn render_excerpt(&mut self,
+                          context: &mut Context,
+                          source: &Path,
+                          default_excerpt_separator: &str)
+                          -> Result<()> {
+        let excerpt_html = {
+            let excerpt_attr = self.attributes
+                .get("excerpt")
+                .and_then(|attr| attr.as_str());
+
+            let excerpt_separator: &str = self.attributes
+                .get("excerpt_separator")
+                .and_then(|attr| attr.as_str())
+                .unwrap_or(default_excerpt_separator);
+
+            let excerpt = if let Some(excerpt_str) = excerpt_attr {
+                excerpt_str
+            } else if excerpt_separator.is_empty() {
+                ""
+            } else {
+                self.content.split(excerpt_separator).next().unwrap_or(&self.content)
+            };
+
+            try!(self.render_html(excerpt, context, source))
+        };
+
+        self.attributes.insert("excerpt".to_owned(), Value::Str(excerpt_html));
+        Ok(())
+    }
+
     /// Renders the document to an HTML string.
     ///
     /// Side effects:

--- a/src/document.rs
+++ b/src/document.rs
@@ -267,14 +267,13 @@ impl Document {
 
         let options = LiquidOptions { file_system: Some(source.to_owned()), ..Default::default() };
 
-        let template = if let Some(layout) = layout {
+        if let Some(layout) = layout {
             data.set_val("content", Value::Str(html));
 
-            try!(liquid::parse(&layout, options))
+            let template = try!(liquid::parse(&layout, options));
+            Ok(try!(template.render(&mut data)).unwrap_or(String::new()))
         } else {
-            try!(liquid::parse(&html, options))
-        };
-
-        Ok(try!(template.render(&mut data)).unwrap_or(String::new()))
+            Ok(html)
+        }
     }
 }

--- a/src/document.rs
+++ b/src/document.rs
@@ -237,9 +237,6 @@ impl Document {
                    post_data: &[Value],
                    layouts_path: &Path)
                    -> Result<String> {
-        let options = LiquidOptions { file_system: Some(source.to_owned()), ..Default::default() };
-        let template = try!(liquid::parse(&self.content, options));
-
         let layout = if let Some(ref layout) = self.layout {
             Some(try!(read_file(layouts_path.join(layout)).map_err(|e| {
                 format!("Layout {} can not be read (defined in {}): {}",
@@ -254,6 +251,8 @@ impl Document {
         let mut data = Context::with_values(self.attributes.clone());
         data.set_val("posts", Value::Array(post_data.to_vec()));
 
+        let options = LiquidOptions { file_system: Some(source.to_owned()), ..Default::default() };
+        let template = try!(liquid::parse(&self.content, options));
         let mut html = try!(template.render(&mut data)).unwrap_or(String::new());
 
         if self.markdown {
@@ -265,11 +264,11 @@ impl Document {
             };
         }
 
-        let options = LiquidOptions { file_system: Some(source.to_owned()), ..Default::default() };
-
         if let Some(layout) = layout {
             data.set_val("content", Value::Str(html));
 
+            let options =
+                LiquidOptions { file_system: Some(source.to_owned()), ..Default::default() };
             let template = try!(liquid::parse(&layout, options));
             Ok(try!(template.render(&mut data)).unwrap_or(String::new()))
         } else {

--- a/tests/fixtures/excerpts/.cobalt.yml
+++ b/tests/fixtures/excerpts/.cobalt.yml
@@ -1,0 +1,6 @@
+name: cobalt blog
+source: "."
+dest: "build"
+ignore:
+  - .git/*
+  - build/*

--- a/tests/fixtures/excerpts/_layouts/default.liquid
+++ b/tests/fixtures/excerpts/_layouts/default.liquid
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        {% if is_post %}
+          <title>{{ title }}</title>
+        {% else %}
+       	  <title>Cobalt.rs Blog</title>
+        {% endif %}
+    </head>
+    <body>
+    <div>
+      {% if is_post %}
+        {% include '_layouts/post.liquid' %}
+      {% else %}
+        {{ content }}
+      {% endif %}
+    </div>
+  </body>
+</html>

--- a/tests/fixtures/excerpts/_layouts/post.liquid
+++ b/tests/fixtures/excerpts/_layouts/post.liquid
@@ -1,0 +1,6 @@
+<div>
+  <h2>{{ title }}</h2>
+  <p>
+    {{content}}
+  </p>
+</div>

--- a/tests/fixtures/excerpts/index.liquid
+++ b/tests/fixtures/excerpts/index.liquid
@@ -1,0 +1,14 @@
+extends: default.liquid
+---
+<div >
+  <h2>Blog!</h2>
+  <!--<br />-->
+  <div>
+    {% for post in posts %}
+      <div>
+        <h4>{{post.title}}</h4>
+        <h4><a href="{{post.path}}">{{ post.title }}</a></h4>
+      </div>
+    {% endfor %}
+  </div>
+</div>

--- a/tests/fixtures/excerpts/index.liquid
+++ b/tests/fixtures/excerpts/index.liquid
@@ -8,6 +8,7 @@ extends: default.liquid
       <div>
         <h4>{{post.title}}</h4>
         <h4><a href="{{post.path}}">{{ post.title }}</a></h4>
+        {{ post.excerpt }}
       </div>
     {% endfor %}
   </div>

--- a/tests/fixtures/excerpts/posts/post-1.md
+++ b/tests/fixtures/excerpts/posts/post-1.md
@@ -1,0 +1,9 @@
+extends: default.liquid
+
+title: First Post
+date: 14 January 2016 21:00:30 -0500
+---
+
+# This is our first Post!
+
+Welcome to the first post ever on cobalt.rs!

--- a/tests/fixtures/excerpts/posts/post-1.md
+++ b/tests/fixtures/excerpts/posts/post-1.md
@@ -1,6 +1,6 @@
 extends: default.liquid
 
-title: First Post
+title: First block is an excerpt
 date: 14 January 2016 21:00:30 -0500
 ---
 

--- a/tests/fixtures/excerpts/posts/post-2.md
+++ b/tests/fixtures/excerpts/posts/post-2.md
@@ -1,0 +1,5 @@
+extends: default.liquid
+
+title: An empty post means an empty excerpt
+date: 14 January 2016 21:01:30 -0500
+---

--- a/tests/fixtures/excerpts/posts/post-3.md
+++ b/tests/fixtures/excerpts/posts/post-3.md
@@ -1,0 +1,10 @@
+extends: default.liquid
+
+title: Explicit `excerpt`
+date: 14 January 2016 21:02:30 -0500
+excerpt: Is in `markdown`
+---
+
+# This is our third Post!
+
+Welcome to the third post ever on cobalt.rs!

--- a/tests/fixtures/excerpts/posts/post-4.md
+++ b/tests/fixtures/excerpts/posts/post-4.md
@@ -1,0 +1,13 @@
+extends: default.liquid
+
+title: Custom excerpt separator
+date: 14 January 2016 21:03:30 -0500
+excerpt_separator: <!-- more -->
+---
+
+# Custom excerpt separator
+
+Welcome to the 4th post on cobalt.rs!
+<!-- more -->
+
+Something below the separator.

--- a/tests/fixtures/excerpts/posts/post-5.md
+++ b/tests/fixtures/excerpts/posts/post-5.md
@@ -1,0 +1,14 @@
+extends: default.liquid
+
+title: Both excerpt and excerpt separator are there
+date: 14 January 2016 21:04:30 -0500
+excerpt: "`excerpt` wins"
+excerpt_separator: <!-- more -->
+---
+
+# Both excerpt and excerpt separator are there
+
+Welcome to the 5th post on cobalt.rs!
+<!-- more -->
+
+Something below the separator.

--- a/tests/fixtures/excerpts/posts/post-6.liquid
+++ b/tests/fixtures/excerpts/posts/post-6.liquid
@@ -1,0 +1,13 @@
+extends: default.liquid
+
+title: Implicit excepts work only in markdown
+date: 14 January 2016 21:05:30 -0500
+excerpt_separator: <!-- more -->
+---
+
+<h1>Custom excerpt separator</h1>
+
+<p>Welcome to the 6th post on cobalt.rs!</p>
+<!-- more -->
+
+<p>Something below the separator.</p>

--- a/tests/fixtures/excerpts/posts/post-7.liquid
+++ b/tests/fixtures/excerpts/posts/post-7.liquid
@@ -1,0 +1,14 @@
+extends: default.liquid
+
+title: Explicit excepts work even in liquid
+date: 14 January 2016 21:06:30 -0500
+excerpt: <strong>explicit</strong> excerpt
+excerpt_separator: <!-- more -->
+---
+
+<h1>Custom excerpt separator</h1>
+
+<p>Welcome to the 7th post on cobalt.rs!</p>
+<!-- more -->
+
+<p>Something below the separator.</p>

--- a/tests/fixtures/liquid_escaped/_layouts/default.liquid
+++ b/tests/fixtures/liquid_escaped/_layouts/default.liquid
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>test</title>
+    </head>
+    <body>
+        <h1>{{ name }}</h1>
+
+        {{ content }}
+    </body>
+</html>
+

--- a/tests/fixtures/liquid_escaped/extends.liquid
+++ b/tests/fixtures/liquid_escaped/extends.liquid
@@ -1,0 +1,4 @@
+extends: default.liquid
+title: with extends and {% invalidtag %}
+---
+{% raw %}{% invalidtag %}{% endraw %}

--- a/tests/fixtures/liquid_escaped/not-extends.liquid
+++ b/tests/fixtures/liquid_escaped/not-extends.liquid
@@ -1,0 +1,3 @@
+title: with extends and {% invalidtag %}
+---
+{% raw %}{% invalidtag %}{% endraw %}

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -144,6 +144,11 @@ pub fn liquid_error() {
 }
 
 #[test]
+pub fn liquid_raw() {
+    run_test("liquid_escaped").expect("Build error");
+}
+
+#[test]
 pub fn no_extends_error() {
     let err = run_test("no_extends_error");
     assert!(err.is_err());

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -180,3 +180,8 @@ pub fn yaml_error() {
     assert!(err.is_err());
     assert_eq!(err.unwrap_err().description(), "unexpected character: `@'");
 }
+
+#[test]
+pub fn excerpts() {
+    run_test("excerpts").unwrap();
+}

--- a/tests/target/copy_files/index.html
+++ b/tests/target/copy_files/index.html
@@ -6,8 +6,7 @@
     <body>
         <h1>index.html</h1>
 
-        
-This is my Index page!
+        This is my Index page!
 
 
  <a href="posts/2014-08-24-my-first-blogpost.html">My first Blogpost</a>

--- a/tests/target/custom_paths/index.html
+++ b/tests/target/custom_paths/index.html
@@ -6,8 +6,7 @@
     <body>
         <h1>index.html</h1>
 
-        
-This is my Index page!
+        This is my Index page!
 
 
  <a href="2015/hello/index.html">Date variables</a>

--- a/tests/target/custom_post_path/index.html
+++ b/tests/target/custom_post_path/index.html
@@ -6,8 +6,7 @@
     <body>
         <h1>index.html</h1>
 
-        
-This is my Index page!
+        This is my Index page!
 
 
  <a href="blog/2016/05/29/index.html">My fourth Blogpost</a>

--- a/tests/target/custom_posts_folder/index.html
+++ b/tests/target/custom_posts_folder/index.html
@@ -6,8 +6,7 @@
     <body>
         <h1>index.html</h1>
 
-        
-This is my Index page!
+        This is my Index page!
 
 
  <a href="blog/2014-08-24-my-first-blogpost.html">My first Blogpost</a>

--- a/tests/target/custom_template_extensions/index.html
+++ b/tests/target/custom_template_extensions/index.html
@@ -6,8 +6,7 @@
     <body>
         <h1>index.html</h1>
 
-        
-This is my Index page!
+        This is my Index page!
 
 
  <a href="posts/2014-08-24-my-first-blogpost.html">My first Blogpost</a>

--- a/tests/target/dotfiles/index.html
+++ b/tests/target/dotfiles/index.html
@@ -6,8 +6,7 @@
     <body>
         <h1>index.html</h1>
 
-        
-This is my Index page!
+        This is my Index page!
 
 
  <a href="posts/2014-08-24-my-first-blogpost.html">My first Blogpost</a>

--- a/tests/target/drafts/index.html
+++ b/tests/target/drafts/index.html
@@ -6,8 +6,7 @@
     <body>
         <h1>index.html</h1>
 
-        
-This is my Index page!
+        This is my Index page!
 
 
  <a href="posts/2014-08-24-my-first-blogpost.html">My first Blogpost</a>

--- a/tests/target/drafts_not_shown_by_default/index.html
+++ b/tests/target/drafts_not_shown_by_default/index.html
@@ -6,8 +6,7 @@
     <body>
         <h1>index.html</h1>
 
-        
-This is my Index page!
+        This is my Index page!
 
 
  <a href="posts/2014-08-24-my-first-blogpost.html">My first Blogpost</a>

--- a/tests/target/example/index.html
+++ b/tests/target/example/index.html
@@ -6,8 +6,7 @@
     <body>
         <h1>index.html</h1>
 
-        
-This is my Index page!
+        This is my Index page!
 
 
  <a href="posts/2014-08-24-my-first-blogpost.html">My first Blogpost</a>

--- a/tests/target/excerpts/index.html
+++ b/tests/target/excerpts/index.html
@@ -14,6 +14,21 @@
   <div>
     
       <div>
+        <h4>Explicit excepts work even in liquid</h4>
+        <h4><a href="posts/post-7.html">Explicit excepts work even in liquid</a></h4>
+        <strong>explicit</strong> excerpt
+      </div>
+    
+      <div>
+        <h4>Implicit excepts work only in markdown</h4>
+        <h4><a href="posts/post-6.html">Implicit excepts work only in markdown</a></h4>
+        <h1>Custom excerpt separator</h1>
+
+<p>Welcome to the 6th post on cobalt.rs!</p>
+
+      </div>
+    
+      <div>
         <h4>Both excerpt and excerpt separator are there</h4>
         <h4><a href="posts/post-5.html">Both excerpt and excerpt separator are there</a></h4>
         <p><code>excerpt</code> wins</p>

--- a/tests/target/excerpts/index.html
+++ b/tests/target/excerpts/index.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        
+       	  <title>Cobalt.rs Blog</title>
+        
+    </head>
+    <body>
+    <div>
+      
+        <div >
+  <h2>Blog!</h2>
+  <!--<br />-->
+  <div>
+    
+      <div>
+        <h4>First Post</h4>
+        <h4><a href="posts/post-1.html">First Post</a></h4>
+      </div>
+    
+  </div>
+</div>
+
+      
+    </div>
+  </body>
+</html>

--- a/tests/target/excerpts/index.html
+++ b/tests/target/excerpts/index.html
@@ -14,8 +14,38 @@
   <div>
     
       <div>
-        <h4>First Post</h4>
-        <h4><a href="posts/post-1.html">First Post</a></h4>
+        <h4>Both excerpt and excerpt separator are there</h4>
+        <h4><a href="posts/post-5.html">Both excerpt and excerpt separator are there</a></h4>
+        <p><code>excerpt</code> wins</p>
+
+      </div>
+    
+      <div>
+        <h4>Custom excerpt separator</h4>
+        <h4><a href="posts/post-4.html">Custom excerpt separator</a></h4>
+        <h1>Custom excerpt separator</h1>
+<p>Welcome to the 4th post on cobalt.rs!</p>
+
+      </div>
+    
+      <div>
+        <h4>Explicit `excerpt`</h4>
+        <h4><a href="posts/post-3.html">Explicit `excerpt`</a></h4>
+        <p>Is in <code>markdown</code></p>
+
+      </div>
+    
+      <div>
+        <h4>An empty post means an empty excerpt</h4>
+        <h4><a href="posts/post-2.html">An empty post means an empty excerpt</a></h4>
+        
+      </div>
+    
+      <div>
+        <h4>First block is an excerpt</h4>
+        <h4><a href="posts/post-1.html">First block is an excerpt</a></h4>
+        <h1>This is our first Post!</h1>
+
       </div>
     
   </div>

--- a/tests/target/excerpts/posts/post-1.html
+++ b/tests/target/excerpts/posts/post-1.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        
+          <title>First Post</title>
+        
+    </head>
+    <body>
+    <div>
+      
+        <div>
+  <h2>First Post</h2>
+  <p>
+    <h1>This is our first Post!</h1>
+<p>Welcome to the first post ever on cobalt.rs!</p>
+
+  </p>
+</div>
+
+      
+    </div>
+  </body>
+</html>

--- a/tests/target/excerpts/posts/post-1.html
+++ b/tests/target/excerpts/posts/post-1.html
@@ -2,14 +2,14 @@
 <html>
     <head>
         
-          <title>First Post</title>
+          <title>First block is an excerpt</title>
         
     </head>
     <body>
     <div>
       
         <div>
-  <h2>First Post</h2>
+  <h2>First block is an excerpt</h2>
   <p>
     <h1>This is our first Post!</h1>
 <p>Welcome to the first post ever on cobalt.rs!</p>

--- a/tests/target/excerpts/posts/post-2.html
+++ b/tests/target/excerpts/posts/post-2.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        
+          <title>An empty post means an empty excerpt</title>
+        
+    </head>
+    <body>
+    <div>
+      
+        <div>
+  <h2>An empty post means an empty excerpt</h2>
+  <p>
+    
+  </p>
+</div>
+
+      
+    </div>
+  </body>
+</html>

--- a/tests/target/excerpts/posts/post-3.html
+++ b/tests/target/excerpts/posts/post-3.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        
+          <title>Explicit `excerpt`</title>
+        
+    </head>
+    <body>
+    <div>
+      
+        <div>
+  <h2>Explicit `excerpt`</h2>
+  <p>
+    <h1>This is our third Post!</h1>
+<p>Welcome to the third post ever on cobalt.rs!</p>
+
+  </p>
+</div>
+
+      
+    </div>
+  </body>
+</html>

--- a/tests/target/excerpts/posts/post-4.html
+++ b/tests/target/excerpts/posts/post-4.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        
+          <title>Custom excerpt separator</title>
+        
+    </head>
+    <body>
+    <div>
+      
+        <div>
+  <h2>Custom excerpt separator</h2>
+  <p>
+    <h1>Custom excerpt separator</h1>
+<p>Welcome to the 4th post on cobalt.rs!</p>
+<!-- more -->
+<p>Something below the separator.</p>
+
+  </p>
+</div>
+
+      
+    </div>
+  </body>
+</html>

--- a/tests/target/excerpts/posts/post-5.html
+++ b/tests/target/excerpts/posts/post-5.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        
+          <title>Both excerpt and excerpt separator are there</title>
+        
+    </head>
+    <body>
+    <div>
+      
+        <div>
+  <h2>Both excerpt and excerpt separator are there</h2>
+  <p>
+    <h1>Both excerpt and excerpt separator are there</h1>
+<p>Welcome to the 5th post on cobalt.rs!</p>
+<!-- more -->
+<p>Something below the separator.</p>
+
+  </p>
+</div>
+
+      
+    </div>
+  </body>
+</html>

--- a/tests/target/excerpts/posts/post-6.html
+++ b/tests/target/excerpts/posts/post-6.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        
+          <title>Implicit excepts work only in markdown</title>
+        
+    </head>
+    <body>
+    <div>
+      
+        <div>
+  <h2>Implicit excepts work only in markdown</h2>
+  <p>
+    <h1>Custom excerpt separator</h1>
+
+<p>Welcome to the 6th post on cobalt.rs!</p>
+<!-- more -->
+
+<p>Something below the separator.</p>
+
+  </p>
+</div>
+
+      
+    </div>
+  </body>
+</html>

--- a/tests/target/excerpts/posts/post-7.html
+++ b/tests/target/excerpts/posts/post-7.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        
+          <title>Explicit excepts work even in liquid</title>
+        
+    </head>
+    <body>
+    <div>
+      
+        <div>
+  <h2>Explicit excepts work even in liquid</h2>
+  <p>
+    <h1>Custom excerpt separator</h1>
+
+<p>Welcome to the 7th post on cobalt.rs!</p>
+<!-- more -->
+
+<p>Something below the separator.</p>
+
+  </p>
+</div>
+
+      
+    </div>
+  </body>
+</html>

--- a/tests/target/hidden_posts_folder/index.html
+++ b/tests/target/hidden_posts_folder/index.html
@@ -6,8 +6,7 @@
     <body>
         <h1>index.html</h1>
 
-        
-This is my Index page!
+        This is my Index page!
 
 
  <a href="_blog/2014-08-24-my-first-blogpost.html">My first Blogpost</a>

--- a/tests/target/ignore_files/index.html
+++ b/tests/target/ignore_files/index.html
@@ -6,8 +6,7 @@
     <body>
         <h1>index.html</h1>
 
-        
-This is my Index page!
+        This is my Index page!
 
 
  <a href="posts/2014-08-24-my-first-blogpost.html">My first Blogpost</a>

--- a/tests/target/liquid_escaped/extends.html
+++ b/tests/target/liquid_escaped/extends.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>test</title>
+    </head>
+    <body>
+        <h1></h1>
+
+        
+{% invalidtag %}
+
+    </body>
+</html>
+

--- a/tests/target/liquid_escaped/extends.html
+++ b/tests/target/liquid_escaped/extends.html
@@ -6,8 +6,7 @@
     <body>
         <h1></h1>
 
-        
-{% invalidtag %}
+        {% invalidtag %}
 
     </body>
 </html>

--- a/tests/target/liquid_escaped/not-extends.html
+++ b/tests/target/liquid_escaped/not-extends.html
@@ -1,2 +1,1 @@
-
 {% invalidtag %}

--- a/tests/target/liquid_escaped/not-extends.html
+++ b/tests/target/liquid_escaped/not-extends.html
@@ -1,0 +1,2 @@
+
+{% invalidtag %}

--- a/tests/target/rss/index.html
+++ b/tests/target/rss/index.html
@@ -6,8 +6,7 @@
     <body>
         <h1>index.html</h1>
 
-        
-This is my Index page!
+        This is my Index page!
 
 
  <a href="posts/my-fifth-blogpost.html">My fifth Blogpost!</a>

--- a/tests/target/sort_posts/index.html
+++ b/tests/target/sort_posts/index.html
@@ -6,8 +6,7 @@
     <body>
         <h1>index.html</h1>
 
-        
-This is my Index page!
+        This is my Index page!
 
 
  <a href="posts/my-fourth-blogpost.html">My fourth Blogpost</a>


### PR DESCRIPTION
Note: the scope of this PR has changed.
- This PR adds Jekyll-like excerpts. Please see [Jekyll docs](https://jekyllrb.com/docs/posts/#post-excerpts) for details. The previous attempt to do it was #145 .
- Fixes content attribute added in #146 - this attribute shouldn't include extended layout, just the document.
- Changes the way we split attributes and content.
- Fixes bug with two sequential rendering when `extends` is not defined.
- Adds a layout cache (#120).

Method `as_html` was replaces with `render` which now has side-effects.
