### PR TITLE
Ref style links in excerpts

### DIFF
--- a/src/document.rs
+++ b/src/document.rs
@@ -297,12 +297,12 @@ impl Document {
         Ok(html.to_owned())
     }
 
-    /// Extracts references from markdown content.
-    pub fn extract_references(&self) -> String {
+    /// Extracts references iff markdown content.
+    pub fn extract_markdown_references(&self) -> String {
         let mut trail = String::new();
         let re = Regex::new(r"(?m:^ {0,3}\[[^\]]+\]:.+$)").unwrap();
 
-        if re.is_match(&self.content) {
+        if self.markdown && re.is_match(&self.content) {
             for mat in re.find_iter(&self.content) {
                 trail.push_str(&self.content[mat.0..mat.1]);
                 trail.push('\n');
@@ -332,7 +332,7 @@ impl Document {
             } else if excerpt_separator.is_empty() {
                 String::new()
             } else {
-                self.extract_references() +
+                self.extract_markdown_references() +
                 self.content
                     .split(excerpt_separator)
                     .next()

--- a/src/document.rs
+++ b/src/document.rs
@@ -330,7 +330,7 @@ impl Document {
             let excerpt = if let Some(excerpt_str) = excerpt_attr {
                 excerpt_str.to_string()
             } else if excerpt_separator.is_empty() {
-                String::new()
+                "".to_string()
             } else {
                 self.extract_markdown_references() +
                 self.content

--- a/tests/fixtures/excerpts/posts/post-10.md
+++ b/tests/fixtures/excerpts/posts/post-10.md
@@ -1,0 +1,12 @@
+extends: default.liquid
+
+title: Reference-style links immediately above first block
+date: 11 Feb 2017 04:50:21 -0000
+---
+
+[20]: /0
+ [21]: /1
+  [22]: /2
+   [23]: /3
+References are placed immediately above the first paragraph:
+[20][] [21][] [22][] [23][]

--- a/tests/fixtures/excerpts/posts/post-11.md
+++ b/tests/fixtures/excerpts/posts/post-11.md
@@ -1,0 +1,16 @@
+extends: default.liquid
+
+title: Reference-style links immediately below first block do not resolve
+date: 11 Feb 2017 04:51:34 -0000
+---
+
+References are placed immediately below the first paragraph:
+[30][] [31][] [32][] [33][]
+[30]: /0
+ [31]: /1
+  [32]: /2
+   [33]: /3
+
+Note that this is at it should be, as the markdown implementations I've tried
+(including CommonMark) do not render the above links (when the post is rendered
+individually).

--- a/tests/fixtures/excerpts/posts/post-12.liquid
+++ b/tests/fixtures/excerpts/posts/post-12.liquid
@@ -1,0 +1,14 @@
+extends: default.liquid
+
+title: Reference-style links in a non-markdown post do not resolve
+date: 11 Feb 2017 04:48:11 -0000
+---
+
+References are placed below the first paragraph, and are separated from the
+first paragraph by a single blank line:
+[40][] [41][] [42][] [43][]
+
+[40]: /0
+ [41]: /1
+  [42]: /2
+   [43]: /3

--- a/tests/fixtures/excerpts/posts/post-6.liquid
+++ b/tests/fixtures/excerpts/posts/post-6.liquid
@@ -1,6 +1,6 @@
 extends: default.liquid
 
-title: Implicit excepts work only in markdown
+title: Implicit excerpts work only in markdown
 date: 14 January 2016 21:05:30 -0500
 excerpt_separator: <!-- more -->
 ---

--- a/tests/fixtures/excerpts/posts/post-7.liquid
+++ b/tests/fixtures/excerpts/posts/post-7.liquid
@@ -1,6 +1,6 @@
 extends: default.liquid
 
-title: Explicit excepts work even in liquid
+title: Explicit excerpts work even in liquid
 date: 14 January 2016 21:06:30 -0500
 excerpt: <strong>explicit</strong> excerpt
 excerpt_separator: <!-- more -->

--- a/tests/fixtures/excerpts/posts/post-8.md
+++ b/tests/fixtures/excerpts/posts/post-8.md
@@ -1,0 +1,14 @@
+extends: default.liquid
+
+title: Reference-style links above first block and separated by blank line resolve
+date: 11 Feb 2017 04:45:01 -0000
+---
+
+[00]: /0
+ [01]: /1
+  [02]: /2
+   [03]: /3
+
+References-style links are placed above the first paragraph, and are separated
+from the first paragraph by a single blank line:
+[00][] [01][] [02][] [03][]

--- a/tests/fixtures/excerpts/posts/post-9.md
+++ b/tests/fixtures/excerpts/posts/post-9.md
@@ -1,0 +1,14 @@
+extends: default.liquid
+
+title: Reference-style links below first block and separated by blank line resolve
+date: 11 Feb 2017 04:48:11 -0000
+---
+
+References are placed below the first paragraph, and are separated from the
+first paragraph by a single blank line:
+[10][] [11][] [12][] [13][]
+
+[10]: /0
+ [11]: /1
+  [12]: /2
+   [13]: /3

--- a/tests/target/excerpts/index.html
+++ b/tests/target/excerpts/index.html
@@ -34,6 +34,14 @@
       </div>
     
       <div>
+        <h4>Reference-style links in a non-markdown post do not resolve</h4>
+        <h4><a href="posts/post-12.html">Reference-style links in a non-markdown post do not resolve</a></h4>
+        References are placed below the first paragraph, and are separated from the
+first paragraph by a single blank line:
+[40][] [41][] [42][] [43][]
+      </div>
+    
+      <div>
         <h4>Reference-style links below first block and separated by blank line resolve</h4>
         <h4><a href="posts/post-9.html">Reference-style links below first block and separated by blank line resolve</a></h4>
         <p>References are placed below the first paragraph, and are separated from the

--- a/tests/target/excerpts/index.html
+++ b/tests/target/excerpts/index.html
@@ -61,8 +61,6 @@ first paragraph by a single blank line:
 
 <p>Welcome to the 6th post on cobalt.rs!</p>
 
-
-
       </div>
     
       <div>

--- a/tests/target/excerpts/index.html
+++ b/tests/target/excerpts/index.html
@@ -49,14 +49,14 @@ first paragraph by a single blank line:
       </div>
     
       <div>
-        <h4>Explicit excepts work even in liquid</h4>
-        <h4><a href="posts/post-7.html">Explicit excepts work even in liquid</a></h4>
+        <h4>Explicit excerpts work even in liquid</h4>
+        <h4><a href="posts/post-7.html">Explicit excerpts work even in liquid</a></h4>
         <strong>explicit</strong> excerpt
       </div>
     
       <div>
-        <h4>Implicit excepts work only in markdown</h4>
-        <h4><a href="posts/post-6.html">Implicit excepts work only in markdown</a></h4>
+        <h4>Implicit excerpts work only in markdown</h4>
+        <h4><a href="posts/post-6.html">Implicit excerpts work only in markdown</a></h4>
         <h1>Custom excerpt separator</h1>
 
 <p>Welcome to the 6th post on cobalt.rs!</p>

--- a/tests/target/excerpts/index.html
+++ b/tests/target/excerpts/index.html
@@ -14,6 +14,41 @@
   <div>
     
       <div>
+        <h4>Reference-style links immediately below first block do not resolve</h4>
+        <h4><a href="posts/post-11.html">Reference-style links immediately below first block do not resolve</a></h4>
+        <p>References are placed immediately below the first paragraph:
+<a href="/0">30</a> <a href="/1">31</a> <a href="/2">32</a> <a href="/3">33</a>
+<a href="/0">30</a>: /0
+<a href="/1">31</a>: /1
+<a href="/2">32</a>: /2
+<a href="/3">33</a>: /3</p>
+
+      </div>
+    
+      <div>
+        <h4>Reference-style links immediately above first block</h4>
+        <h4><a href="posts/post-10.html">Reference-style links immediately above first block</a></h4>
+        <p>References are placed immediately above the first paragraph:
+<a href="/0">20</a> <a href="/1">21</a> <a href="/2">22</a> <a href="/3">23</a></p>
+
+      </div>
+    
+      <div>
+        <h4>Reference-style links below first block and separated by blank line resolve</h4>
+        <h4><a href="posts/post-9.html">Reference-style links below first block and separated by blank line resolve</a></h4>
+        <p>References are placed below the first paragraph, and are separated from the
+first paragraph by a single blank line:
+<a href="/0">10</a> <a href="/1">11</a> <a href="/2">12</a> <a href="/3">13</a></p>
+
+      </div>
+    
+      <div>
+        <h4>Reference-style links above first block and separated by blank line resolve</h4>
+        <h4><a href="posts/post-8.html">Reference-style links above first block and separated by blank line resolve</a></h4>
+        
+      </div>
+    
+      <div>
         <h4>Explicit excepts work even in liquid</h4>
         <h4><a href="posts/post-7.html">Explicit excepts work even in liquid</a></h4>
         <strong>explicit</strong> excerpt
@@ -25,6 +60,8 @@
         <h1>Custom excerpt separator</h1>
 
 <p>Welcome to the 6th post on cobalt.rs!</p>
+
+
 
       </div>
     

--- a/tests/target/excerpts/posts/post-10.html
+++ b/tests/target/excerpts/posts/post-10.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        
+          <title>Reference-style links immediately above first block</title>
+        
+    </head>
+    <body>
+    <div>
+      
+        <div>
+  <h2>Reference-style links immediately above first block</h2>
+  <p>
+    <p>References are placed immediately above the first paragraph:
+<a href="/0">20</a> <a href="/1">21</a> <a href="/2">22</a> <a href="/3">23</a></p>
+
+  </p>
+</div>
+
+      
+    </div>
+  </body>
+</html>

--- a/tests/target/excerpts/posts/post-11.html
+++ b/tests/target/excerpts/posts/post-11.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        
+          <title>Reference-style links immediately below first block do not resolve</title>
+        
+    </head>
+    <body>
+    <div>
+      
+        <div>
+  <h2>Reference-style links immediately below first block do not resolve</h2>
+  <p>
+    <p>References are placed immediately below the first paragraph:
+[30][] [31][] [32][] [33][]
+[30]: /0
+[31]: /1
+[32]: /2
+[33]: /3</p>
+<p>Note that this is at it should be, as the markdown implementations I've tried
+(including CommonMark) do not render the above links (when the post is rendered
+individually).</p>
+
+  </p>
+</div>
+
+      
+    </div>
+  </body>
+</html>

--- a/tests/target/excerpts/posts/post-12.html
+++ b/tests/target/excerpts/posts/post-12.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        
+          <title>Reference-style links in a non-markdown post do not resolve</title>
+        
+    </head>
+    <body>
+    <div>
+      
+        <div>
+  <h2>Reference-style links in a non-markdown post do not resolve</h2>
+  <p>
+    References are placed below the first paragraph, and are separated from the
+first paragraph by a single blank line:
+[40][] [41][] [42][] [43][]
+
+[40]: /0
+ [41]: /1
+  [42]: /2
+   [43]: /3
+
+  </p>
+</div>
+
+      
+    </div>
+  </body>
+</html>

--- a/tests/target/excerpts/posts/post-6.html
+++ b/tests/target/excerpts/posts/post-6.html
@@ -2,14 +2,14 @@
 <html>
     <head>
         
-          <title>Implicit excepts work only in markdown</title>
+          <title>Implicit excerpts work only in markdown</title>
         
     </head>
     <body>
     <div>
       
         <div>
-  <h2>Implicit excepts work only in markdown</h2>
+  <h2>Implicit excerpts work only in markdown</h2>
   <p>
     <h1>Custom excerpt separator</h1>
 

--- a/tests/target/excerpts/posts/post-7.html
+++ b/tests/target/excerpts/posts/post-7.html
@@ -2,14 +2,14 @@
 <html>
     <head>
         
-          <title>Explicit excepts work even in liquid</title>
+          <title>Explicit excerpts work even in liquid</title>
         
     </head>
     <body>
     <div>
       
         <div>
-  <h2>Explicit excepts work even in liquid</h2>
+  <h2>Explicit excerpts work even in liquid</h2>
   <p>
     <h1>Custom excerpt separator</h1>
 

--- a/tests/target/excerpts/posts/post-8.html
+++ b/tests/target/excerpts/posts/post-8.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        
+          <title>Reference-style links above first block and separated by blank line resolve</title>
+        
+    </head>
+    <body>
+    <div>
+      
+        <div>
+  <h2>Reference-style links above first block and separated by blank line resolve</h2>
+  <p>
+    <p>References-style links are placed above the first paragraph, and are separated
+from the first paragraph by a single blank line:
+<a href="/0">00</a> <a href="/1">01</a> <a href="/2">02</a> <a href="/3">03</a></p>
+
+  </p>
+</div>
+
+      
+    </div>
+  </body>
+</html>

--- a/tests/target/excerpts/posts/post-9.html
+++ b/tests/target/excerpts/posts/post-9.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        
+          <title>Reference-style links below first block and separated by blank line resolve</title>
+        
+    </head>
+    <body>
+    <div>
+      
+        <div>
+  <h2>Reference-style links below first block and separated by blank line resolve</h2>
+  <p>
+    <p>References are placed below the first paragraph, and are separated from the
+first paragraph by a single blank line:
+<a href="/0">10</a> <a href="/1">11</a> <a href="/2">12</a> <a href="/3">13</a></p>
+
+  </p>
+</div>
+
+      
+    </div>
+  </body>
+</html>


### PR DESCRIPTION
This should address issue #186: feedback requested, as I'm still learning Rust.

I used the [regex from Jekyll](https://github.com/jekyll/jekyll/blob/master/lib/jekyll/excerpt.rb#L120) to match the reference-style links.

Also, instead of creating a new set of tests, I added the tests to the existing excerpts test set: let me know if that's the preferred method.