### PR TITLE
RSS: use content as a default description, add guid

### DIFF
--- a/src/cobalt.rs
+++ b/src/cobalt.rs
@@ -122,11 +122,6 @@ pub fn build(config: &Config) -> Result<()> {
     // fall back to the default date
     posts.sort_by(|a, b| b.date.unwrap_or(default_date).cmp(&a.date.unwrap_or(default_date)));
 
-    // check if we should create an RSS file and create it!
-    if let &Some(ref path) = &config.rss {
-        try!(create_rss(path, dest, &config, &posts));
-    }
-
     // collect all posts attributes to pass them to other posts for rendering
     let simple_posts_data: Vec<Value> = posts.iter()
         .map(|x| Value::Object(x.attributes.clone()))
@@ -141,6 +136,11 @@ pub fn build(config: &Config) -> Result<()> {
         try!(post.render_excerpt(&mut context, &source, &config.excerpt_separator));
         let post_html = try!(post.render(&mut context, &source, &layouts, &mut layouts_cache));
         try!(create_document_file(&post_html, &post.path, dest));
+    }
+
+    // check if we should create an RSS file and create it!
+    if let &Some(ref path) = &config.rss {
+        try!(create_rss(path, dest, &config, &posts));
     }
 
     // during post rendering additional attributes such as content were

--- a/src/document.rs
+++ b/src/document.rs
@@ -222,6 +222,7 @@ impl Document {
     pub fn to_rss(&self, root_url: &str) -> rss::Item {
         let description = self.attributes
             .get("description")
+            .or(self.attributes.get("excerpt"))
             .or(self.attributes.get("content"))
             .and_then(|s| s.as_str())
             .map(|s| s.to_owned());

--- a/src/document.rs
+++ b/src/document.rs
@@ -220,15 +220,23 @@ impl Document {
 
     /// Metadata for generating RSS feeds
     pub fn to_rss(&self, root_url: &str) -> rss::Item {
-        let description = self.attributes.get("description")
+        let description = self.attributes
+            .get("description")
             .or(self.attributes.get("content"))
             .and_then(|s| s.as_str())
             .map(|s| s.to_owned());
 
+        // Swap back slashes to forward slashes to ensure the URL's are valid on Windows
+        let link = root_url.to_owned() + &self.path.replace("\\", "/");
+        let guid = rss::Guid {
+            value: link.clone(),
+            is_perma_link: true,
+        };
+
         rss::Item {
             title: self.attributes.get("title").and_then(|s| s.as_str()).map(|s| s.to_owned()),
-            // Swap back slashes to forward slashes to ensure the URL's are valid on Windows
-            link: Some(root_url.to_owned() + &self.path.replace("\\", "/")),
+            link: Some(link),
+            guid: Some(guid),
             pub_date: self.date.map(|date| date.to_rfc2822()),
             description: description,
             ..Default::default()

--- a/src/document.rs
+++ b/src/document.rs
@@ -220,15 +220,17 @@ impl Document {
 
     /// Metadata for generating RSS feeds
     pub fn to_rss(&self, root_url: &str) -> rss::Item {
+        let description = self.attributes.get("description")
+            .or(self.attributes.get("content"))
+            .and_then(|s| s.as_str())
+            .map(|s| s.to_owned());
+
         rss::Item {
             title: self.attributes.get("title").and_then(|s| s.as_str()).map(|s| s.to_owned()),
             // Swap back slashes to forward slashes to ensure the URL's are valid on Windows
             link: Some(root_url.to_owned() + &self.path.replace("\\", "/")),
             pub_date: self.date.map(|date| date.to_rfc2822()),
-            description: self.attributes
-                .get("description")
-                .and_then(|s| s.as_str())
-                .map(|s| s.to_owned()),
+            description: description,
             ..Default::default()
         }
     }

--- a/tests/target/rss/rss.xml
+++ b/tests/target/rss/rss.xml
@@ -1,13 +1,13 @@
 <?xml version='1.0' encoding='UTF-8'?><rss version='2.0'><channel><title>My blog!</title><link>http://example.com/</link><description>Blog description</description><item><title>My fifth Blogpost!</title><link>http://example.com/posts/my-fifth-blogpost.html</link><description>&lt;h1&gt;My fifth Blogpost!&lt;/h1&gt;
 &lt;p&gt;Hey there this is my first blogpost and this is super awesome.&lt;/p&gt;
 &lt;p&gt;My Blog is lorem ipsum like, yes it is..&lt;/p&gt;
-</description><pubDate>Tue, 16 Feb 2016 10:00:00 +0100</pubDate></item><item><title>My first Blogpost</title><link>http://example.com/posts/my-first-blogpost.html</link><description>It&apos;s my first blog post</description><pubDate>Fri,  1 Jan 2016 21:00:00 +0100</pubDate></item><item><title>My fourth Blogpost</title><link>http://example.com/posts/my-fourth-blogpost.html</link><description>&lt;h1&gt;My fourth Blogpost&lt;/h1&gt;
+</description><guid>http://example.com/posts/my-fifth-blogpost.html</guid><pubDate>Tue, 16 Feb 2016 10:00:00 +0100</pubDate></item><item><title>My first Blogpost</title><link>http://example.com/posts/my-first-blogpost.html</link><description>It&apos;s my first blog post</description><guid>http://example.com/posts/my-first-blogpost.html</guid><pubDate>Fri,  1 Jan 2016 21:00:00 +0100</pubDate></item><item><title>My fourth Blogpost</title><link>http://example.com/posts/my-fourth-blogpost.html</link><description>&lt;h1&gt;My fourth Blogpost&lt;/h1&gt;
 &lt;p&gt;Hey there this is my first blogpost and this is super awesome.&lt;/p&gt;
 &lt;p&gt;My Blog is lorem ipsum like, yes it is..&lt;/p&gt;
-</description><pubDate>Fri, 29 May 2015 23:00:00 +0100</pubDate></item><item><title>My third Blogpost</title><link>http://example.com/posts/my-third-blogpost.html</link><description>&lt;h1&gt;My third Blogpost&lt;/h1&gt;
+</description><guid>http://example.com/posts/my-fourth-blogpost.html</guid><pubDate>Fri, 29 May 2015 23:00:00 +0100</pubDate></item><item><title>My third Blogpost</title><link>http://example.com/posts/my-third-blogpost.html</link><description>&lt;h1&gt;My third Blogpost&lt;/h1&gt;
 &lt;p&gt;Hey there this is my first blogpost and this is super awesome.&lt;/p&gt;
 &lt;p&gt;My Blog is lorem ipsum like, yes it is..&lt;/p&gt;
-</description><pubDate>Wed, 27 May 2015 23:00:00 +0100</pubDate></item><item><title>My second Blogpost</title><link>http://example.com/posts/my-second-blogpost.html</link><description>&lt;h1&gt;My second Blogpost&lt;/h1&gt;
+</description><guid>http://example.com/posts/my-third-blogpost.html</guid><pubDate>Wed, 27 May 2015 23:00:00 +0100</pubDate></item><item><title>My second Blogpost</title><link>http://example.com/posts/my-second-blogpost.html</link><description>&lt;h1&gt;My second Blogpost&lt;/h1&gt;
 &lt;p&gt;Hey there this is my first blogpost and this is super awesome.&lt;/p&gt;
 &lt;p&gt;My Blog is lorem ipsum like, yes it is..&lt;/p&gt;
-</description><pubDate>Fri,  2 Jan 2015 10:00:00 +0100</pubDate></item></channel></rss>
+</description><guid>http://example.com/posts/my-second-blogpost.html</guid><pubDate>Fri,  2 Jan 2015 10:00:00 +0100</pubDate></item></channel></rss>

--- a/tests/target/rss/rss.xml
+++ b/tests/target/rss/rss.xml
@@ -1,1 +1,13 @@
-<?xml version='1.0' encoding='UTF-8'?><rss version='2.0'><channel><title>My blog!</title><link>http://example.com/</link><description>Blog description</description><item><title>My fifth Blogpost!</title><link>http://example.com/posts/my-fifth-blogpost.html</link><pubDate>Tue, 16 Feb 2016 10:00:00 +0100</pubDate></item><item><title>My first Blogpost</title><link>http://example.com/posts/my-first-blogpost.html</link><description>It&apos;s my first blog post</description><pubDate>Fri,  1 Jan 2016 21:00:00 +0100</pubDate></item><item><title>My fourth Blogpost</title><link>http://example.com/posts/my-fourth-blogpost.html</link><pubDate>Fri, 29 May 2015 23:00:00 +0100</pubDate></item><item><title>My third Blogpost</title><link>http://example.com/posts/my-third-blogpost.html</link><pubDate>Wed, 27 May 2015 23:00:00 +0100</pubDate></item><item><title>My second Blogpost</title><link>http://example.com/posts/my-second-blogpost.html</link><pubDate>Fri,  2 Jan 2015 10:00:00 +0100</pubDate></item></channel></rss>
+<?xml version='1.0' encoding='UTF-8'?><rss version='2.0'><channel><title>My blog!</title><link>http://example.com/</link><description>Blog description</description><item><title>My fifth Blogpost!</title><link>http://example.com/posts/my-fifth-blogpost.html</link><description>&lt;h1&gt;My fifth Blogpost!&lt;/h1&gt;
+&lt;p&gt;Hey there this is my first blogpost and this is super awesome.&lt;/p&gt;
+&lt;p&gt;My Blog is lorem ipsum like, yes it is..&lt;/p&gt;
+</description><pubDate>Tue, 16 Feb 2016 10:00:00 +0100</pubDate></item><item><title>My first Blogpost</title><link>http://example.com/posts/my-first-blogpost.html</link><description>It&apos;s my first blog post</description><pubDate>Fri,  1 Jan 2016 21:00:00 +0100</pubDate></item><item><title>My fourth Blogpost</title><link>http://example.com/posts/my-fourth-blogpost.html</link><description>&lt;h1&gt;My fourth Blogpost&lt;/h1&gt;
+&lt;p&gt;Hey there this is my first blogpost and this is super awesome.&lt;/p&gt;
+&lt;p&gt;My Blog is lorem ipsum like, yes it is..&lt;/p&gt;
+</description><pubDate>Fri, 29 May 2015 23:00:00 +0100</pubDate></item><item><title>My third Blogpost</title><link>http://example.com/posts/my-third-blogpost.html</link><description>&lt;h1&gt;My third Blogpost&lt;/h1&gt;
+&lt;p&gt;Hey there this is my first blogpost and this is super awesome.&lt;/p&gt;
+&lt;p&gt;My Blog is lorem ipsum like, yes it is..&lt;/p&gt;
+</description><pubDate>Wed, 27 May 2015 23:00:00 +0100</pubDate></item><item><title>My second Blogpost</title><link>http://example.com/posts/my-second-blogpost.html</link><description>&lt;h1&gt;My second Blogpost&lt;/h1&gt;
+&lt;p&gt;Hey there this is my first blogpost and this is super awesome.&lt;/p&gt;
+&lt;p&gt;My Blog is lorem ipsum like, yes it is..&lt;/p&gt;
+</description><pubDate>Fri,  2 Jan 2015 10:00:00 +0100</pubDate></item></channel></rss>

--- a/tests/target/rss/rss.xml
+++ b/tests/target/rss/rss.xml
@@ -1,13 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?><rss version='2.0'><channel><title>My blog!</title><link>http://example.com/</link><description>Blog description</description><item><title>My fifth Blogpost!</title><link>http://example.com/posts/my-fifth-blogpost.html</link><description>&lt;h1&gt;My fifth Blogpost!&lt;/h1&gt;
-&lt;p&gt;Hey there this is my first blogpost and this is super awesome.&lt;/p&gt;
-&lt;p&gt;My Blog is lorem ipsum like, yes it is..&lt;/p&gt;
 </description><guid>http://example.com/posts/my-fifth-blogpost.html</guid><pubDate>Tue, 16 Feb 2016 10:00:00 +0100</pubDate></item><item><title>My first Blogpost</title><link>http://example.com/posts/my-first-blogpost.html</link><description>It&apos;s my first blog post</description><guid>http://example.com/posts/my-first-blogpost.html</guid><pubDate>Fri,  1 Jan 2016 21:00:00 +0100</pubDate></item><item><title>My fourth Blogpost</title><link>http://example.com/posts/my-fourth-blogpost.html</link><description>&lt;h1&gt;My fourth Blogpost&lt;/h1&gt;
-&lt;p&gt;Hey there this is my first blogpost and this is super awesome.&lt;/p&gt;
-&lt;p&gt;My Blog is lorem ipsum like, yes it is..&lt;/p&gt;
 </description><guid>http://example.com/posts/my-fourth-blogpost.html</guid><pubDate>Fri, 29 May 2015 23:00:00 +0100</pubDate></item><item><title>My third Blogpost</title><link>http://example.com/posts/my-third-blogpost.html</link><description>&lt;h1&gt;My third Blogpost&lt;/h1&gt;
-&lt;p&gt;Hey there this is my first blogpost and this is super awesome.&lt;/p&gt;
-&lt;p&gt;My Blog is lorem ipsum like, yes it is..&lt;/p&gt;
 </description><guid>http://example.com/posts/my-third-blogpost.html</guid><pubDate>Wed, 27 May 2015 23:00:00 +0100</pubDate></item><item><title>My second Blogpost</title><link>http://example.com/posts/my-second-blogpost.html</link><description>&lt;h1&gt;My second Blogpost&lt;/h1&gt;
-&lt;p&gt;Hey there this is my first blogpost and this is super awesome.&lt;/p&gt;
-&lt;p&gt;My Blog is lorem ipsum like, yes it is..&lt;/p&gt;
 </description><guid>http://example.com/posts/my-second-blogpost.html</guid><pubDate>Fri,  2 Jan 2015 10:00:00 +0100</pubDate></item></channel></rss>


### PR DESCRIPTION
This PR:
- uses excerpt or content as a default value for description in rss
- adds guid tag to rss feed (as suggested by [validator.w3.org](https://validator.w3.org/feed/docs/warning/MissingGuid.html))
