### PR TITLE
Fix coverage reporting

### DIFF
--- a/ci/coverage.sh
+++ b/ci/coverage.sh
@@ -12,6 +12,9 @@ main() {
   sudo make install
   cd ../..
 
+  cargo clean
+  cargo test --no-run
+
   ls target/debug
 
   # collect coverage


### PR DESCRIPTION
Somehow (caching?) there are multiple test binaries when running
coverage, so I'm adding a `cargo clean` to remove them.
Makes the whole thing slower, unfortunately