### PR TITLE
Don't cache files in target/debug (fixes #178)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 dist: trusty
+sudo: false
 language: rust
 
 rust: stable
@@ -45,7 +46,13 @@ script:
 before_deploy:
   - sh ci/before_deploy.sh
 
-cache: cargo
+cache:
+  apt: true
+  directories:
+    - $HOME/.cargo
+    - target/debug/deps
+    - target/debug/build
+
 before_cache:
     # Travis can't cache files that are not readable by "others"
     - chmod -R a+r $HOME/.cargo

--- a/ci/coverage.sh
+++ b/ci/coverage.sh
@@ -9,11 +9,7 @@ main() {
   cmake ..
   make
   make install DESTDIR=../tmp
-  sudo make install
   cd ../..
-
-  cargo clean
-  cargo test --no-run
 
   ls target/debug
 


### PR DESCRIPTION
This very likely solves the coverage problem without cleaning and rebuilding. I also added a sudo:false because I don't think we were running on container infrastructure by default 😅