### PR TITLE
ErrorKind error instead of String

### DIFF
--- a/src/cobalt.rs
+++ b/src/cobalt.rs
@@ -6,7 +6,7 @@ use std::ffi::OsStr;
 use liquid::Value;
 use walkdir::{WalkDir, DirEntry, WalkDirIterator};
 use document::Document;
-use error::{Error, Result};
+use error::{ErrorKind, Result};
 use config::Config;
 use chrono::{UTC, FixedOffset};
 use chrono::offset::TimeZone;
@@ -232,10 +232,7 @@ fn create_rss(path: &str, dest: &Path, config: &Config, posts: &[Document]) -> R
             info!("Created RSS file at {}", rss_path.display());
             Ok(())
         }
-        _ => {
-            Err(Error::from("name, description and link need to be defined in the config file to \
-                             generate RSS"))
-        }
+        _ => Err(ErrorKind::ConfigFileMissingFields.into()),
     }
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -16,5 +16,10 @@ error_chain! {
     }
 
     errors {
+        ConfigFileMissingFields {
+            description("missing fields in config file")
+            display("name, description and link need to be defined in the config file to \
+                    generate RSS")
+        }
     }
 }

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -131,8 +131,12 @@ pub fn custom_template_extensions() {
 pub fn incomplete_rss() {
     let err = run_test("incomplete_rss");
     assert!(err.is_err());
-    assert_eq!(err.unwrap_err().description(),
+
+    let err = err.unwrap_err();
+    assert_eq!(format!("{}",err),
                "name, description and link need to be defined in the config file to generate RSS");
+    assert_eq!(err.description(),
+               "missing fields in config file");
 }
 
 #[test]


### PR DESCRIPTION
Depends on #156.

Replaces the error generated on incomplete RSS configs with an `ErrorKind` instead of a `String`.
