### PR TITLE
Add support for YAML->Liquid conversion of dicts

### DIFF
--- a/src/document.rs
+++ b/src/document.rs
@@ -1,5 +1,5 @@
 use std::fs::File;
-use std::collections::HashMap;
+use std::collections::{HashMap, BTreeMap};
 use std::collections::hash_map::Entry;
 use std::ffi::OsStr;
 use std::path::{Path, PathBuf};
@@ -39,6 +39,19 @@ fn read_file<P: AsRef<Path>>(path: P) -> Result<String> {
     Ok(text)
 }
 
+fn yaml_btreemap_to_hashmap(input: &BTreeMap<Yaml, Yaml>) -> HashMap<String, Value> {
+    let mut result = HashMap::new();
+    for (yaml_key, yaml_value) in input {
+        if let Yaml::String(ref s) = *yaml_key {
+            let liquid_value = yaml_to_liquid(yaml_value).expect("Value must be liquid data");
+            result.insert(s.to_owned(), liquid_value);
+        } else {
+            panic!("Key in yaml dictionary must be string");
+        }
+    }
+    result
+}
+
 fn yaml_to_liquid(yaml: &Yaml) -> Option<Value> {
     match *yaml {
         Yaml::Real(ref s) |
@@ -46,8 +59,48 @@ fn yaml_to_liquid(yaml: &Yaml) -> Option<Value> {
         Yaml::Integer(i) => Some(Value::Num(i as f32)),
         Yaml::Boolean(b) => Some(Value::Bool(b)),
         Yaml::Array(ref a) => Some(Value::Array(a.iter().filter_map(yaml_to_liquid).collect())),
+        Yaml::Hash(ref dict) => Some(Value::Object(yaml_btreemap_to_hashmap(dict))),
         Yaml::BadValue | Yaml::Null => None,
         _ => panic!("Not implemented yet"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::{HashMap, BTreeMap};
+    use yaml_rust as yaml;
+    use liquid;
+
+    #[test]
+    fn test_yaml_to_liquid() {
+        let key_str = "key".to_owned();
+        let input = {
+            let mut temp = BTreeMap::new();
+            temp.insert(yaml::Yaml::String(key_str.clone()), yaml::Yaml::Integer(42));
+            yaml::Yaml::Hash(temp)
+        };
+        let expected = {
+            let mut temp = HashMap::new();
+            temp.insert(key_str.clone(), liquid::Value::Num(42.0));
+            Some(liquid::Value::Object(temp))
+        };
+        assert_eq!(super::yaml_to_liquid(&input), expected);
+    }
+
+    #[test]
+    fn test_dictionary_conversion() {
+        let key_str = "key".to_owned();
+        let input = {
+            let mut temp = BTreeMap::new();
+            temp.insert(yaml::Yaml::String(key_str.clone()), yaml::Yaml::Integer(42));
+            temp
+        };
+        let expected = {
+            let mut temp = HashMap::new();
+            temp.insert(key_str.clone(), liquid::Value::Num(42.0));
+            temp
+        };
+        assert_eq!(super::yaml_btreemap_to_hashmap(&input), expected);
     }
 }
 

--- a/tests/fixtures/yaml_dicts/_layouts/index.liquid
+++ b/tests/fixtures/yaml_dicts/_layouts/index.liquid
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>My blog - {{ title }}</title>
+</head>
+<body>
+{{ content }}</body>
+</html>

--- a/tests/fixtures/yaml_dicts/index.md
+++ b/tests/fixtures/yaml_dicts/index.md
@@ -1,0 +1,14 @@
+extends: index.liquid
+
+title:   My first Blogpost
+date:    24/08/2014 at 15:36
+some-data:
+  - nested:
+      dicts: Works
+  - nested:
+      dicts: just fine
+---
+# {{ title }}
+{% for entry in some-data %}
+## {{ entry.nested.dicts }}
+{% endfor %}

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -200,3 +200,8 @@ pub fn excerpts() {
 pub fn posts_in_subfolder() {
     run_test("posts_in_subfolder").unwrap();
 }
+
+#[test]
+pub fn yaml_dicts() {
+    run_test("yaml_dicts").unwrap();
+}

--- a/tests/target/yaml_dicts/index.html
+++ b/tests/target/yaml_dicts/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>My blog - My first Blogpost</title>
+</head>
+<body>
+<h1>My first Blogpost</h1>
+<h2>Works</h2>
+<h2>just fine</h2>
+</body>
+</html>


### PR DESCRIPTION
YAML dictionaries are BTreeMap<yaml::Yaml::Value, yaml::Yaml::Value> 
and Liquid dictionaries are HashMap<String, liquid::Value>.

This commit adds support for converting from the yaml definition to
the liquid definition of a dictionary data type.