### PR TITLE
Le Big CI Overhaul

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@
 dist: trusty
 language: rust
 services: docker
-sudo: required
 
 rust: stable
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,5 @@
-# Based on the "trust" template v0.1.1
-# # https://github.com/japaric/trust/tree/v0.1.1
-
 dist: trusty
 language: rust
-services: docker
 
 rust: stable
 
@@ -17,7 +13,6 @@ matrix:
   include:
     # Linux
     # - env: TARGET=x86_64-unknown-linux-gnu  # this is the default job
-    - env: TARGET=x86_64-unknown-linux-musl
 
     # OSX
     - env: TARGET=x86_64-apple-darwin

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,16 @@ language: rust
 
 rust: stable
 
+addons:
+  apt:
+    packages:
+      - libcurl4-openssl-dev
+      - libelf-dev
+      - libdw-dev
+      - cmake
+      - gcc
+      - binutils-dev
+
 env:
   global:
     - CRATE_NAME=cobalt
@@ -46,9 +56,8 @@ branches:
     - /^v\d+\.\d+\.\d+.*$/
     - master
 
-# TODO: Upload coverage
-#after_success:
- #- travis-cargo --only stable coveralls --no-sudo --exclude-pattern="src/main.rs,src/new.rs,target/debug/build/"
+after_success:
+  - bash ci/coverage.sh
 
 deploy:
   provider: releases

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ env:
     - TARGET=x86_64-unknown-linux-gnu
 
 matrix:
+  fast_finish: true
   include:
     # Linux
     # - env: TARGET=x86_64-unknown-linux-gnu  # this is the default job
@@ -49,16 +50,16 @@ branches:
 #after_success:
  #- travis-cargo --only stable coveralls --no-sudo --exclude-pattern="src/main.rs,src/new.rs,target/debug/build/"
 
-#deploy:
-  #api_key:
-    #secure: IzxVmMO+mVWc4BSoB7Ek7L6Ye5FNrCI4fb/pIFitrQRmP3Cpuw7qMm5sxL5niiGaMRJHwce07ukyKsCNgs+64k8VwToUDPWy4F7+EbIHrjDOJtIY8TME+hUeaCmkMysuqUj1oKtDS+l8F+Yc42ZXNMqz/1kF/h6sGTRSmlzR3mc=
-  #file_glob: true
-  #file: $CRATE_NAME-$TRAVIS_TAG-$TARGET.*
-  #on:
-    #condition: $TRAVIS_RUST_VERSION = stable
-    #tags: true
-  #provider: releases
-  #skip_cleanup: true
+deploy:
+  provider: releases
+  api_key:
+    secure: "EGyMK0pMUtzHFuDRaACsVj7fkq4zkLumM8UHVSny2TWr+6Ln4uVwVjnQbuYdHVZfJWXWysdmlDpdH5kAVKA+80ysafv7QsORHOfiOlwvpEpAF1KzsiqKubn+IT1+/kKzztzDxeTyJX4BitEI5QIbWy+FIAWJFbxvy6M/y1baS+A="
+  file_glob: true
+  file: $CRATE_NAME-$TRAVIS_TAG-$TARGET.*
+  on:
+    condition: $TRAVIS_RUST_VERSION = stable
+    tags: true
+  skip_cleanup: true
 
 notifications:
   webhooks:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,37 +1,70 @@
-sudo: false
+# Based on the "trust" template v0.1.1
+# # https://github.com/japaric/trust/tree/v0.1.1
+
+dist: trusty
 language: rust
-cache: cargo
-rust:
-  - stable
-  - beta
-  - nightly
+services: docker
+sudo: required
 
-before_script:
-  - |
-    pip install 'travis-cargo<0.2' --user &&
-    (cargo install rustfmt || true) &&
-    export PATH=$HOME/.local/bin:$PATH &&
-    export PATH=$HOME/.cargo/bin:$PATH
-
-script:
-  - |
-    cargo fmt -- --write-mode=diff &&
-    travis-cargo build &&
-    travis-cargo test
-
-addons:
-  apt:
-    packages:
-      - libcurl4-openssl-dev
-      - libelf-dev
-      - libdw-dev
-
-after_success:
-  - travis-cargo --only stable coveralls --no-sudo --exclude-pattern="src/main.rs,src/new.rs,target/debug/build/"
+rust: stable
 
 env:
   global:
-  - TRAVIS_CARGO_NIGHTLY_FEATURE="clippy"
+    - CRATE_NAME=cobalt
+    # default job
+    - TARGET=x86_64-unknown-linux-gnu
+
+matrix:
+  include:
+    # Linux
+    # - env: TARGET=x86_64-unknown-linux-gnu  # this is the default job
+    - env: TARGET=x86_64-unknown-linux-musl
+
+    # OSX
+    - env: TARGET=x86_64-apple-darwin
+      os: osx
+
+    # Testing other channels
+    - env: TARGET=x86_64-unknown-linux-gnu
+      rust: beta
+    - env: TARGET=x86_64-unknown-linux-gnu
+      rust: nightly
+
+install:
+  - sh ci/install.sh
+  - source ~/.cargo/env || true
+
+script:
+  - bash ci/script.sh
+
+before_deploy:
+  - sh ci/before_deploy.sh
+
+cache: cargo
+before_cache:
+    # Travis can't cache files that are not readable by "others"
+    - chmod -R a+r $HOME/.cargo
+
+branches:
+  only:
+    # release tags
+    - /^v\d+\.\d+\.\d+.*$/
+    - master
+
+# TODO: Upload coverage
+#after_success:
+ #- travis-cargo --only stable coveralls --no-sudo --exclude-pattern="src/main.rs,src/new.rs,target/debug/build/"
+
+#deploy:
+  #api_key:
+    #secure: IzxVmMO+mVWc4BSoB7Ek7L6Ye5FNrCI4fb/pIFitrQRmP3Cpuw7qMm5sxL5niiGaMRJHwce07ukyKsCNgs+64k8VwToUDPWy4F7+EbIHrjDOJtIY8TME+hUeaCmkMysuqUj1oKtDS+l8F+Yc42ZXNMqz/1kF/h6sGTRSmlzR3mc=
+  #file_glob: true
+  #file: $CRATE_NAME-$TRAVIS_TAG-$TARGET.*
+  #on:
+    #condition: $TRAVIS_RUST_VERSION = stable
+    #tags: true
+  #provider: releases
+  #skip_cleanup: true
 
 notifications:
   webhooks:

--- a/README.md
+++ b/README.md
@@ -23,8 +23,23 @@ A static site generator written in [Rust](http://www.rust-lang.org/).
 
 ## Installation
 
+### Using the install script
+
+No prerequisites
+
 ```
-  $ cargo install cobalt-bin
+$ curl -LSfs https://japaric.github.io/trust/install.sh | sh -s -- --git cobalt-org/cobalt.rs
+```
+
+You can also manually download all releases [here](https://github.com/cobalt-org/cobalt.rs/releases).
+If your platform is not supported yet, please try installing from source (see below) and file an issue.
+
+### Using cargo
+
+Requires Rust
+
+```
+$ cargo install cobalt-bin
 ```
 
 ## Examples

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,9 +1,12 @@
-# This is based on https://github.com/rust-lang-nursery/rustfmt/blob/master/appveyor.yml
-# which is in turn based on https://github.com/japaric/rust-everywhere/blob/master/appveyor.yml
+# Based on the "trust" template v0.1.1
+# https://github.com/japaric/trust/tree/v0.1.1
 
 environment:
   global:
-    PROJECT_NAME: cobalt.rs
+    RUST_VERSION: stable
+
+    CRATE_NAME: cobalt
+
   matrix:
     # Stable channel
     - TARGET: x86_64-pc-windows-gnu
@@ -19,25 +22,63 @@ environment:
     - TARGET: x86_64-pc-windows-msvc
       CHANNEL: nightly
 
-# Install Rust and Cargo
-# (Based on from https://github.com/rust-lang/libc/blob/master/appveyor.yml)
 install:
-  - ps: Start-FileDownload "https://static.rust-lang.org/dist/channel-rust-stable"
-  - ps: $env:RUST_VERSION = Get-Content channel-rust-stable | select -first 1 | %{$_.split('-')[1]}
-  - if NOT "%CHANNEL%" == "stable" set RUST_VERSION=%CHANNEL%
-  - ps: Start-FileDownload "https://static.rust-lang.org/dist/rust-${env:RUST_VERSION}-${env:TARGET}.exe"
-  - rust-%RUST_VERSION%-%TARGET%.exe /VERYSILENT /NORESTART /DIR="C:\Program Files (x86)\Rust"
-  - SET PATH=%PATH%;C:\Program Files (x86)\Rust\bin
-  - if "%TARGET%" == "i686-pc-windows-gnu" set PATH=%PATH%;C:\msys64\mingw32\bin
-  - if "%TARGET%" == "x86_64-pc-windows-gnu" set PATH=%PATH%;C:\msys64\mingw64\bin
-  - rustc -V
+  - ps: >-
+      If ($Env:TARGET -eq 'x86_64-pc-windows-gnu') {
+        $Env:PATH += ';C:\msys64\mingw64\bin'
+      } ElseIf ($Env:TARGET -eq 'i686-pc-windows-gnu') {
+        $Env:PATH += ';C:\msys64\mingw32\bin'
+      }
+  - curl -sSf -o rustup-init.exe https://win.rustup.rs/
+  - rustup-init.exe -y --default-host %TARGET% --default-toolchain %RUST_VERSION%
+  - set PATH=%PATH%;C:\Users\appveyor\.cargo\bin
+  - rustc -Vv
   - cargo -V
 
-# ???
-build: false
-
-# Build and test
 test_script:
-  - cargo build --verbose
-  - cargo test
+  # we don't run the "test phase" when doing deploys
+  - if [%APPVEYOR_REPO_TAG%]==[false] (
+      cargo build --target %TARGET% &&
+      cargo build --target %TARGET% --release &&
+      cargo test --target %TARGET% &&
+      cargo test --target %TARGET% --release
+    )
 
+before_deploy:
+  - cargo rustc --target %TARGET% --release --bin cargo -- -C lto
+  - ps: ci\before_deploy.ps1
+
+#deploy:
+  #artifact: /.*\.zip/
+  ## TODO update `auth_token.secure`
+  ## - Create a `public_repo` GitHub token. Go to: https://github.com/settings/tokens/new
+  ## - Encrypt it. Go to https://ci.appveyor.com/tools/encrypt
+  ## - Paste the output down here
+  #auth_token:
+    #secure: t3puM/2hOig26EHhAodcZBc61NywF7/PFEpimR6SwGaCiqS07KR5i7iAhSABmBp7
+  #description: ''
+  #on:
+    ## TODO Here you can pick which targets will generate binary releases
+    ## In this example, there are some targets that are tested using the stable
+    ## and nightly channels. This condition makes sure there is only one release
+    ## for such targets and that's generated using the stable channel
+    #RUST_VERSION: stable
+    #appveyor_repo_tag: true
+  #provider: GitHub
+
+cache:
+  - C:\Users\appveyor\.cargo\registry
+  - target
+
+branches:
+  only:
+    # Release tags
+    - /^v\d+\.\d+\.\d+.*$/
+    - master
+
+notifications:
+  - provider: Email
+    on_build_success: false
+
+# disable automatic builds
+build: false

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -38,14 +38,11 @@ install:
 test_script:
   # we don't run the "test phase" when doing deploys
   - if [%APPVEYOR_REPO_TAG%]==[false] (
-      cargo build --target %TARGET% &&
-      cargo build --target %TARGET% --release &&
-      cargo test --target %TARGET% &&
-      cargo test --target %TARGET% --release
+      cargo build --verbose && cargo test
     )
 
 before_deploy:
-  - cargo rustc --target %TARGET% --release --bin cargo -- -C lto
+  - cargo rustc --target %TARGET% --release --bin cobalt -- -C lto
   - ps: ci\before_deploy.ps1
 
 #deploy:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -45,23 +45,15 @@ before_deploy:
   - cargo rustc --target %TARGET% --release --bin cobalt -- -C lto
   - ps: ci\before_deploy.ps1
 
-#deploy:
-  #artifact: /.*\.zip/
-  ## TODO update `auth_token.secure`
-  ## - Create a `public_repo` GitHub token. Go to: https://github.com/settings/tokens/new
-  ## - Encrypt it. Go to https://ci.appveyor.com/tools/encrypt
-  ## - Paste the output down here
-  #auth_token:
-    #secure: t3puM/2hOig26EHhAodcZBc61NywF7/PFEpimR6SwGaCiqS07KR5i7iAhSABmBp7
-  #description: ''
-  #on:
-    ## TODO Here you can pick which targets will generate binary releases
-    ## In this example, there are some targets that are tested using the stable
-    ## and nightly channels. This condition makes sure there is only one release
-    ## for such targets and that's generated using the stable channel
-    #RUST_VERSION: stable
-    #appveyor_repo_tag: true
-  #provider: GitHub
+deploy:
+  artifact: /.*\.zip/
+  auth_token:
+    secure: utuy2/b3b27gNjfJb/n/pZYEP3uMi9oDa6qvtbTg31QAgeih1+q8cQTsiCzN8fWZ
+  description: ''
+  on:
+    RUST_VERSION: stable
+    appveyor_repo_tag: true
+  provider: GitHub
 
 cache:
   - C:\Users\appveyor\.cargo\registry

--- a/ci/before_deploy.ps1
+++ b/ci/before_deploy.ps1
@@ -1,0 +1,22 @@
+# This script takes care of packaging the build artifacts that will go in the
+# release zipfile
+
+$SRC_DIR = $PWD.Path
+$STAGE = [System.Guid]::NewGuid().ToString()
+
+Set-Location $ENV:Temp
+New-Item -Type Directory -Name $STAGE
+Set-Location $STAGE
+
+$ZIP = "$SRC_DIR\$($Env:CRATE_NAME)-$($Env:APPVEYOR_REPO_TAG_NAME)-$($Env:TARGET).zip"
+
+Copy-Item "$SRC_DIR\target\$($Env:TARGET)\release\cobalt.exe" '.\'
+
+7z a "$ZIP" *
+
+Push-AppveyorArtifact "$ZIP"
+
+Remove-Item *.* -Force
+Set-Location ..
+Remove-Item $STAGE
+Set-Location $SRC_DIR

--- a/ci/before_deploy.sh
+++ b/ci/before_deploy.sh
@@ -1,0 +1,31 @@
+# This script takes care of building your crate and packaging it for release
+
+set -ex
+
+main() {
+    local src=$(pwd) \
+          stage=
+
+    case $TRAVIS_OS_NAME in
+        linux)
+            stage=$(mktemp -d)
+            ;;
+        osx)
+            stage=$(mktemp -d -t tmp)
+            ;;
+    esac
+
+    test -f Cargo.lock || cargo generate-lockfile
+
+    cross rustc --bin cobalt --target $TARGET --release -- -C lto
+
+    cp target/$TARGET/release/cobalt $stage/
+
+    cd $stage
+    tar czf $src/$CRATE_NAME-$TRAVIS_TAG-$TARGET.tar.gz *
+    cd $src
+
+    rm -rf $stage
+}
+
+main

--- a/ci/before_deploy.sh
+++ b/ci/before_deploy.sh
@@ -13,8 +13,6 @@ main() {
             ;;
     esac
 
-    test -f Cargo.lock || cargo generate-lockfile
-
     cargo rustc --target $TARGET --release --bin cobalt -- -C lto
 
     cp target/$TARGET/release/cobalt $stage/

--- a/ci/before_deploy.sh
+++ b/ci/before_deploy.sh
@@ -1,5 +1,3 @@
-# This script takes care of building your crate and packaging it for release
-
 set -ex
 
 main() {
@@ -17,7 +15,7 @@ main() {
 
     test -f Cargo.lock || cargo generate-lockfile
 
-    cross rustc --bin cobalt --target $TARGET --release -- -C lto
+    cargo rustc --target $TARGET --release --bin cobalt -- -C lto
 
     cp target/$TARGET/release/cobalt $stage/
 

--- a/ci/coverage.sh
+++ b/ci/coverage.sh
@@ -1,0 +1,34 @@
+set -ex
+
+main() {
+  # install kcov
+  wget https://github.com/SimonKagstrom/kcov/archive/master.tar.gz
+  tar xzf master.tar.gz
+  mkdir kcov-master/build
+  cd kcov-master/build
+  cmake ..
+  make
+  make install DESTDIR=../tmp
+  sudo make install
+  cd ../..
+
+  ls target/debug
+
+  # collect coverage
+  for file in target/debug/cobalt-*; do
+    ./kcov-master/tmp/usr/local/bin/kcov --exclude-pattern=/.cargo,target/ --verify target/kcov "$file"
+  done
+
+  ./kcov-master/tmp/usr/local/bin/kcov --exclude-pattern=/.cargo,target/ --verify target/kcov target/debug/mod-*
+
+  # the last job should upload the merged data
+  ./kcov-master/tmp/usr/local/bin/kcov --coveralls-id=$TRAVIS_JOB_ID --exclude-pattern=/.cargo,target/ --verify target/kcov target/debug/cli-*
+
+  ls target/kcov
+}
+
+# only run coverage on the default job
+if [ "$TRAVIS_RUST_VERSION" = "stable" -a "$TARGET" = "x86_64-unknown-linux-gnu" ]; then
+    main
+fi
+

--- a/ci/install.sh
+++ b/ci/install.sh
@@ -10,7 +10,7 @@ main() {
            --force \
            --crate rustfmt \
            --git japaric/rustfmt-bin \
-           --tag v0.6.3-20170107 \
+           --tag v0.6.3-20161120 \
 
     if [ "$TRAVIS_RUST_VERSION" = "nightly" ]; then
       cargo install clippy || true

--- a/ci/install.sh
+++ b/ci/install.sh
@@ -1,0 +1,31 @@
+set -ex
+
+main() {
+    curl https://sh.rustup.rs -sSf | \
+        sh -s -- -y --default-toolchain $TRAVIS_RUST_VERSION
+
+    local target=
+    if [ $TRAVIS_OS_NAME = linux ]; then
+        target=x86_64-unknown-linux-gnu
+    else
+        target=x86_64-apple-darwin
+    fi
+
+    curl -LSfs https://japaric.github.io/trust/install.sh | \
+        sh -s -- \
+           --force \
+           --git japaric/cross \
+           --tag v0.1.4 \
+           --target $target
+
+    if [ $target = x86_64-unknown-linux-gnu ]; then
+        # TODO: use https://github.com/japaric/rustfmt-bin
+        cargo install rustfmt || true
+    fi
+
+    if [ $TRAVIS_RUST_VERSION == nightly ]; then
+      cargo install clippy || true
+    fi
+}
+
+main

--- a/ci/install.sh
+++ b/ci/install.sh
@@ -4,20 +4,6 @@ main() {
     curl https://sh.rustup.rs -sSf | \
         sh -s -- -y --default-toolchain $TRAVIS_RUST_VERSION
 
-    local target=
-    if [ $TRAVIS_OS_NAME = linux ]; then
-        target=x86_64-unknown-linux-gnu
-    else
-        target=x86_64-apple-darwin
-    fi
-
-    curl -LSfs https://japaric.github.io/trust/install.sh | \
-        sh -s -- \
-           --force \
-           --git japaric/cross \
-           --tag v0.1.4 \
-           --target $target
-
     # Install rustfmt
     curl -LSfs https://japaric.github.io/trust/install.sh | \
         sh -s -- \
@@ -25,9 +11,8 @@ main() {
            --crate rustfmt \
            --git japaric/rustfmt-bin \
            --tag v0.6.3-20170107 \
-           --target $target
 
-    if [ $TRAVIS_RUST_VERSION == nightly ]; then
+    if [ "$TRAVIS_RUST_VERSION" = "nightly" ]; then
       cargo install clippy || true
     fi
 }

--- a/ci/install.sh
+++ b/ci/install.sh
@@ -18,10 +18,14 @@ main() {
            --tag v0.1.4 \
            --target $target
 
-    if [ $target = x86_64-unknown-linux-gnu ]; then
-        # TODO: use https://github.com/japaric/rustfmt-bin
-        cargo install rustfmt || true
-    fi
+    # Install rustfmt
+    curl -LSfs https://japaric.github.io/trust/install.sh | \
+        sh -s -- \
+           --force \
+           --crate rustfmt \
+           --git japaric/rustfmt-bin \
+           --tag v0.6.3-20170107 \
+           --target $target
 
     if [ $TRAVIS_RUST_VERSION == nightly ]; then
       cargo install clippy || true

--- a/ci/script.sh
+++ b/ci/script.sh
@@ -1,0 +1,30 @@
+# This script takes care of testing your crate
+
+set -ex
+
+main() {
+    if [ $TARGET = x86_64-unknown-linux-gnu ]; then
+        cargo fmt -- --write-mode=diff
+    fi
+
+    cross build --target $TARGET
+    cross build --target $TARGET --release
+
+    if [ -n $DISABLE_TESTS ]; then
+        return
+    fi
+
+    cross test --target $TARGET
+    cross test --target $TARGET --release
+
+    if [ $TRAVIS_RUST_VERSION == nightly ]; then
+      cargo clippy
+    fi
+
+}
+
+# we don't run the "test phase" when doing deploys
+if [ -z $TRAVIS_TAG ]; then
+    main
+fi
+

--- a/ci/script.sh
+++ b/ci/script.sh
@@ -3,24 +3,17 @@
 set -ex
 
 main() {
-    if [ $TARGET = x86_64-unknown-linux-gnu ]; then
-        cargo fmt -- --write-mode=diff
-    fi
+    TARGET=$TARGET cross build --target $TARGET
+    TARGET=$TARGET cross build --target $TARGET --release
 
-    cross build --target $TARGET
-    cross build --target $TARGET --release
-
-    if [ -n $DISABLE_TESTS ]; then
-        return
-    fi
-
-    cross test --target $TARGET
-    cross test --target $TARGET --release
+    TARGET=$TARGET cross test --target $TARGET
+    TARGET=$TARGET cross test --target $TARGET --release
 
     if [ $TRAVIS_RUST_VERSION == nightly ]; then
       cargo clippy
     fi
 
+    cargo fmt -- --write-mode=diff
 }
 
 # we don't run the "test phase" when doing deploys

--- a/ci/script.sh
+++ b/ci/script.sh
@@ -1,18 +1,15 @@
-# This script takes care of testing your crate
-
 set -ex
 
 main() {
-    TARGET=$TARGET cross build --target $TARGET
-    TARGET=$TARGET cross build --target $TARGET --release
+    cargo build
+    cargo test
 
-    TARGET=$TARGET cross test --target $TARGET
-    TARGET=$TARGET cross test --target $TARGET --release
-
-    if [ $TRAVIS_RUST_VERSION == nightly ]; then
+    if [ "$TRAVIS_RUST_VERSION" = "nightly" ]; then
+      cargo clippy -- --version
       cargo clippy
     fi
 
+    cargo fmt -- --version
     cargo fmt -- --write-mode=diff
 }
 

--- a/src/cobalt.rs
+++ b/src/cobalt.rs
@@ -67,7 +67,7 @@ pub fn build(config: &Config) -> Result<()> {
 
     for entry in walker {
         let entry_path = entry.path();
-        let extension = &entry_path.extension().unwrap_or(OsStr::new(""));
+        let extension = &entry_path.extension().unwrap_or_else(|| OsStr::new(""));
         if template_extensions.contains(extension) {
             // if the document is in the posts folder it's considered a post
             let is_post =
@@ -95,7 +95,7 @@ pub fn build(config: &Config) -> Result<()> {
 
         for entry in walker {
             let entry_path = entry.path();
-            let extension = &entry_path.extension().unwrap_or(OsStr::new(""));
+            let extension = &entry_path.extension().unwrap_or_else(|| OsStr::new(""));
             let new_path = posts_path
                 .join(entry_path.strip_prefix(&drafts).expect("Draft not in draft folder!"));
             let new_path = new_path.strip_prefix(source).expect("Entry not in source folder");
@@ -133,7 +133,7 @@ pub fn build(config: &Config) -> Result<()> {
     }
 
     // check if we should create an RSS file and create it!
-    if let &Some(ref path) = &config.rss {
+    if let Some(ref path) = config.rss {
         try!(create_rss(path, dest, &config, &posts));
     }
 
@@ -164,7 +164,8 @@ pub fn build(config: &Config) -> Result<()> {
                 ignore_filter(e, source, &config.ignore) &&
                 !template_extensions.contains(&e.path()
                     .extension()
-                    .unwrap_or(OsStr::new(""))) && !compare_paths(e.path(), dest)
+                    .unwrap_or_else(|| OsStr::new(""))) &&
+                !compare_paths(e.path(), dest)
             })
             .filter_map(|e| e.ok());
 
@@ -176,7 +177,7 @@ pub fn build(config: &Config) -> Result<()> {
             let relative = try!(entry_path.split(source_str)
                 .last()
                 .map(|s| s.trim_left_matches("/"))
-                .ok_or(format!("Empty path")));
+                .ok_or("Empty path"));
 
             if try!(entry.metadata()).is_dir() {
                 try!(fs::create_dir_all(&dest.join(relative)));

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,4 +1,4 @@
-#![cfg_attr(feature = "clippy", allow(redundant_closure))]
+#![cfg_attr(feature = "cargo-clippy", allow(redundant_closure))]
 use std::io;
 use yaml_rust::scanner;
 use walkdir;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,40 +1,12 @@
-// This library uses Clippy!
-#![cfg_attr(feature="clippy", feature(plugin))]
-#![cfg_attr(feature="clippy", plugin(clippy))]
-
 // Deny warnings, except in dev mode
 #![deny(warnings)]
 // #![deny(missing_docs)]
 #![cfg_attr(feature="dev", warn(warnings))]
 
-// Ignore clippy, except in dev mode
-#![cfg_attr(feature="clippy", allow(clippy))]
-#![cfg_attr(feature="dev", warn(clippy))]
-
-// Stuff we want clippy to fail on
-#![cfg_attr(feature="clippy", deny(
-        clone_on_copy,
-        cmp_owned,
-        explicit_iter_loop,
-        len_zero,
-        map_clone,
-        map_entry,
-        match_bool,
-        match_same_arms,
-        new_ret_no_self,
-        new_without_default,
-        needless_borrow,
-        needless_lifetimes,
-        needless_range_loop,
-        needless_return,
-        no_effect,
-        ok_expect,
-        out_of_bounds_indexing,
-        ptr_arg,
-        redundant_closure,
-        single_char_pattern,
-        unused_collect,
-        useless_vec,
+// Stuff we want clippy to ignore
+#![cfg_attr(feature="cargo-clippy", allow(
+        cyclomatic_complexity,
+        too_many_arguments,
         ))]
 
 extern crate liquid;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,7 +21,6 @@ extern crate regex;
 #[cfg(all(feature="syntax-highlight", not(windows)))]
 extern crate syntect;
 
-
 #[macro_use]
 extern crate log;
 

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -11,7 +11,8 @@ static EMPTY: &'static [&'static str] = &[];
 lazy_static! {
     static ref _CWD: PathBuf = env::current_dir().unwrap();
     static ref CWD: &'static Path = _CWD.as_path();
-    static ref _BIN: PathBuf = CWD.join("target/").join(env!("TARGET")).join("debug").join("cobalt");
+    static ref _BIN: PathBuf = CWD.join("target/")
+        .join(option_env!("TARGET").unwrap_or("")).join("debug").join("cobalt");
     static ref BIN: &'static str = _BIN.to_str().unwrap();
 }
 

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -11,7 +11,7 @@ static EMPTY: &'static [&'static str] = &[];
 lazy_static! {
     static ref _CWD: PathBuf = env::current_dir().unwrap();
     static ref CWD: &'static Path = _CWD.as_path();
-    static ref _BIN: PathBuf = CWD.join("target/debug/cobalt");
+    static ref _BIN: PathBuf = CWD.join("target/").join(env!("TARGET")).join("debug").join("cobalt");
     static ref BIN: &'static str = _BIN.to_str().unwrap();
 }
 
@@ -33,8 +33,7 @@ macro_rules! assert_contains_not {
 
 #[test]
 pub fn invalid_calls() {
-    env::set_current_dir(CWD.join("tests/fixtures/example")).unwrap();
-
+    println!("Binary: {:?}", BIN.to_owned());
     let output = assert_cli!(&BIN, EMPTY => Error 1).unwrap();
     assert_contains!(&output.stderr, "requires a subcommand");
 

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -11,8 +11,8 @@ static EMPTY: &'static [&'static str] = &[];
 lazy_static! {
     static ref _CWD: PathBuf = env::current_dir().unwrap();
     static ref CWD: &'static Path = _CWD.as_path();
-    static ref _BIN: PathBuf = CWD.join("target/")
-        .join(option_env!("TARGET").unwrap_or("")).join("debug").join("cobalt");
+    // TODO test on release
+    static ref _BIN: PathBuf = CWD.join("target/debug/cobalt");
     static ref BIN: &'static str = _BIN.to_str().unwrap();
 }
 

--- a/tests/fixtures/custom_paths/posts/all_date_variables.md
+++ b/tests/fixtures/custom_paths/posts/all_date_variables.md
@@ -1,7 +1,7 @@
 extends: posts.liquid
 
 title:  All date variables
-date:  3 May 2015 06:05:20 +0100
+date:  3 May 2015 01:05:20 +0100
 path:  /:year/:month/:i_month/:day/:i_day/:hour/:minute/:second/
 ---
 # {{ title }}

--- a/tests/fixtures/custom_paths/posts/custom-leading-slash.md
+++ b/tests/fixtures/custom_paths/posts/custom-leading-slash.md
@@ -1,6 +1,7 @@
 extends: posts.liquid
 
 title:  Custom paths with leading slash
+date:  3 May 2015 02:05:20 +0100
 path:  /test/thing2.html
 ---
 # {{ title }}

--- a/tests/fixtures/custom_paths/posts/custom.md
+++ b/tests/fixtures/custom_paths/posts/custom.md
@@ -1,6 +1,7 @@
 extends: posts.liquid
 
 title:  Custom paths
+date:  3 May 2015 03:05:20 +0100
 path:  test/thing.html
 ---
 # {{ title }}

--- a/tests/fixtures/custom_paths/posts/date_variables.md
+++ b/tests/fixtures/custom_paths/posts/date_variables.md
@@ -2,7 +2,7 @@ extends: posts.liquid
 
 title:  Date variables
 thing: hello
-date:  27 Oct 2015 14:00:00 +0100
+date:  3 May 2015 04:05:20 +0100
 path:  /:year/:thing/
 ---
 # {{ title }}

--- a/tests/fixtures/custom_paths/posts/explodes-urls-without-trailing-slash.md
+++ b/tests/fixtures/custom_paths/posts/explodes-urls-without-trailing-slash.md
@@ -1,6 +1,7 @@
 extends: posts.liquid
 
 title:  Boom without trailing slash
+date:  3 May 2015 05:05:20 +0100
 path:  test/thing4
 ---
 # {{ title }}

--- a/tests/fixtures/custom_paths/posts/explodes-urls.md
+++ b/tests/fixtures/custom_paths/posts/explodes-urls.md
@@ -1,6 +1,7 @@
 extends: posts.liquid
 
 title:  Boom
+date:  3 May 2015 06:05:20 +0100
 path:  test/thing3/
 ---
 # {{ title }}

--- a/tests/fixtures/custom_paths/posts/no-path.md
+++ b/tests/fixtures/custom_paths/posts/no-path.md
@@ -1,6 +1,7 @@
 extends: posts.liquid
 
 title:  Custom paths
+date:  3 May 2015 07:05:20 +0100
 ---
 # {{ title }}
 

--- a/tests/fixtures/custom_paths/posts/variables.md
+++ b/tests/fixtures/custom_paths/posts/variables.md
@@ -2,6 +2,7 @@ extends: posts.liquid
 
 title:  Variables
 thing: hello
+date:  3 May 2015 08:05:20 +0100
 path:  test/:thing/
 ---
 # {{ title }}

--- a/tests/fixtures/custom_paths/posts/variables_file.md
+++ b/tests/fixtures/custom_paths/posts/variables_file.md
@@ -3,6 +3,7 @@ extends: posts.liquid
 title:  Variables file name
 thing: hello
 thang: world
+date:  3 May 2015 09:05:20 +0100
 path:  test/:thing/:thang.abc
 ---
 # {{ title }}

--- a/tests/target/custom_paths/2015/05/5/03/3/01/05/20/index.html
+++ b/tests/target/custom_paths/2015/05/5/03/3/01/05/20/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
     <head>
-        <title>My blog - 2015/05/5/03/3/06/05/20/index.html</title>
+        <title>My blog - 2015/05/5/03/3/01/05/20/index.html</title>
     </head>
     <body>
         <h1>All date variables</h1>

--- a/tests/target/custom_paths/index.html
+++ b/tests/target/custom_paths/index.html
@@ -9,23 +9,23 @@
         This is my Index page!
 
 
- <a href="2015/hello/index.html">Date variables</a>
-
- <a href="2015/05/5/03/3/06/05/20/index.html">All date variables</a>
-
- <a href="test/thing2.html">Custom paths with leading slash</a>
-
- <a href="test/thing.html">Custom paths</a>
-
- <a href="test/thing4/index.html">Boom without trailing slash</a>
-
- <a href="test/thing3/index.html">Boom</a>
-
- <a href="posts/no-path.html">Custom paths</a>
+ <a href="test/hello/world.abc">Variables file name</a>
 
  <a href="test/hello/index.html">Variables</a>
 
- <a href="test/hello/world.abc">Variables file name</a>
+ <a href="posts/no-path.html">Custom paths</a>
+
+ <a href="test/thing3/index.html">Boom</a>
+
+ <a href="test/thing4/index.html">Boom without trailing slash</a>
+
+ <a href="2015/hello/index.html">Date variables</a>
+
+ <a href="test/thing.html">Custom paths</a>
+
+ <a href="test/thing2.html">Custom paths with leading slash</a>
+
+ <a href="2015/05/5/03/3/01/05/20/index.html">All date variables</a>
 
 
     </body>


### PR DESCRIPTION
This switches our CI to a system that

- [x] Automatically builds and uploads binaries for Linux, OSX and Windows that can be easily installed through a shell script
- [x] Downloads rustfmt binaries instead of installing them from source
- [x] Runs cargo-clippy which allows us to remove most clippy rules from our lib.rs and will keep us up-to date on clippy (it also makes it way easier to run clippy locally)
- [x] Fixes code coverage

The system is originally based on https://github.com/japaric/trust but I made some pretty big changes along the way, including throwing out cross for now. We can easily drop it in once we need support for more exotic compilation targets.

cc @nott @gnunicorn 