### PR TITLE
Set charset utf-8 in the default template

### DIFF
--- a/src/new.rs
+++ b/src/new.rs
@@ -11,6 +11,7 @@ ignore:
 const default_liquid: &'static [u8] = b"<!DOCTYPE html>
 <html>
     <head>
+        <meta charset=\"utf-8\">
         {% if is_post %}
           <title>{{ title }}</title>
         {% else %}


### PR DESCRIPTION
Fixes #169 (reported by @uetoyo)

How to test this PR manually:

* create new blog with `cobalt new`
* add non-ascii text in utf-8 to `posts/post-1.md`
* build the blog
* open post 1 in Firefox

I don't think we need to cover this with unit tests.