### PR TITLE
adding clean command

### DIFF
--- a/src/cobalt.rs
+++ b/src/cobalt.rs
@@ -42,13 +42,6 @@ pub fn build(config: &Config) -> Result<()> {
     let dest = PathBuf::from(&config.dest).join("");
     let dest = dest.as_path();
 
-    // try to create the supplied dest dir if it currently does not exist
-    if dest.is_dir() == false {
-        try!(fs::create_dir(dest));
-        info!("Created dest dir: {:?}", dest);
-    }
-
-
     let template_extensions: Vec<&OsStr> = config.template_extensions
         .iter()
         .map(OsStr::new)

--- a/src/cobalt.rs
+++ b/src/cobalt.rs
@@ -42,6 +42,13 @@ pub fn build(config: &Config) -> Result<()> {
     let dest = PathBuf::from(&config.dest).join("");
     let dest = dest.as_path();
 
+    // try to create the supplied dest dir if it currently does not exist
+    if dest.is_dir() == false {
+        try!(fs::create_dir(dest));
+        info!("Created dest dir: {:?}", dest);
+    }
+
+
     let template_extensions: Vec<&OsStr> = config.template_extensions
         .iter()
         .map(OsStr::new)

--- a/src/main.rs
+++ b/src/main.rs
@@ -122,8 +122,7 @@ fn main() {
                 .help("Commit message that will be used on import")
                 .default_value("cobalt site import")
                 .takes_value(true)))
-        .subcommand(SubCommand::with_name("clean")
-            .about("cleans directory set as destination"))
+        .subcommand(SubCommand::with_name("clean").about("cleans directory set as destination"))
         .subcommand(SubCommand::with_name("serve")
             .about("build and serve the cobalt project at the source dir")
             .arg(Arg::with_name("port")
@@ -262,8 +261,8 @@ fn main() {
 
         "clean" => {
             match fs::remove_dir_all(&config.dest) {
-              Ok(..) => println!("directory \"{}\" removed", &config.dest),
-              Err(err) => println!("Error: {}", err)
+                Ok(..) => info!("directory \"{}\" removed", &config.dest),
+                Err(err) => error!("Error: {}", err),
             }
         }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -122,6 +122,8 @@ fn main() {
                 .help("Commit message that will be used on import")
                 .default_value("cobalt site import")
                 .takes_value(true)))
+        .subcommand(SubCommand::with_name("clean")
+            .about("cleans directory set as destination"))
         .subcommand(SubCommand::with_name("serve")
             .about("build and serve the cobalt project at the source dir")
             .arg(Arg::with_name("port")
@@ -255,6 +257,13 @@ fn main() {
                 let branch = matches.value_of("branch").unwrap().to_string();
                 let message = matches.value_of("message").unwrap().to_string();
                 import(&config, &branch, &message);
+            }
+        }
+
+        "clean" => {
+            match fs::remove_dir_all(&config.dest) {
+              Ok(..) => println!("directory \"{}\" removed", &config.dest),
+              Err(err) => println!("Error: {}", err)
             }
         }
 

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -65,3 +65,12 @@ pub fn log_levels() {
     assert_cli!(&BIN, &["build", "--silent"] => Success, "").unwrap();
 }
 
+#[test]
+pub fn clean() {
+    env::set_current_dir(CWD.join("tests/fixtures/example")).unwrap();
+    assert_cli!(&BIN, &["build", "-d", "./test_dest"] => Success).unwrap();
+    assert_eq!(Path::new("./test_dest/").is_dir(), true);
+
+    assert_cli!(&BIN, &["clean", "-d", "./test_dest"] => Success).unwrap();
+    assert_eq!(Path::new("./test_dest").is_dir(), false);
+}

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -71,6 +71,7 @@ pub fn clean() {
     assert_cli!(&BIN, &["build", "-d", "./test_dest"] => Success).unwrap();
     assert_eq!(Path::new("./test_dest/").is_dir(), true);
 
-    assert_cli!(&BIN, &["clean", "-d", "./test_dest"] => Success).unwrap();
+    let output = assert_cli!(&BIN, &["clean", "-d", "./test_dest"] => Success).unwrap();
     assert_eq!(Path::new("./test_dest").is_dir(), false);
+    assert_contains!(&output.stderr, "directory \"./test_dest\" removed"); 
 }


### PR DESCRIPTION
fixes #102 

If there is a cleaner way to do this, please let me know.
I kept getting `expected (), found enum 'std::result::Result\'` but writing it this way worked.

I did not add a test for this just yet but trying to figure that out.