### PR TITLE
extensive usage of Result in main

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8,7 +8,7 @@ dependencies = [
  "clippy 0.0.98 (registry+https://github.com/rust-lang/crates.io-index)",
  "difference 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "error-chain 0.5.0 (git+https://github.com/brson/error-chain.git)",
+ "error-chain 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ghp 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.9.12 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -59,7 +59,7 @@ dependencies = [
 
 [[package]]
 name = "backtrace"
-version = "0.2.3"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "backtrace-sys 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -188,10 +188,10 @@ dependencies = [
 
 [[package]]
 name = "error-chain"
-version = "0.5.0"
-source = "git+https://github.com/brson/error-chain.git#2374ed1212bb961e76d28cb1948c9631917529b3"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "backtrace 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "backtrace 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -743,7 +743,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum ansi_term 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ae206c860259479b73b3abc98b66da811843056ed570ed79eb95d3d9b2524325"
 "checksum ansi_term 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "23ac7c30002a5accbf7e8987d0632fa6de155b7c3d39d0067317a391e00a2ef6"
 "checksum assert_cli 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "240645c6effe2439d5b08204b1999afddd0c003b851b12cc378c115737cc3f38"
-"checksum backtrace 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "346d7644f0b5f9bc73082d3b2236b69a05fd35cce0cfa3724e184e6a5c9e2a2f"
+"checksum backtrace 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f551bc2ddd53aea015d453ef0b635af89444afa5ed2405dd0b2062ad5d600d80"
 "checksum backtrace-sys 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "3602e8d8c43336088a8505fa55cae2b3884a9be29440863a11528a42f46f6bb7"
 "checksum bitflags 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8dead7461c1127cf637931a1e50934eb6eee8bff2f74433ac7909e9afcee04a3"
 "checksum bitflags 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4f67931368edf3a9a51d29886d245f1c3db2f1ef0dcc9e35ff70341b78c10d23"
@@ -758,7 +758,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum dbghelp-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "97590ba53bcb8ac28279161ca943a924d1fd4a8fb3fa63302591647c4fc5b850"
 "checksum difference 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ffef4c144e881a906ed5bd6e1e749dc1955cd3f0c7969d3d34122a971981c5ea"
 "checksum env_logger 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "15abd780e45b3ea4f76b4e9a26ff4843258dd8a3eed2775a0e7368c2e7936c2f"
-"checksum error-chain 0.5.0 (git+https://github.com/brson/error-chain.git)" = "<none>"
+"checksum error-chain 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "be9cb54f0b3504d22ff42c1fbed938ebe55e14dd3707768c65b07fde7198b389"
 "checksum filetime 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "5363ab8e4139b8568a6237db5248646e5a8a2f89bd5ccb02092182b11fd3e922"
 "checksum fsevent 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)" = "740a52ca589381d87dd0d9960555de3320aa6d408326659e3bae88be9f71a125"
 "checksum fsevent-sys 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "72e33a926306442d961595c3a325864326ca4287795e106dae8993afe484ede6"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8,7 +8,7 @@ dependencies = [
  "clippy 0.0.98 (registry+https://github.com/rust-lang/crates.io-index)",
  "difference 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "error-chain 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "error-chain 0.5.0 (git+https://github.com/brson/error-chain.git)",
  "ghp 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.9.12 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -189,7 +189,7 @@ dependencies = [
 [[package]]
 name = "error-chain"
 version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+source = "git+https://github.com/brson/error-chain.git#2374ed1212bb961e76d28cb1948c9631917529b3"
 dependencies = [
  "backtrace 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -758,7 +758,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum dbghelp-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "97590ba53bcb8ac28279161ca943a924d1fd4a8fb3fa63302591647c4fc5b850"
 "checksum difference 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ffef4c144e881a906ed5bd6e1e749dc1955cd3f0c7969d3d34122a971981c5ea"
 "checksum env_logger 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "15abd780e45b3ea4f76b4e9a26ff4843258dd8a3eed2775a0e7368c2e7936c2f"
-"checksum error-chain 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bd5c82c815138e278b8dcdeffc49f27ea6ffb528403e9dea4194f2e3dd40b143"
+"checksum error-chain 0.5.0 (git+https://github.com/brson/error-chain.git)" = "<none>"
 "checksum filetime 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "5363ab8e4139b8568a6237db5248646e5a8a2f89bd5ccb02092182b11fd3e922"
 "checksum fsevent 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)" = "740a52ca589381d87dd0d9960555de3320aa6d408326659e3bae88be9f71a125"
 "checksum fsevent-sys 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "72e33a926306442d961595c3a325864326ca4287795e106dae8993afe484ede6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,11 +31,13 @@ ghp = "0.1"
 glob = "0.2.11"
 regex = "0.1"
 clippy = {version = "0.0", optional = true}
-error-chain = "0.5.0"
 
 [dependencies.hyper]
 version = "0.9"
 default-features = false
+
+[dependencies.error-chain]
+git = "https://github.com/brson/error-chain.git"
 
 [dev-dependencies]
 assert_cli = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,13 +31,11 @@ ghp = "0.1"
 glob = "0.2.11"
 regex = "0.1"
 clippy = {version = "0.0", optional = true}
+error-chain = "~0.6.0"
 
 [dependencies.hyper]
 version = "0.9"
 default-features = false
-
-[dependencies.error-chain]
-git = "https://github.com/brson/error-chain.git"
 
 [dev-dependencies]
 assert_cli = "0.3"

--- a/src/cobalt.rs
+++ b/src/cobalt.rs
@@ -1,3 +1,5 @@
+pub use error::*;
+
 use std::fs::{self, File};
 use std::collections::HashMap;
 use std::io::Write;
@@ -6,7 +8,6 @@ use std::ffi::OsStr;
 use liquid::Value;
 use walkdir::{WalkDir, DirEntry, WalkDirIterator};
 use document::Document;
-use error::{ErrorKind, Result};
 use config::Config;
 use chrono::{UTC, FixedOffset};
 use chrono::offset::TimeZone;

--- a/src/error.rs
+++ b/src/error.rs
@@ -5,6 +5,10 @@ use liquid;
 
 error_chain! {
 
+    types {
+        Error, ErrorKind, Result;
+    }
+
     links {
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -44,6 +44,7 @@ error_chain! {
     }
 
     foreign_links {
+        // FIXME: shouldn't the first one be under "links"?
         ::cobalt::error::Error, Lib;
         std::io::Error, Io;
         notify::Error, Notify;

--- a/src/main.rs
+++ b/src/main.rs
@@ -62,8 +62,7 @@ error_chain! {
 }
 
 #[derive(Debug,Clone,Copy)]
-enum Command
-{
+enum Command {
     New,
     Build,
     Clean,
@@ -282,23 +281,23 @@ fn main() {
     // dependencies of commands
     let chain = match command {
         "new" => vec![New],
-        "build" => if matches.is_present("import") {
-            vec![Build,Import]
+        "build" => {
+            if matches.is_present("import") {
+                vec![Build, Import]
+            } else {
+                vec![Build]
+            }
         }
-        else {
-            vec![Build]
-        },
         "clean" => vec![Clean],
-        "serve" => vec![Build,Serve],
-        "watch" => vec![Build,Watch],
+        "serve" => vec![Build, Serve],
+        "watch" => vec![Build, Watch],
         _ => {
             println!("{}", global_matches.usage());
             vec![]
         }
     };
 
-    for result in chain.iter().map(|&cmd|exec(cmd,&config,&matches))
-    {
+    for result in chain.iter().map(|&cmd| exec(cmd, &config, &matches)) {
         if let Err(err) = result {
             error!("Error: {}", err);
             std::process::exit(1);
@@ -306,10 +305,9 @@ fn main() {
     }
 }
 
-fn exec(command: Command, config: &Config, matches: &ArgMatches) -> Result<()>
-{
+fn exec(command: Command, config: &Config, matches: &ArgMatches) -> Result<()> {
     use Command::*;
-    info!("Executing {:?}",command);
+    info!("Executing {:?}", command);
     match command {
         New => {
             let directory = matches.value_of("DIRECTORY").unwrap();
@@ -317,9 +315,7 @@ fn exec(command: Command, config: &Config, matches: &ArgMatches) -> Result<()>
             Ok(try!(create_new_project(&directory.to_string())))
         }
 
-        Build => {
-            Ok(try!(build(&config)))
-        }
+        Build => Ok(try!(build(&config))),
 
         Clean => {
             try!(fs::remove_dir_all(&config.dest));
@@ -368,12 +364,11 @@ fn exec(command: Command, config: &Config, matches: &ArgMatches) -> Result<()>
                     let rel_path = abs_path.strip_prefix(&cwd).unwrap_or(&path);
 
                     // check whether this path has been marked as ignored in config
-                    let rel_path_matches =
-                        |pattern| Pattern::matches_path(pattern, rel_path);
+                    let rel_path_matches = |pattern| Pattern::matches_path(pattern, rel_path);
                     let path_ignored = &config.ignore.iter().any(rel_path_matches);
 
                     if !path_ignored {
-                        try!(exec(Build,&config,&matches));
+                        try!(exec(Build, &config, &matches));
                     }
                 }
             }


### PR DESCRIPTION
I pretty much just stuck *error-chain* into `main()`. The tests still pass (I guess you didn't really write a lot of tests for this) and the actual error handling is more central.

I still feel like someone should go over the code and add some [`chain_err`s](https://brson.github.io/error-chain/error_chain/index.html#chaining-errors) all over the place but that's up to you.

I also did not really test the current output, it probably doesn't show a lot of useful information as long as there is no `chain_err`.

I also added a mechanism to declare dependencies (e.g. serve needs build) which then even further centralises error handling.


Please do me a favour and let someone thoroughly review those changes.
