### PR TITLE
Trim starting `/` from relative entry path

### DIFF
--- a/src/cobalt.rs
+++ b/src/cobalt.rs
@@ -175,6 +175,7 @@ pub fn build(config: &Config) -> Result<()> {
 
             let relative = try!(entry_path.split(source_str)
                 .last()
+                .map(|s| s.trim_left_matches("/"))
                 .ok_or(format!("Empty path")));
 
             if try!(entry.metadata()).is_dir() {


### PR DESCRIPTION
While calculating the relative path, trim away the starting `/`. Otherwise,
`dest.join` ends up ignoring `dest` altogether and tries to create the directory
under root (say `/posts`).

To reproduce, try (in OSX El Capitan):
```bash
$ cobalt new
[warn]   No .cobalt.yml file found in current directory, using default config.
[info]   Created new project at ./
```
.cobalt.yml
```yaml
name: cobalt blog
source: "."
dest: "build"
ignore:
  - .git/*
  - build/*
```
```bash
$ cobalt build
[info]   Using config file .cobalt.yml
[info]   Building from . into build
[info]   Created build/posts/post-1.html
[info]   Created build/index.html
[info]   Copying remaining assets
[error]  Permission denied (os error 13)
[error]  Build not successful
```

Used the following extracted out code to experiment:
```rust
use std::path::Path;

fn main () {
    let source = Path::new(".");
    let dest = Path::new("build");
    let entry_path = "./posts";
    let source_str = source.to_str().unwrap();
    let relative = entry_path.split(source_str).last().unwrap(); // Needs .trim_left_matches("/");

    println!("Dest: {:?}, Source: {:?}, Entry: {:?}, Relative: {:?}, Final Path: {:?}",
             dest, source_str, entry_path, relative, &dest.join(relative));
}
```