### PR TITLE
feat(attributes): Add input-file based attributes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,7 @@ dependencies = [
  "ghp 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.9.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "itertools 0.5.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "liquid 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -208,6 +209,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "either"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "env_logger"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -337,6 +343,14 @@ version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.2.20 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "itertools"
+version = "0.5.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "either 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -899,6 +913,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum cookie 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "0e3d6405328b6edb412158b3b7710e2634e23f3614b9bb1c412df7952489a626"
 "checksum dbghelp-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "97590ba53bcb8ac28279161ca943a924d1fd4a8fb3fa63302591647c4fc5b850"
 "checksum difference 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ffef4c144e881a906ed5bd6e1e749dc1955cd3f0c7969d3d34122a971981c5ea"
+"checksum either 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "63f94a35a9ca0d4178e85f0250373f2cea55c5d603e6993778d68a99b3d8071c"
 "checksum env_logger 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "15abd780e45b3ea4f76b4e9a26ff4843258dd8a3eed2775a0e7368c2e7936c2f"
 "checksum error-chain 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bd5c82c815138e278b8dcdeffc49f27ea6ffb528403e9dea4194f2e3dd40b143"
 "checksum filetime 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "5363ab8e4139b8568a6237db5248646e5a8a2f89bd5ccb02092182b11fd3e922"
@@ -915,6 +930,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum hyper 0.9.14 (registry+https://github.com/rust-lang/crates.io-index)" = "bcb3fc65554155980167fb821d05c7c66177f92464976c0b676a19d9e03387a7"
 "checksum idna 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1053236e00ce4f668aeca4a769a09b3bf5a682d802abd6f3cb39374f6b162c11"
 "checksum inotify 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "e8458c07bdbdaf309c80e2c3304d14c3db64e7465d4f07cf589ccb83fd0ff31a"
+"checksum itertools 0.5.9 (registry+https://github.com/rust-lang/crates.io-index)" = "d95557e7ba6b71377b0f2c3b3ae96c53f1b75a926a6901a500f557a370af730a"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
 "checksum language-tags 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a91d884b6667cd606bb5a69aa0c99ba811a115fc68915e7056ec08a46e93199a"
 "checksum lazy_static 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6abe0ee2e758cd6bc8a2cd56726359007748fbf4128da998b65d0b70f881e19b"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ glob = "0.2.11"
 regex = "0.1"
 clippy = {version = "0.0", optional = true}
 error-chain = "0.5.0"
-lazy_static = {version = "0.2", optional =true}
+lazy_static = "0.2"
 itertools = "0.5.9"
 
 [dependencies.hyper]
@@ -55,5 +55,5 @@ default = []
 unstable = []
 dev = []
 
-syntax-highlight = ["syntect", "lazy_static"]
+syntax-highlight = ["syntect"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ regex = "0.1"
 clippy = {version = "0.0", optional = true}
 error-chain = "0.5.0"
 lazy_static = {version = "0.2", optional =true}
+itertools = "0.5.9"
 
 [dependencies.hyper]
 version = "0.9"

--- a/src/document.rs
+++ b/src/document.rs
@@ -20,7 +20,8 @@ use pulldown_cmark as cmark;
 use liquid;
 
 lazy_static!{
-    static ref DATE_VARIABLES: Regex = Regex::new(":(year|month|i_month|day|i_day|short_year|hour|minute|second)").unwrap();
+    static ref DATE_VARIABLES: Regex =
+        Regex::new(":(year|month|i_month|day|i_day|short_year|hour|minute|second)").unwrap();
     static ref SLUG_INVALID_CHARS: Regex = Regex::new(r"([^a-zA-Z0-9]+)").unwrap();
     static ref FRONT_MATTER_DIVIDE: Regex = Regex::new(r"---\s*\r?\n").unwrap();
     static ref MARKDOWN_REF: Regex = Regex::new(r"(?m:^ {0,3}\[[^\]]+\]:.+$)").unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,6 +18,8 @@ extern crate rss;
 extern crate glob;
 extern crate regex;
 
+extern crate itertools;
+
 #[cfg(all(feature="syntax-highlight", not(windows)))]
 extern crate syntect;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,6 +44,5 @@ mod new;
 #[cfg(feature="syntax-highlight")]
 mod syntax_highlight;
 
-#[cfg(feature="syntax-highlight")]
 #[macro_use]
 extern crate lazy_static;


### PR DESCRIPTION
Add document attributes "title", "slug", and "ext" if needed based on the
input-file.

The primary motivation for this change is to allow a custom "path" while
retaining the original :slug. A more surgical approach was taken rather
than trying to achieve 100% Jekyll-compatibility though Jekyll does serve
as an inspiration for how these features work.

The "slug" attribute defaults to a lower-case slugified version of the
document's filename.  The primary use is for specifying a custom "path"
attribute that still includes the original file name (via :slug).

Jekyll compatibility:
- Precedence: Allows a user to override "slug" in their front matter.
- Template variable for path: The default slug attempts to be formatted
  like Jekyll
Jekyll incompatibility:
- General: Jekyll excludes "YYYY-MM-DD-" from the slug. Cobalt would need
  additional work done to make "date" more Jekyll compatible before this
  is worth implementing.
- Template variable for path: An overridden slug is not slugified in
  Cobalt. This is in part for simplicity and in part trusting the user.
- Attribute: Jekyll does not sluggify the attribute but instead expects
  the user to slugify it with a filter.

The "title" attribute is now defaulted to a title-cased, slugified version
of the document's filename. The primary use is to minimize user's having
to repeat themselves in their liquid document.

Jekyll compatibility:
- Precedence: Allows a user to override "title" in their front matter.
  Does not use the overridden "slug" attribute if provided.
Jekyll incompatibility:
- General: Jekyll excludes "YYYY-MM-DD-" from the title.
- Template variable for path: :title is supposed to be a "pretty" mixed
  case version of :slug
- Attribute: Jekyll does not slugify the file name before title-casing it.

The "ext" attribute defaults to the file extension of the liquid document
("md", "liquid", etc)

Jekyll compatibility:
- Precedence: Allows a user to override "ext" in their front matter.
Jekyll incompatibility:
- Attribute: Jekyll includes the ".".

The :name template variable for path (slugified file_stem, not overriding
allowed) was also going to be added but for some reason it caused a test
to fail. Since it wasn't needed for the primary purpose of this change, it
was skipped rather than time being spent on investigating the failure.