### PR TITLE
Add next and previous posts to liquid context

### DIFF
--- a/src/document.rs
+++ b/src/document.rs
@@ -4,7 +4,7 @@ use std::collections::hash_map::Entry;
 use std::ffi::OsStr;
 use std::path::{Path, PathBuf};
 use std::default::Default;
-use error::Result;
+use error::{Error, ErrorKind, Result};
 use chrono::{DateTime, FixedOffset, Datelike, Timelike};
 use yaml_rust::{Yaml, YamlLoader};
 use std::io::Read;
@@ -329,24 +329,29 @@ impl Document {
         Ok(())
     }
 
-    /// Renders the document to an HTML string.
-    ///
-    /// Side effects:
-    ///
-    /// * content is inserted to the attributes of the document
-    /// * content is inserted to context
-    /// * layout may be inserted to layouts cache
+    /// Renders content and adds it to the attributes of the document and to the context.
     ///
     /// When we say "content" we mean only this document without extended layout.
+    pub fn render_content(&mut self, context: &mut Context, source: &Path) -> Result<()> {
+        let content_html = try!(self.render_html(&self.content, context, source));
+        self.attributes.insert("content".to_owned(), Value::Str(content_html.clone()));
+        context.set_val("content", Value::Str(content_html.to_owned()));
+        Ok(())
+    }
+
+    /// Renders the document to an HTML string.
+    ///
+    /// Layout may be inserted to layouts cache as a side effect.
     pub fn render(&mut self,
                   context: &mut Context,
                   source: &Path,
                   layouts_dir: &Path,
                   layouts_cache: &mut HashMap<String, String>)
                   -> Result<String> {
-        let content_html = try!(self.render_html(&self.content, context, source));
-        self.attributes.insert("content".to_owned(), Value::Str(content_html.clone()));
-        context.set_val("content", Value::Str(content_html.clone()));
+        let content_html = try!(self.attributes
+            .get("content")
+            .and_then(|d| d.as_str())
+            .ok_or(Error::from(ErrorKind::NoContent)));
 
         if let Some(ref layout) = self.layout {
             let layout_data_ref = match layouts_cache.entry(layout.to_owned()) {
@@ -367,7 +372,7 @@ impl Document {
             let template = try!(liquid::parse(layout_data_ref, options));
             Ok(try!(template.render(context)).unwrap_or(String::new()))
         } else {
-            Ok(content_html)
+            Ok(content_html.to_owned())
         }
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -21,5 +21,9 @@ error_chain! {
             display("name, description and link need to be defined in the config file to \
                     generate RSS")
         }
+        NoContent {
+            description("content attribute is missing")
+            display("content attribute should have been rendered by now")
+        }
     }
 }

--- a/tests/fixtures/previous_next/.cobalt.yml
+++ b/tests/fixtures/previous_next/.cobalt.yml
@@ -1,0 +1,6 @@
+name: cobalt blog
+source: "."
+dest: "build"
+ignore:
+  - .git/*
+  - build/*

--- a/tests/fixtures/previous_next/_layouts/default.liquid
+++ b/tests/fixtures/previous_next/_layouts/default.liquid
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        {% if is_post %}
+          <title>{{ title }}</title>
+        {% else %}
+       	  <title>Cobalt.rs Blog</title>
+        {% endif %}
+    </head>
+    <body>
+    <div>
+      {% if is_post %}
+        {% include '_layouts/post.liquid' %}
+      {% else %}
+        {{ content }}
+      {% endif %}
+    </div>
+  </body>
+</html>

--- a/tests/fixtures/previous_next/_layouts/post.liquid
+++ b/tests/fixtures/previous_next/_layouts/post.liquid
@@ -1,0 +1,15 @@
+<div>
+  <h2>{{ title }}</h2>
+  <p>
+    {{content}}
+  </p>
+</div>
+
+<div>
+  {% if previous.path %}
+    <a class="prev" href="{{previous.path}}">&laquo; {{previous.title}}</a>
+  {% endif %}
+  {% if next.path %}
+    <a class="next" href="{{next.path}}">{{next.title}} &raquo;</a>
+  {% endif %}
+</div>

--- a/tests/fixtures/previous_next/index.liquid
+++ b/tests/fixtures/previous_next/index.liquid
@@ -1,0 +1,14 @@
+extends: default.liquid
+---
+<div >
+  <h2>Blog!</h2>
+  <!--<br />-->
+  <div>
+    {% for post in posts %}
+      <div>
+        <h4>{{post.title}}</h4>
+        <h4><a href="{{post.path}}">{{ post.title }}</a></h4>
+      </div>
+    {% endfor %}
+  </div>
+</div>

--- a/tests/fixtures/previous_next/posts/post-1.md
+++ b/tests/fixtures/previous_next/posts/post-1.md
@@ -1,0 +1,9 @@
+extends: default.liquid
+
+title: First Post
+date: 14 January 2016 21:00:30 -0500
+---
+
+# This is our first Post!
+
+Welcome to the first post ever on cobalt.rs!

--- a/tests/fixtures/previous_next/posts/post-2.md
+++ b/tests/fixtures/previous_next/posts/post-2.md
@@ -1,0 +1,9 @@
+extends: default.liquid
+
+title: Second Post
+date: 15 January 2016 21:00:30 -0500
+---
+
+# This is our second Post!
+
+Welcome to the second post on cobalt.rs!

--- a/tests/fixtures/previous_next/posts/post-3.md
+++ b/tests/fixtures/previous_next/posts/post-3.md
@@ -1,0 +1,9 @@
+extends: default.liquid
+
+title: Third Post
+date: 16 January 2016 21:00:30 -0500
+---
+
+# This is our third Post!
+
+Welcome to the third post on cobalt.rs!

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -195,3 +195,8 @@ pub fn yaml_error() {
 pub fn excerpts() {
     run_test("excerpts").unwrap();
 }
+
+#[test]
+pub fn previous_next() {
+    run_test("previous_next").unwrap();
+}

--- a/tests/target/previous_next/index.html
+++ b/tests/target/previous_next/index.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        
+       	  <title>Cobalt.rs Blog</title>
+        
+    </head>
+    <body>
+    <div>
+      
+        <div >
+  <h2>Blog!</h2>
+  <!--<br />-->
+  <div>
+    
+      <div>
+        <h4>Third Post</h4>
+        <h4><a href="posts/post-3.html">Third Post</a></h4>
+      </div>
+    
+      <div>
+        <h4>Second Post</h4>
+        <h4><a href="posts/post-2.html">Second Post</a></h4>
+      </div>
+    
+      <div>
+        <h4>First Post</h4>
+        <h4><a href="posts/post-1.html">First Post</a></h4>
+      </div>
+    
+  </div>
+</div>
+
+      
+    </div>
+  </body>
+</html>

--- a/tests/target/previous_next/posts/post-1.html
+++ b/tests/target/previous_next/posts/post-1.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        
+          <title>First Post</title>
+        
+    </head>
+    <body>
+    <div>
+      
+        <div>
+  <h2>First Post</h2>
+  <p>
+    <h1>This is our first Post!</h1>
+<p>Welcome to the first post ever on cobalt.rs!</p>
+
+  </p>
+</div>
+
+<div>
+  
+  
+    <a class="next" href="posts/post-2.html">Second Post &raquo;</a>
+  
+</div>
+
+      
+    </div>
+  </body>
+</html>

--- a/tests/target/previous_next/posts/post-2.html
+++ b/tests/target/previous_next/posts/post-2.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        
+          <title>Second Post</title>
+        
+    </head>
+    <body>
+    <div>
+      
+        <div>
+  <h2>Second Post</h2>
+  <p>
+    <h1>This is our second Post!</h1>
+<p>Welcome to the second post on cobalt.rs!</p>
+
+  </p>
+</div>
+
+<div>
+  
+    <a class="prev" href="posts/post-1.html">&laquo; First Post</a>
+  
+  
+    <a class="next" href="posts/post-3.html">Third Post &raquo;</a>
+  
+</div>
+
+      
+    </div>
+  </body>
+</html>

--- a/tests/target/previous_next/posts/post-3.html
+++ b/tests/target/previous_next/posts/post-3.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        
+          <title>Third Post</title>
+        
+    </head>
+    <body>
+    <div>
+      
+        <div>
+  <h2>Third Post</h2>
+  <p>
+    <h1>This is our third Post!</h1>
+<p>Welcome to the third post on cobalt.rs!</p>
+
+  </p>
+</div>
+
+<div>
+  
+    <a class="prev" href="posts/post-2.html">&laquo; Second Post</a>
+  
+  
+</div>
+
+      
+    </div>
+  </body>
+</html>


### PR DESCRIPTION
Fixes #139

The idea how to use this feature in Jekyll has been described in [this blog post by David Elbe](http://david.elbe.me/jekyll/2015/06/20/how-to-link-to-next-and-previous-post-with-jekyll.html).

Same in cobalt:
```
<div>
  {% if previous.path %}
    <a class="prev" href="{{previous.path}}">&laquo; {{previous.title}}</a>
  {% endif %}
  {% if next.path %}
    <a class="next" href="{{next.path}}">{{next.title}} &raquo;</a>
  {% endif %}
</div>
```