### PR TITLE
Win path fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,6 +1,6 @@
 [root]
 name = "cobalt-bin"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "assert_cli 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.2.25 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/src/cobalt.rs
+++ b/src/cobalt.rs
@@ -1,7 +1,7 @@
 use std::fs::{self, File};
 use std::collections::HashMap;
 use std::io::Write;
-use std::path::Path;
+use std::path::{self, Path};
 use std::ffi::OsStr;
 use liquid::Value;
 use walkdir::{WalkDir, DirEntry, WalkDirIterator};
@@ -188,7 +188,7 @@ pub fn build(config: &Config) -> Result<()> {
             } else {
                 try!(entry_path.split(source_str)
                     .last()
-                    .map(|s| s.trim_left_matches("/"))
+                    .map(|s| s.trim_left_matches(path::MAIN_SEPARATOR))
                     .ok_or("Empty path"))
             };
 


### PR DESCRIPTION
This PR fixes #194 : use the system dependent path separator instead of hard `"/"`.
I've also updated Cargo.lock for 0.6.0, but in the separate commit.