### PR TITLE
gitignore for vim

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@
 
 .DS_Store
 *.rs.bk
+
+.*.swp
+


### PR DESCRIPTION
Ignores vim's `.<filename>.swp` files.