### PR TITLE
Adding syntax highlighting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,6 +19,7 @@ dependencies = [
  "pulldown-cmark 0.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 0.1.80 (registry+https://github.com/rust-lang/crates.io-index)",
  "rss 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syntect 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempdir 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "walkdir 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "yaml-rust 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -81,6 +82,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "bincode"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "byteorder 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-serialize 0.3.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 0.8.18 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "bitflags"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -93,6 +105,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "bitflags"
 version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "byteorder"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -152,6 +169,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "cmake"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "gcc 0.3.38 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "cookie"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -201,6 +226,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.2.17 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "flate2"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "miniz-sys 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "fnv"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "fsevent"
@@ -357,6 +396,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "miniz-sys"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "gcc 0.3.38 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.17 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "mio"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -469,6 +517,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "onig"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "onig_sys 61.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "onig_sys"
+version = "61.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cmake 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pkg-config 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "pkg-config"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "plist"
+version = "0.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "byteorder 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "chrono 0.2.25 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-serialize 0.3.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 0.7.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "xml-rs 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "pulldown-cmark"
 version = "0.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -555,6 +641,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "serde"
+version = "0.8.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "skeptic"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -590,6 +686,24 @@ dependencies = [
 name = "strsim"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "syntect"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bincode 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "flate2 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fnv 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "onig 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "plist 0.0.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex-syntax 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-serialize 0.3.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "walkdir 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "yaml-rust 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "tempdir"
@@ -733,6 +847,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "xml-rs"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bitflags 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "yaml-rust"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -745,21 +867,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum assert_cli 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "240645c6effe2439d5b08204b1999afddd0c003b851b12cc378c115737cc3f38"
 "checksum backtrace 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "346d7644f0b5f9bc73082d3b2236b69a05fd35cce0cfa3724e184e6a5c9e2a2f"
 "checksum backtrace-sys 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "3602e8d8c43336088a8505fa55cae2b3884a9be29440863a11528a42f46f6bb7"
+"checksum bincode 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9fbba641f73d3e74a5431d4a6d9e42a70bcce76d466d796c852ba1db31ba41bc"
 "checksum bitflags 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8dead7461c1127cf637931a1e50934eb6eee8bff2f74433ac7909e9afcee04a3"
 "checksum bitflags 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4f67931368edf3a9a51d29886d245f1c3db2f1ef0dcc9e35ff70341b78c10d23"
 "checksum bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "aad18937a628ec6abcd26d1489012cc0e18c21798210f491af69ded9b881106d"
+"checksum byteorder 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "0fc10e8cc6b2580fda3f36eb6dc5316657f812a3df879a44a66fc9f0fdbc4855"
 "checksum bytes 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c129aff112dcc562970abb69e2508b40850dd24c274761bb50fb8a0067ba6c27"
 "checksum cfg-if 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "de1e760d7b6535af4241fca8bd8adf68e2e7edacc6b29f5d399050c5e48cf88c"
 "checksum chrono 0.2.25 (registry+https://github.com/rust-lang/crates.io-index)" = "9213f7cd7c27e95c2b57c49f0e69b1ea65b27138da84a170133fd21b07659c00"
 "checksum clap 2.18.0 (registry+https://github.com/rust-lang/crates.io-index)" = "40046b8a004bf3ba43b9078bf4b9b6d1708406a234848f925dbd7160a374c8a8"
 "checksum clippy 0.0.98 (registry+https://github.com/rust-lang/crates.io-index)" = "6d51fa3f39b300c58906f8e103bc4c5ee5651f89fbbc46ea1423e2651461b0e7"
 "checksum clippy_lints 0.0.98 (registry+https://github.com/rust-lang/crates.io-index)" = "4329699b62341fd3ce3ebe13ade6c87d35b8778091e0c2f6da51399e081b9671"
+"checksum cmake 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)" = "0e5bcf27e097a184c1df4437654ed98df3d7a516e8508a6ba45d8b092bbdf283"
 "checksum cookie 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "0e3d6405328b6edb412158b3b7710e2634e23f3614b9bb1c412df7952489a626"
 "checksum dbghelp-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "97590ba53bcb8ac28279161ca943a924d1fd4a8fb3fa63302591647c4fc5b850"
 "checksum difference 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ffef4c144e881a906ed5bd6e1e749dc1955cd3f0c7969d3d34122a971981c5ea"
 "checksum env_logger 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "15abd780e45b3ea4f76b4e9a26ff4843258dd8a3eed2775a0e7368c2e7936c2f"
 "checksum error-chain 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bd5c82c815138e278b8dcdeffc49f27ea6ffb528403e9dea4194f2e3dd40b143"
 "checksum filetime 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "5363ab8e4139b8568a6237db5248646e5a8a2f89bd5ccb02092182b11fd3e922"
+"checksum flate2 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)" = "3eeb481e957304178d2e782f2da1257f1434dfecbae883bafb61ada2a9fea3bb"
+"checksum fnv 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "6cc484842f1e2884faf56f529f960cc12ad8c71ce96cc7abba0a067c98fee344"
 "checksum fsevent 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)" = "740a52ca589381d87dd0d9960555de3320aa6d408326659e3bae88be9f71a125"
 "checksum fsevent-sys 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "72e33a926306442d961595c3a325864326ca4287795e106dae8993afe484ede6"
 "checksum gcc 0.3.38 (registry+https://github.com/rust-lang/crates.io-index)" = "553f11439bdefe755bf366b264820f1da70f3aaf3924e594b886beb9c831bcf5"
@@ -780,6 +907,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum matches 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "efd7622e3022e1a6eaa602c4cea8912254e5582c9c692e9167714182244801b1"
 "checksum memchr 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)" = "d8b629fb514376c675b98c1421e80b151d3817ac42d7c667717d282761418d20"
 "checksum mime 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "b5c93a4bd787ddc6e7833c519b73a50883deb5863d76d9b71eb8216fb7f94e66"
+"checksum miniz-sys 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "9d1f4d337a01c32e1f2122510fed46393d53ca35a7f429cb0450abaedfa3ed54"
 "checksum mio 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a637d1ca14eacae06296a008fa7ad955347e34efcb5891cfd8ba05491a37907e"
 "checksum miow 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "d5bfc6782530ac8ace97af10a540054a37126b63b0702ddaaa243b73b5745b9a"
 "checksum net2 0.2.26 (registry+https://github.com/rust-lang/crates.io-index)" = "5edf9cb6be97212423aed9413dd4729d62b370b5e1c571750e882cebbbc1e3e2"
@@ -791,6 +919,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum num-iter 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)" = "287a1c9969a847055e1122ec0ea7a5c5d6f72aad97934e131c83d5c08ab4e45c"
 "checksum num-traits 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)" = "a16a42856a256b39c6d3484f097f6713e14feacd9bfb02290917904fae46c81c"
 "checksum num_cpus 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8890e6084723d57d0df8d2720b0d60c6ee67d6c93e7169630e4371e88765dcad"
+"checksum onig 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9c9d96ce5ce6addc4ea6cf4ca7b1a38ced8de5a3ed56a20a018c92c423e72e02"
+"checksum onig_sys 61.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a35f2cca300f0945538564da6052a449db55e65870cf0e9d443c1bce3d5dda47"
+"checksum pkg-config 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)" = "8cee804ecc7eaf201a4a207241472cc870e825206f6c031e3ee2a72fa425f2fa"
+"checksum plist 0.0.14 (registry+https://github.com/rust-lang/crates.io-index)" = "29f7f7deddf1244a97e2771e47edb01e5b5603d133bd4a0e516ea0e6817adc64"
 "checksum pulldown-cmark 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "8361e81576d2e02643b04950e487ec172b687180da65c731c03cf336784e6c07"
 "checksum pulldown-cmark 0.0.8 (registry+https://github.com/rust-lang/crates.io-index)" = "1058d7bb927ca067656537eec4e02c2b4b70eaaa129664c5b90c111e20326f41"
 "checksum quine-mc_cluskey 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "07589615d719a60c8dd8a4622e7946465dfef20d1a428f969e3443e7386d5f45"
@@ -803,11 +935,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum rustc_version 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "c5f5376ea5e30ce23c03eb77cbe4962b988deead10910c372b226388b594c084"
 "checksum semver 0.1.20 (registry+https://github.com/rust-lang/crates.io-index)" = "d4f410fedcf71af0345d7607d246e7ad15faaadd49d240ee3b24e5dc21a820ac"
 "checksum semver 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2d5b7638a1f03815d94e88cb3b3c08e87f0db4d683ef499d1836aaf70a45623f"
+"checksum serde 0.7.15 (registry+https://github.com/rust-lang/crates.io-index)" = "1b0e0732aa8ec4267f61815a396a942ba3525062e3bd5520aa8419927cfc0a92"
+"checksum serde 0.8.18 (registry+https://github.com/rust-lang/crates.io-index)" = "d9b524a2fac246f45c36a7f3a5742c19dcb0b2d1252d1ad5458ca07f26e04a57"
 "checksum skeptic 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "061203a849117b0f7090baf8157aa91dac30545208fbb85166ac58b4ca33d89c"
 "checksum skeptic 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "34c7f11b6755efa4abfd2739426c17de0a36153510bacd6147113fd3a9f2634d"
 "checksum slab 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "d807fd58c4181bbabed77cb3b891ba9748241a552bcc5be698faaebefc54f46e"
 "checksum solicit 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "172382bac9424588d7840732b250faeeef88942e37b6e35317dce98cafdd75b2"
 "checksum strsim 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "50c069df92e4b01425a8bf3576d5d417943a6a7272fbabaf5bd80b1aaa76442e"
+"checksum syntect 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2951ac71496ad0983fb701cf871ee46e8ad975a032d51faaa9a6c6e6bb568453"
 "checksum tempdir 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "87974a6f5c1dfb344d733055601650059a3363de2a6104819293baff662132d6"
 "checksum term_size 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3f7f5f3f71b0040cecc71af239414c23fd3c73570f5ff54cf50e03cef637f2a0"
 "checksum thread-id 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a9539db560102d1cef46b8b78ce737ff0bb64e7e18d35b2a5688f7d097d0ff03"
@@ -828,4 +963,5 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
 "checksum winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc"
 "checksum ws2_32-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d59cefebd0c892fa2dd6de581e937301d8552cb44489cdff035c6187cb63fa5e"
+"checksum xml-rs 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "65e74b96bd3179209dc70a980da6df843dff09e46eee103a0376c0949257e3ef"
 "checksum yaml-rust 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "371cea3a33a58d11dc83c0992fb37e44f651ebdf2df12f9d939f6cb24be2a8fd"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,8 @@ glob = "0.2.11"
 regex = "0.1"
 clippy = {version = "0.0", optional = true}
 error-chain = "0.5.0"
+syntect = {version = "1.0", optional = true}
+lazy_static = {version = "0.2", optional =true}
 
 [dependencies.hyper]
 version = "0.9"
@@ -44,5 +46,9 @@ difference = "0.4"
 tempdir = "0.3"
 
 [features]
+default = ["syntax-highlight"]
 unstable = []
 dev = []
+
+syntax-highlight = ["syntect", "lazy_static"]
+

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ difference = "0.4"
 tempdir = "0.3"
 
 [features]
-default = ["syntax-highlight"]
+default = []
 unstable = []
 dev = []
 

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ To mark a post as draft you can either set `draft: true` in your front matter or
 
 Any file with the .md or .liquid file extension is considered a liquid template and will be parsed for metadata and compiled using liquid, like a post.
 
-Unlike posts, files outside the ``_posts`` directory will not be indexed as blog posts and not passed to the index file in the list of contents.
+Unlike posts, files outside the ``posts`` directory will not be indexed as blog posts and not passed to the index file in the list of contents.
 
 All other files and directories in the source folder will be recursively added to your destination folder.
 
@@ -147,7 +147,7 @@ In example above _title_ is accessible via ```{{ title }}``` and _date_ via ```{
 
 #### posts
 
-`{{ posts }}` is a list of the attributes of all templates in the `_posts` directory. Example usage on a page listing all blog posts:
+`{{ posts }}` is a list of the attributes of all templates in the `posts` directory. Example usage on a page listing all blog posts:
 
 ```
 {% for post in posts %}
@@ -157,7 +157,7 @@ In example above _title_ is accessible via ```{{ title }}``` and _date_ via ```{
 
 ### RSS
 
-To generate an RSS file from the metadata of your `_posts`, you need to provide the following data in your config.file:
+To generate an RSS file from the metadata of your posts, you need to provide the following data in your config file:
 
 ```yaml
 # path where the RSS file should be generated

--- a/README.md
+++ b/README.md
@@ -171,6 +171,15 @@ None of these fields are optional, as by the [RSS 2.0 spec]().
 
 Make sure to also provide the fields `title`, `date` and `description` in the front matter of your posts.
 
+### Syntax Highlighting
+
+> This feature is currently experimental and causes installation to fail on Windows. To enable syntax highlighting, you need to install Cobalt using cargo like this:
+>  ```
+>  cargo install cobalt-bin --features="syntax-highlight"
+>  ```
+
+If you [annotate your Markdown code blocks](https://help.github.com/articles/creating-and-highlighting-code-blocks/#syntax-highlighting), Cobalt will automatically highlight source code using [Syntect](https://github.com/trishume/syntect/).
+
 ### Import
 
 To import your site to your `gh-pages` branch you can either pass a `build --import` flag when you build the site or after you have build the site with `build` you can run `import`. There are also some flags that can be found via `import --help`.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,7 +46,7 @@ extern crate rss;
 extern crate glob;
 extern crate regex;
 
-#[cfg(feature="syntax-highlight")]
+#[cfg(all(feature="syntax-highlight", not(windows)))]
 extern crate syntect;
 
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,6 +46,10 @@ extern crate rss;
 extern crate glob;
 extern crate regex;
 
+#[cfg(feature="syntax-highlight")]
+extern crate syntect;
+
+
 #[macro_use]
 extern crate log;
 
@@ -63,3 +67,10 @@ mod config;
 pub mod error;
 mod document;
 mod new;
+
+#[cfg(feature="syntax-highlight")]
+mod syntax_highlight;
+
+#[cfg(feature="syntax-highlight")]
+#[macro_use]
+extern crate lazy_static;

--- a/src/syntax_highlight.rs
+++ b/src/syntax_highlight.rs
@@ -99,8 +99,11 @@ impl<'a> Iterator for DecoratedParser<'a> {
                             .next()
                             .and_then(|lang| SETUP.syntax_set.find_syntax_by_token(lang))
                             .unwrap_or_else(|| SETUP.syntax_set.find_syntax_plain_text());
-                        self.h = Some(HighlightLines::new(&cur_syntax, &SETUP.theme_set.themes[THEME_NAME]));
-                        return Some(Html(Owned(start_coloured_html_snippet(&SETUP.theme_set.themes[THEME_NAME]))));
+                        self.h = Some(HighlightLines::new(&cur_syntax,
+                                                          &SETUP.theme_set.themes[THEME_NAME]));
+                        let snippet =
+                            start_coloured_html_snippet(&SETUP.theme_set.themes[THEME_NAME]);
+                        return Some(Html(Owned(snippet)));
                     }
                     if let End(cmarkTag::CodeBlock(_)) = item {
                         // reset highlighter

--- a/src/syntax_highlight.rs
+++ b/src/syntax_highlight.rs
@@ -10,9 +10,10 @@ use liquid::Token::{self, Identifier};
 use liquid::lexer::Element::{self, Expression, Tag, Raw};
 use liquid::Error;
 
-use syntect::parsing::{SyntaxSet};
+use syntect::parsing::SyntaxSet;
 use syntect::highlighting::ThemeSet;
-use syntect::html::{IncludeBackground, highlighted_snippet_for_string, styles_to_coloured_html, start_coloured_html_snippet};
+use syntect::html::{IncludeBackground, highlighted_snippet_for_string, styles_to_coloured_html,
+                    start_coloured_html_snippet};
 use syntect::easy::HighlightLines;
 
 use std::borrow::Cow::Owned;

--- a/src/syntax_highlight.rs
+++ b/src/syntax_highlight.rs
@@ -1,4 +1,3 @@
-
 extern crate syntect;
 extern crate liquid;
 extern crate pulldown_cmark as cmark;
@@ -29,10 +28,8 @@ struct Setup {
     theme_set: ThemeSet,
 }
 
-
 unsafe impl Send for Setup {}
 unsafe impl Sync for Setup {}
-
 
 lazy_static!{
     static ref SETUP: Setup = Setup {
@@ -40,7 +37,6 @@ lazy_static!{
         theme_set: ThemeSet::load_defaults()
     };
 }
-
 
 struct CodeBlock {
     lang: Option<String>,
@@ -62,7 +58,6 @@ impl Renderable for CodeBlock {
     }
 }
 
-
 pub struct DecoratedParser<'a> {
     h: Option<HighlightLines<'a>>,
     parser: Parser<'a>,
@@ -76,7 +71,6 @@ impl<'a> DecoratedParser<'a> {
         }
     }
 }
-
 
 impl<'a> Iterator for DecoratedParser<'a> {
     type Item = Event<'a>;
@@ -141,18 +135,15 @@ pub fn initialize_codeblock(_: &str,
         _ => None,
     };
 
-    // FIXME: add language declarion support
     Ok(Box::new(CodeBlock {
         code: content,
         lang: lang,
     }))
 }
 
-
 pub fn decorate_markdown<'a>(parser: Parser<'a>) -> DecoratedParser {
     DecoratedParser::new(parser)
 }
-
 
 #[cfg(test)]
 mod test {

--- a/src/syntax_highlight.rs
+++ b/src/syntax_highlight.rs
@@ -1,0 +1,195 @@
+
+extern crate syntect;
+extern crate liquid;
+extern crate pulldown_cmark as cmark;
+
+use liquid::Renderable;
+use liquid::Context;
+use liquid::LiquidOptions;
+use liquid::Token::{self, Identifier};
+use liquid::lexer::Element::{self, Expression, Tag, Raw};
+use liquid::Error;
+
+use syntect::parsing::{SyntaxSet, SyntaxDefinition};
+use syntect::highlighting::ThemeSet;
+use syntect::html::highlighted_snippet_for_string;
+
+use std::borrow::Cow::Owned;
+
+use self::cmark::Parser;
+use self::cmark::Tag as cmarkTag;
+use self::cmark::Event::{self, Start, End, Text, Html};
+
+const THEME_NAME: &'static str = "base16-ocean.dark";
+
+struct Setup {
+    syntax_set: SyntaxSet,
+    theme_set: ThemeSet,
+}
+
+
+unsafe impl Send for Setup {}
+unsafe impl Sync for Setup {}
+
+
+lazy_static!{
+    static ref SETUP: Setup = Setup {
+        syntax_set: SyntaxSet::load_defaults_newlines(),
+        theme_set: ThemeSet::load_defaults()
+    };
+}
+
+
+struct CodeBlock {
+    lang: Option<String>,
+    code: String,
+}
+
+impl Renderable for CodeBlock {
+    fn render(&self, _: &mut Context) -> Result<Option<String>, Error> {
+
+        let syntax = match self.lang {
+                Some(ref lang) => SETUP.syntax_set.find_syntax_by_token(lang),
+                _ => None,
+            }
+            .unwrap_or_else(|| SETUP.syntax_set.find_syntax_plain_text());
+
+        Ok(Some(highlighted_snippet_for_string(&self.code,
+                                               syntax,
+                                               &SETUP.theme_set.themes[THEME_NAME])))
+    }
+}
+
+
+pub struct DecoratedParser<'a> {
+    parser: Parser<'a>,
+    cur_syntax: Option<SyntaxDefinition>,
+}
+
+impl<'a> DecoratedParser<'a> {
+    pub fn new(parser: Parser<'a>) -> Self {
+        DecoratedParser {
+            parser: parser,
+            cur_syntax: None,
+        }
+    }
+}
+
+
+impl<'a> Iterator for DecoratedParser<'a> {
+    type Item = Event<'a>;
+
+    fn next(&mut self) -> Option<Event<'a>> {
+        match self.parser.next() {
+            Some(item) => {
+                if let Text(text) = item {
+                    if let Some(ref syntax) = self.cur_syntax {
+                        Some(Html(Owned(
+                            highlighted_snippet_for_string(&text,
+                                                           syntax,
+                                                           &SETUP.theme_set.themes[THEME_NAME]))))
+                    } else {
+                        Some(Text(text))
+                    }
+                } else {
+                    if let Start(cmarkTag::CodeBlock(ref info)) = item {
+                        // set local highlighter, if found
+                        self.cur_syntax = Some(info.clone()
+                            .split(' ')
+                            .next()
+                            .and_then(|lang| SETUP.syntax_set.find_syntax_by_token(lang))
+                            .unwrap_or_else(|| SETUP.syntax_set.find_syntax_plain_text())
+                            .clone());
+                    }
+                    if let End(cmarkTag::CodeBlock(_)) = item {
+                        // reset
+                        self.cur_syntax = None
+                    }
+
+                    Some(item)
+                }
+            }
+            None => None,
+        }
+    }
+}
+
+pub fn initialize_codeblock(_: &str,
+                            arguments: &[Token],
+                            tokens: Vec<Element>,
+                            _: &LiquidOptions)
+                            -> Result<Box<Renderable>, Error> {
+
+    let content = tokens.iter().fold("".to_owned(), |a, b| {
+        match *b {
+                Expression(_, ref text) |
+                Tag(_, ref text) |
+                Raw(ref text) => text,
+            }
+            .to_owned() + &a
+    });
+
+    let lang = match arguments.iter().next() {
+        Some(&Identifier(ref x)) => Some(x.clone()),
+        _ => None,
+    };
+
+    // FIXME: add language declarion support
+    Ok(Box::new(CodeBlock {
+        code: content,
+        lang: lang,
+    }))
+}
+
+
+pub fn decorate_markdown<'a>(parser: Parser<'a>) -> DecoratedParser {
+    DecoratedParser::new(parser)
+}
+
+
+#[cfg(test)]
+mod test {
+
+    use std::default::Default;
+    use syntax_highlight::initialize_codeblock;
+    use liquid::{self, Renderable, LiquidOptions, Context};
+
+    const CODE_BLOCK: &'static str = "mod test {
+        fn hello(arg: int) -> bool {
+            \
+                                      true
+        }
+    }
+    ";
+
+    const RENDERED: &'static str =
+        "<pre style=\"background-color:#2b303b;\">\n<span \
+         style=\"color:#b48ead;\">mod</span><span style=\"color:#c0c5ce;\"> </span><span \
+         style=\"color:#c0c5ce;\">test</span><span style=\"color:#c0c5ce;\"> </span><span \
+         style=\"color:#c0c5ce;\">{</span>\n<span style=\"color:#c0c5ce;\">        </span><span \
+         style=\"color:#b48ead;\">fn</span><span style=\"color:#c0c5ce;\"> </span><span \
+         style=\"color:#8fa1b3;\">hello</span><span style=\"color:#c0c5ce;\">(</span><span \
+         style=\"color:#bf616a;\">arg</span><span style=\"color:#c0c5ce;\">:</span><span \
+         style=\"color:#c0c5ce;\"> int</span><span style=\"color:#c0c5ce;\">)</span><span \
+         style=\"color:#c0c5ce;\"> </span><span style=\"color:#c0c5ce;\">-&gt;</span><span \
+         style=\"color:#c0c5ce;\"> </span><span style=\"color:#b48ead;\">bool</span><span \
+         style=\"color:#c0c5ce;\"> </span><span style=\"color:#c0c5ce;\">{</span>\n<span \
+         style=\"color:#c0c5ce;\">            </span><span \
+         style=\"color:#d08770;\">true</span>\n<span style=\"color:#c0c5ce;\">        \
+         </span><span style=\"color:#c0c5ce;\">}</span>\n<span style=\"color:#c0c5ce;\">    \
+         </span><span style=\"color:#c0c5ce;\">}</span>\n<span style=\"color:#c0c5ce;\">    \
+         </span>\n</pre>\n";
+    #[test]
+    fn test_codeblock_renders_rust() {
+        let mut options: LiquidOptions = Default::default();
+        options.blocks.insert("codeblock".to_string(), Box::new(initialize_codeblock));
+        let template = liquid::parse(&format!("{{% codeblock rust %}}{}{{% endcodeblock %}}",
+                                              CODE_BLOCK),
+                                     options)
+            .unwrap();
+        let mut data = Context::new();
+        let output = template.render(&mut data);
+        assert_eq!(output.unwrap(), Some(RENDERED.to_string()));
+    }
+
+}

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -1,11 +1,13 @@
-#[macro_use] extern crate assert_cli;
-#[macro_use] extern crate lazy_static;
+#[macro_use]
+extern crate assert_cli;
+#[macro_use]
+extern crate lazy_static;
 
 use std::env;
 use std::str;
 use std::path::{Path, PathBuf};
 
-static EMPTY : &'static [&'static str] = &[];
+static EMPTY: &'static [&'static str] = &[];
 lazy_static! {
     static ref _CWD: PathBuf = env::current_dir().unwrap();
     static ref CWD: &'static Path = _CWD.as_path();
@@ -37,7 +39,8 @@ pub fn invalid_calls() {
     assert_contains!(&output.stderr, "requires a subcommand");
 
     let output = assert_cli!(&BIN, &["--nonexistent-argument"] => Error 1).unwrap();
-    assert_contains!(&output.stderr, r"Found argument '--nonexistent-argument' which wasn't expected");
+    assert_contains!(&output.stderr,
+                     r"Found argument '--nonexistent-argument' which wasn't expected");
 }
 
 #[test]
@@ -73,5 +76,5 @@ pub fn clean() {
 
     let output = assert_cli!(&BIN, &["clean", "-d", "./test_dest"] => Success).unwrap();
     assert_eq!(Path::new("./test_dest").is_dir(), false);
-    assert_contains!(&output.stderr, "directory \"./test_dest\" removed"); 
+    assert_contains!(&output.stderr, "directory \"./test_dest\" removed");
 }

--- a/tests/fixtures/syntax_highlight/rust.md
+++ b/tests/fixtures/syntax_highlight/rust.md
@@ -1,0 +1,23 @@
+This is a rust markdown-inline-example
+
+```rust
+
+fn hello() -> bool {
+    true
+}
+
+```
+
+
+
+{% highlight rust %}
+
+pub struct World {
+    virtual: bool
+}
+
+fn create(virtual: bool) -> World {
+    World{virtual: virtual}
+}
+
+{% endhighlight %}

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -14,11 +14,12 @@ use cobalt::Config;
 fn run_test(name: &str) -> Result<(), cobalt::Error> {
     let target = format!("tests/target/{}/", name);
     let mut config = Config::from_file(format!("tests/fixtures/{}/.cobalt.yml", name))
-                         .unwrap_or(Default::default());
+        .unwrap_or(Default::default());
     let destdir = TempDir::new(name).expect("Tempdir not created");
 
     config.source = format!("tests/fixtures/{}/", name);
-    config.dest = destdir.path().to_str()
+    config.dest = destdir.path()
+        .to_str()
         .expect("Can't convert destdir to str")
         .to_owned();
 
@@ -36,8 +37,8 @@ fn run_test(name: &str) -> Result<(), cobalt::Error> {
         // walk through fixture and created tmp directory and compare files
         for entry in walker {
             let relative = entry.path()
-                                .strip_prefix(&target)
-                                .expect("Comparison error");
+                .strip_prefix(&target)
+                .expect("Comparison error");
 
             let mut original = String::new();
             File::open(entry.path())
@@ -62,12 +63,13 @@ fn run_test(name: &str) -> Result<(), cobalt::Error> {
 
         for entry in walker {
             let relative = entry.path()
-                                .strip_prefix(&config.dest)
-                                .expect("Comparison error");
+                .strip_prefix(&config.dest)
+                .expect("Comparison error");
             let relative = Path::new(&target).join(&relative);
 
-            File::open(&relative)
-                .expect(&format!("File {:?} does not exist in reference ({:?}).", entry.path(), relative));
+            File::open(&relative).expect(&format!("File {:?} does not exist in reference ({:?}).",
+                                                  entry.path(),
+                                                  relative));
         }
     }
 
@@ -127,16 +129,21 @@ pub fn custom_template_extensions() {
     run_test("custom_template_extensions").expect("Build error");
 }
 
+#[cfg(feature = "syntax-highlight")]
+#[test]
+pub fn syntax_highlight() {
+    run_test("syntax_highlight").expect("Build error");
+}
+
 #[test]
 pub fn incomplete_rss() {
     let err = run_test("incomplete_rss");
     assert!(err.is_err());
 
     let err = err.unwrap_err();
-    assert_eq!(format!("{}",err),
+    assert_eq!(format!("{}", err),
                "name, description and link need to be defined in the config file to generate RSS");
-    assert_eq!(err.description(),
-               "missing fields in config file");
+    assert_eq!(err.description(), "missing fields in config file");
 }
 
 #[test]
@@ -156,11 +163,10 @@ pub fn liquid_raw() {
 pub fn no_extends_error() {
     let err = run_test("no_extends_error");
     assert!(err.is_err());
-    assert!(err
-            .unwrap_err()
-            .description()
-            .contains("Layout default_nonexistent.liquid can not be read (defined in tests/fixtures/no_extends_error/index.liquid)")
-            );
+    assert!(err.unwrap_err()
+        .description()
+        .contains("Layout default_nonexistent.liquid can not be read (defined in \
+                   tests/fixtures/no_extends_error/index.liquid)"));
 }
 
 #[test]

--- a/tests/target/syntax_highlight/rust.html
+++ b/tests/target/syntax_highlight/rust.html
@@ -1,0 +1,28 @@
+<p>This is a rust markdown-inline-example</p>
+<pre><code class="language-rust"><pre style="background-color:#2b303b;">
+
+</pre>
+<pre style="background-color:#2b303b;">
+<span style="color:#b48ead;">fn</span><span style="color:#c0c5ce;"> </span><span style="color:#8fa1b3;">hello</span><span style="color:#c0c5ce;">(</span><span style="color:#c0c5ce;">)</span><span style="color:#c0c5ce;"> </span><span style="color:#c0c5ce;">-&gt;</span><span style="color:#c0c5ce;"> </span><span style="color:#b48ead;">bool</span><span style="color:#c0c5ce;"> </span><span style="color:#c0c5ce;">{</span>
+</pre>
+<pre style="background-color:#2b303b;">
+<span style="color:#c0c5ce;">    </span>
+</pre>
+<pre style="background-color:#2b303b;">
+<span style="color:#d08770;">true</span>
+</pre>
+<pre style="background-color:#2b303b;">
+<span style="color:#c0c5ce;">}</span>
+</pre>
+<pre style="background-color:#2b303b;">
+
+</pre>
+</code></pre>
+<pre style="background-color:#2b303b;">
+<p><span style="color:#b48ead;">pub</span><span style="color:#c0c5ce;"> </span><span style="color:#b48ead;">struct</span><span style="color:#c0c5ce;"> </span><span style="color:#c0c5ce;">World</span><span style="color:#c0c5ce;"> </span><span style="color:#c0c5ce;">{</span>
+<span style="color:#c0c5ce;">    </span><span style="color:#bf616a;">virtual</span><span style="color:#c0c5ce;">:</span><span style="color:#c0c5ce;"> </span><span style="color:#b48ead;">bool</span>
+<span style="color:#c0c5ce;">}</span></p>
+<p><span style="color:#b48ead;">fn</span><span style="color:#c0c5ce;"> </span><span style="color:#8fa1b3;">create</span><span style="color:#c0c5ce;">(</span><span style="color:#bf616a;">virtual</span><span style="color:#c0c5ce;">:</span><span style="color:#c0c5ce;"> </span><span style="color:#b48ead;">bool</span><span style="color:#c0c5ce;">)</span><span style="color:#c0c5ce;"> </span><span style="color:#c0c5ce;">-&gt;</span><span style="color:#c0c5ce;"> World</span><span style="color:#c0c5ce;"> </span><span style="color:#c0c5ce;">{</span>
+<span style="color:#c0c5ce;">    World</span><span style="color:#c0c5ce;">{</span><span style="background-color:#bf616a;color:#2b303b;">virtual</span><span style="color:#c0c5ce;">:</span><span style="color:#c0c5ce;"> </span><span style="background-color:#bf616a;color:#2b303b;">virtual</span><span style="color:#c0c5ce;">}</span>
+<span style="color:#c0c5ce;">}</span></p>
+</pre>

--- a/tests/target/syntax_highlight/rust.html
+++ b/tests/target/syntax_highlight/rust.html
@@ -1,24 +1,11 @@
 <p>This is a rust markdown-inline-example</p>
-<pre><code class="language-rust"><pre style="background-color:#2b303b;">
-
-</pre>
-<pre style="background-color:#2b303b;">
-<span style="color:#b48ead;">fn</span><span style="color:#c0c5ce;"> </span><span style="color:#8fa1b3;">hello</span><span style="color:#c0c5ce;">(</span><span style="color:#c0c5ce;">)</span><span style="color:#c0c5ce;"> </span><span style="color:#c0c5ce;">-&gt;</span><span style="color:#c0c5ce;"> </span><span style="color:#b48ead;">bool</span><span style="color:#c0c5ce;"> </span><span style="color:#c0c5ce;">{</span>
-</pre>
-<pre style="background-color:#2b303b;">
-<span style="color:#c0c5ce;">    </span>
-</pre>
-<pre style="background-color:#2b303b;">
-<span style="color:#d08770;">true</span>
-</pre>
-<pre style="background-color:#2b303b;">
-<span style="color:#c0c5ce;">}</span>
-</pre>
-<pre style="background-color:#2b303b;">
-
-</pre>
-</code></pre>
-<pre style="background-color:#2b303b;">
+<pre style="background-color:#2b303b">
+<span style="background-color:#2b303b;color:#c0c5ce;">
+</span><span style="background-color:#2b303b;color:#b48ead;">fn</span><span style="background-color:#2b303b;color:#c0c5ce;"> </span><span style="background-color:#2b303b;color:#8fa1b3;">hello</span><span style="background-color:#2b303b;color:#c0c5ce;">(</span><span style="background-color:#2b303b;color:#c0c5ce;">)</span><span style="background-color:#2b303b;color:#c0c5ce;"> </span><span style="background-color:#2b303b;color:#c0c5ce;">-&gt;</span><span style="background-color:#2b303b;color:#c0c5ce;"> </span><span style="background-color:#2b303b;color:#b48ead;">bool</span><span style="background-color:#2b303b;color:#c0c5ce;"> </span><span style="background-color:#2b303b;color:#c0c5ce;">{</span><span style="background-color:#2b303b;color:#c0c5ce;">
+</span><span style="background-color:#2b303b;color:#c0c5ce;">    </span><span style="background-color:#2b303b;color:#d08770;">true</span><span style="background-color:#2b303b;color:#c0c5ce;">
+</span><span style="background-color:#2b303b;color:#c0c5ce;">}</span><span style="background-color:#2b303b;color:#c0c5ce;">
+</span><span style="background-color:#2b303b;color:#c0c5ce;">
+</span></pre><pre style="background-color:#2b303b;">
 <p><span style="color:#b48ead;">pub</span><span style="color:#c0c5ce;"> </span><span style="color:#b48ead;">struct</span><span style="color:#c0c5ce;"> </span><span style="color:#c0c5ce;">World</span><span style="color:#c0c5ce;"> </span><span style="color:#c0c5ce;">{</span>
 <span style="color:#c0c5ce;">    </span><span style="color:#bf616a;">virtual</span><span style="color:#c0c5ce;">:</span><span style="color:#c0c5ce;"> </span><span style="color:#b48ead;">bool</span>
 <span style="color:#c0c5ce;">}</span></p>


### PR DESCRIPTION
This work adds syntax highlighting to cobalt using the awesome syntect library. This still work in progress, not ready for merging yet!

- [x] add syntax highligting behind a (default on) feature flag
- [x] implement [highlight template tag](http://jekyllrb.com/docs/templates/#code-snippet-highlighting)
- [x] implement for markdown-inline-code-fences (_three ticks_)
- [x] include default set of syntax parsers into the binary (comes built-in with syntect! - whooot!?!)
- [x] add feature to configure hl-theme (how?)
- [x] move syntax loading into singleton