### PR TITLE
First take on categories, has to be used togehter with a liquid-rust patch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 /target
-/build
+build
 
 .DS_Store
 *.rs.bk

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,7 +13,7 @@ dependencies = [
  "glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.9.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "liquid 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "liquid 0.9.1",
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "notify 2.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "pulldown-cmark 0.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -39,6 +39,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "aho-corasick"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "memchr 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "ansi_term"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -61,6 +69,20 @@ dependencies = [
 [[package]]
 name = "backtrace"
 version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "backtrace-sys 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "dbghelp-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.20 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-demangle 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "backtrace"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "backtrace-sys 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -365,12 +387,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "liquid"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+version = "0.9.1"
 dependencies = [
+ "backtrace 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.2.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 0.1.80 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "skeptic 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -387,6 +409,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "memchr"
 version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.20 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "memchr"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.2.20 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -607,6 +637,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "aho-corasick 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex-syntax 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thread_local 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "utf8-ranges 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "regex-syntax"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -748,11 +790,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread-id"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.20 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "thread_local"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "thread-id 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "thread_local"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "thread-id 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unreachable 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -816,6 +876,14 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "unreachable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "url"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -830,8 +898,18 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "utf8-ranges"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "vec_map"
 version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "void"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -878,10 +956,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [metadata]
 "checksum RustyXML 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "9222d58bccd9e6e3b82098a2ec142ad34e5d433de986d46cec03ad3a2b5fd529"
 "checksum aho-corasick 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ca972c2ea5f742bfce5687b9aef75506a764f61d37f8f649047846a9686ddb66"
+"checksum aho-corasick 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "0638fd549427caa90c499814196d1b9e3725eb4d15d7339d6de073a680ed0ca2"
 "checksum ansi_term 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ae206c860259479b73b3abc98b66da811843056ed570ed79eb95d3d9b2524325"
 "checksum ansi_term 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "23ac7c30002a5accbf7e8987d0632fa6de155b7c3d39d0067317a391e00a2ef6"
 "checksum assert_cli 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "240645c6effe2439d5b08204b1999afddd0c003b851b12cc378c115737cc3f38"
 "checksum backtrace 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "346d7644f0b5f9bc73082d3b2236b69a05fd35cce0cfa3724e184e6a5c9e2a2f"
+"checksum backtrace 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f551bc2ddd53aea015d453ef0b635af89444afa5ed2405dd0b2062ad5d600d80"
 "checksum backtrace-sys 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "3602e8d8c43336088a8505fa55cae2b3884a9be29440863a11528a42f46f6bb7"
 "checksum bincode 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "55eb0b7fd108527b0c77860f75eca70214e11a8b4c6ef05148c54c05a25d48ad"
 "checksum bitflags 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8dead7461c1127cf637931a1e50934eb6eee8bff2f74433ac7909e9afcee04a3"
@@ -919,10 +999,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum language-tags 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a91d884b6667cd606bb5a69aa0c99ba811a115fc68915e7056ec08a46e93199a"
 "checksum lazy_static 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6abe0ee2e758cd6bc8a2cd56726359007748fbf4128da998b65d0b70f881e19b"
 "checksum libc 0.2.20 (registry+https://github.com/rust-lang/crates.io-index)" = "684f330624d8c3784fb9558ca46c4ce488073a8d22450415c5eb4f4cfb0d11b5"
-"checksum liquid 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "30fa97aebc7f3e872621ea83225b95f011ece8fca473fc3cd6a608f24a594010"
 "checksum log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "ab83497bf8bf4ed2a74259c1c802351fcd67a65baa86394b6ba73c36f4838054"
 "checksum matches 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "efd7622e3022e1a6eaa602c4cea8912254e5582c9c692e9167714182244801b1"
 "checksum memchr 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)" = "d8b629fb514376c675b98c1421e80b151d3817ac42d7c667717d282761418d20"
+"checksum memchr 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "1dbccc0e46f1ea47b9f17e6d67c5a96bd27030519c519c9c91327e31275a47b4"
 "checksum mime 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "b5c93a4bd787ddc6e7833c519b73a50883deb5863d76d9b71eb8216fb7f94e66"
 "checksum miniz-sys 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "9d1f4d337a01c32e1f2122510fed46393d53ca35a7f429cb0450abaedfa3ed54"
 "checksum mio 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a637d1ca14eacae06296a008fa7ad955347e34efcb5891cfd8ba05491a37907e"
@@ -946,6 +1026,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum rand 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)" = "022e0636ec2519ddae48154b028864bdce4eaf7d35226ab8e65c611be97b189d"
 "checksum redox_syscall 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "8dd35cc9a8bdec562c757e3d43c1526b5c6d2653e23e2315065bc25556550753"
 "checksum regex 0.1.80 (registry+https://github.com/rust-lang/crates.io-index)" = "4fd4ace6a8cf7860714a2c2280d6c1f7e6a413486c13298bbc86fd3da019402f"
+"checksum regex 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4278c17d0f6d62dfef0ab00028feb45bd7d2102843f80763474eeb1be8a10c01"
 "checksum regex-syntax 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "f9ec002c35e86791825ed294b50008eea9ddfc8def4420124fbc6b08db834957"
 "checksum regex-syntax 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2f9191b1f57603095f105d317e375d19b1c9c5c3185ea9633a99a6dcbed04457"
 "checksum rss 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "681e6d04b914d82ad3270c032d8756331e80e048f6a2bc7ae5db4cfdf042b9d2"
@@ -965,7 +1046,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum tempdir 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "87974a6f5c1dfb344d733055601650059a3363de2a6104819293baff662132d6"
 "checksum term_size 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3f7f5f3f71b0040cecc71af239414c23fd3c73570f5ff54cf50e03cef637f2a0"
 "checksum thread-id 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a9539db560102d1cef46b8b78ce737ff0bb64e7e18d35b2a5688f7d097d0ff03"
+"checksum thread-id 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4437c97558c70d129e40629a5b385b3fb1ffac301e63941335e4d354081ec14a"
 "checksum thread_local 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "8576dbbfcaef9641452d5cf0df9b0e7eeab7694956dd33bb61515fb8f18cfdd5"
+"checksum thread_local 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7793b722f0f77ce716e7f1acf416359ca32ff24d04ffbac4269f44a4a83be05d"
 "checksum time 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)" = "211b63c112206356ef1ff9b19355f43740fc3f85960c598a93d3a3d3ba7beade"
 "checksum toml 0.1.30 (registry+https://github.com/rust-lang/crates.io-index)" = "0590d72182e50e879c4da3b11c6488dae18fccb1ae0c7a3eda18e16795844796"
 "checksum traitobject 0.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "07eaeb7689bb7fca7ce15628319635758eda769fed481ecfe6686ddef2600616"
@@ -975,9 +1058,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum unicode-normalization 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "5e94e9f6961090fcc75180629c4ef33e5310d6ed2c0dd173f4ca63c9043b669e"
 "checksum unicode-segmentation 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "c3bc443ded17b11305ffffe6b37e2076f328a5a8cb6aa877b1b98f77699e98b5"
 "checksum unicode-width 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "bf3a113775714a22dcb774d8ea3655c53a32debae63a063acc00a91cc586245f"
+"checksum unreachable 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "1f2ae5ddb18e1c92664717616dd9549dde73f539f01bd7b77c2edb2446bdff91"
 "checksum url 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "cbcb1997952b5a73b438a90940834621a8002e59640a8d92a1c05ef8fa58a1da"
 "checksum utf8-ranges 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a1ca13c08c41c9c3e04224ed9ff80461d97e121589ff27c753a16cb10830ae0f"
+"checksum utf8-ranges 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "662fab6525a98beff2921d7f61a39e7d59e0b425ebc7d0d9e66d316e55124122"
 "checksum vec_map 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "cac5efe5cb0fa14ec2f84f83c701c562ee63f6dcc680861b21d65c682adfb05f"
+"checksum void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 "checksum walkdir 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "c66c0b9792f0a765345452775f3adbd28dde9d33f30d13e5dcc5ae17cf6f3780"
 "checksum winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
 "checksum winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,9 +18,11 @@ doc = false
 
 [dependencies]
 clap = "2.4.0"
-liquid = "0.9"
+liquid = { version = "0.9", path = "/Users/uwe/repo/liquid-rust" } 
 walkdir = "0.1"
 yaml-rust = "0.3"
+# doesn't work
+# yaml-rust = { version = "0.3", features = ["preserve_order"] }
 chrono = "0.2"
 log = "0.3"
 env_logger = "0.3"

--- a/src/config.rs
+++ b/src/config.rs
@@ -5,6 +5,7 @@ use std::io::Read;
 use glob::Pattern;
 use error::Result;
 use yaml_rust::YamlLoader;
+use std::collections::HashMap;
 
 #[derive(Debug, PartialEq)]
 pub struct Config {
@@ -22,6 +23,8 @@ pub struct Config {
     pub link: Option<String>,
     pub ignore: Vec<Pattern>,
     pub excerpt_separator: String,
+    pub categories: HashMap<String, Vec<String>>,
+    pub categories_flat: Vec<String>,
 }
 
 impl Default for Config {
@@ -41,6 +44,8 @@ impl Default for Config {
             link: None,
             ignore: vec![],
             excerpt_separator: "\n\n".to_owned(),
+            categories: HashMap::new(),
+            categories_flat: vec![],
         }
     }
 }
@@ -115,9 +120,31 @@ impl Config {
             config.excerpt_separator = excerpt_separator.to_owned();
         };
 
+        if let Some(categories) = yaml["categories"].as_vec() {
+            for cat in categories {
+                let d = cat.as_hash();
+                for x in d {
+                    for (g, h) in x {
+                        config.categories_flat.push(g.as_str().unwrap().to_string());
+                        let mut subcat = Vec::new();
+                        for w in h.as_vec().unwrap() {
+                            config.categories_flat.push(w.as_str().unwrap().to_string());
+                            subcat.push(w.as_str().unwrap().to_string());
+                        }
+                        config.categories.insert(g.as_str().unwrap().to_string(), subcat);
+                    }
+                }
+            }
+        };
+
         Ok(config)
     }
+
+    /*pub fn as_liquid() -> Vec::<Value> {
+        Vec::<Value>::new();
+    }*/
 }
+
 
 #[test]
 fn test_from_file_ok() {

--- a/src/document.rs
+++ b/src/document.rs
@@ -248,9 +248,10 @@ impl Document {
     }
 
     /// Prepares liquid context for further rendering.
-    pub fn get_render_context(&self, posts: &[Value]) -> Context {
+    pub fn get_render_context(&self, posts: &[Value], site: &[Value]) -> Context {
         let mut context = Context::with_values(self.attributes.clone());
         context.set_val("posts", Value::Array(posts.to_vec()));
+        context.set_val("site", Value::Array(site.to_vec()));
         context
     }
 

--- a/tests/fixtures/posts_in_subfolder/.cobalt.yml
+++ b/tests/fixtures/posts_in_subfolder/.cobalt.yml
@@ -1,4 +1,13 @@
 name: cobalt blog testing posts in subfolders
+description: and also categories
+link: http://posts-in-subfolders.cobalt.rs/
+
+categories: [ CatA : [],
+              CatB : [ SubCatC, SubCatD ],
+              CatE : [ SubCatF ]]
+
+excerpt_separator: <!-- more -->
+ 
 source: "."
 dest: "build"
 ignore:

--- a/tests/fixtures/posts_in_subfolder/categories.liquid
+++ b/tests/fixtures/posts_in_subfolder/categories.liquid
@@ -1,0 +1,58 @@
+extends: default.liquid
+
+title: All Blog posts after Categories
+---
+
+<div>
+  <h3>print some site values</h3>
+  <b>site.name:</b> {{ site.name }}<br/>
+  <b>site.description:</b> {{ site.description }}<br/>
+  <b>site.link:</b> {{ site.link }}<br/>
+  <b>site.excerpt_separator:</b>
+    {{ site.excerpt_separator | replace: "<", "&lt;" | replace: ">", "&gt;" }} <br/>
+</div>
+
+<div>
+  <h3>print categories with posts</h3>
+    <!-- check if there are categories in config -->
+    {%if site.categories %}
+      <!-- run over categories -->
+      {% for category in site.categories %}
+        <h4>{{ category.name }}</h4>
+        <!-- run over posts -->
+        {% if category.posts %}
+          Posts in this category<br/>
+          {% for post in category.posts %}
+            {{ post.date | date: "%d.%m.%Y" }} | {{ post.title }}<br/>
+          {% endfor %}
+        {% endif %}
+        <!-- run over subcategories -->
+        {% if category.subcategories %}
+          {% for subcategory in category.subcategories %}
+            <h5>{{ subcategory.name }}</h5>
+            <!-- run over posts -->
+            {% if subcategory.posts %}
+              Posts in this subcategory<br/>
+              {% for post in subcategory.posts %}
+                {{ post.date | date: "%d.%m.%Y" }} | {{ post.title }}<br/>
+              {% endfor %}
+            {% endif %}
+          {% endfor %}
+        {% endif %}
+      {% endfor %}
+    {% endif %}
+</div>
+
+<div>
+  <h3>print post list with categories</h3>
+  {% for post in posts %}
+    <p>
+      {{ post.date | date: "%d.%m.%Y" }} | {{ post.title }}<br/>
+      {% if post.categories %}
+        {% for category in post.categories %}
+         {{ category }} <br/>
+        {% endfor %}
+      {% endif %}
+    </p>
+  {% endfor %}
+</div>

--- a/tests/fixtures/posts_in_subfolder/posts/2017/01/05/post.md
+++ b/tests/fixtures/posts_in_subfolder/posts/2017/01/05/post.md
@@ -1,7 +1,9 @@
 extends: default.liquid
 
-title: a post inside posts/2017/01/05/
+title: a post inside folder posts/2017/01/05/
 date: 05 Jan 2017 21:00:00 -0000
+
+categories: [CatE, SubCatC]
 ---
 
 # a post inside posts/2017/01/05/

--- a/tests/fixtures/posts_in_subfolder/posts/2017/01/08/post.md
+++ b/tests/fixtures/posts_in_subfolder/posts/2017/01/08/post.md
@@ -1,7 +1,9 @@
 extends: default.liquid
 
-title: a post inside posts/2017/01/08/
+title: a post inside folder posts/2017/01/08/
 date: 08 Jan 2017 21:00:00 -0000
+
+categories: [SubCatD, SubCatF]
 ---
 
 # a post inside posts/2017/01/08/

--- a/tests/fixtures/posts_in_subfolder/posts/20170103/post.md
+++ b/tests/fixtures/posts_in_subfolder/posts/20170103/post.md
@@ -1,7 +1,9 @@
 extends: default.liquid
 
-title: a post inside posts/20170103/
+title: a post inside folder posts/20170103/
 date: 03 Jan 2017 21:00:00 -0000
+
+categories: [CatE, SubCatD]
 ---
 
 # a post inside posts/20170103/

--- a/tests/fixtures/posts_in_subfolder/posts/post.md
+++ b/tests/fixtures/posts_in_subfolder/posts/post.md
@@ -2,6 +2,8 @@ extends: default.liquid
 
 title: a post inside posts
 date: 01 Jan 2017 21:00:00 -0000
+
+categories: [CatA, SubCatD]
 ---
 
 # a post inside posts

--- a/tests/fixtures/posts_in_subfolder/posts/post_with_wrong_category.md
+++ b/tests/fixtures/posts_in_subfolder/posts/post_with_wrong_category.md
@@ -1,0 +1,11 @@
+extends: default.liquid
+
+title: post with wrong category
+date: 17 Jan 2017 21:00:00 -0000
+
+categories: [CatE, WrongCat]
+---
+
+# post with wrong category
+
+/posts/post_with_wrong_category.md

--- a/tests/fixtures/posts_in_subfolder/posts/post_without_categories.md
+++ b/tests/fixtures/posts_in_subfolder/posts/post_without_categories.md
@@ -1,0 +1,9 @@
+extends: default.liquid
+
+title: post without categories
+date: 14 Jan 2017 21:00:00 -0000
+---
+
+# post without categories
+
+/posts/post_without_categories.md

--- a/tests/target/posts_in_subfolder/categories.html
+++ b/tests/target/posts_in_subfolder/categories.html
@@ -1,0 +1,189 @@
+<!DOCTYPE html>
+<html>
+  <!-- start default.liquid -->
+  <head>
+    
+       <title>Cobalt.rs Blog</title>
+    
+  </head>
+  <body>
+    <div>
+      
+        <div>
+  <h3>print some site values</h3>
+  <b>site.name:</b> cobalt blog testing posts in subfolders<br/>
+  <b>site.description:</b> and also categories<br/>
+  <b>site.link:</b> http://posts-in-subfolders.cobalt.rs/<br/>
+  <b>site.excerpt_separator:</b>
+    &lt;!-- more --&gt; <br/>
+</div>
+
+<div>
+  <h3>print categories with posts</h3>
+    <!-- check if there are categories in config -->
+    
+      <!-- run over categories -->
+      
+        <h4>CatA</h4>
+        <!-- run over posts -->
+        
+          Posts in this category<br/>
+          
+            01.01.2017 | a post inside posts<br/>
+          
+        
+        <!-- run over subcategories -->
+        
+      
+        <h4></h4>
+        <!-- run over posts -->
+        
+        <!-- run over subcategories -->
+        
+          
+        
+      
+        <h4>CatB</h4>
+        <!-- run over posts -->
+        
+          Posts in this category<br/>
+          
+        
+        <!-- run over subcategories -->
+        
+      
+        <h4></h4>
+        <!-- run over posts -->
+        
+        <!-- run over subcategories -->
+        
+          
+            <h5>SubCatC</h5>
+            <!-- run over posts -->
+            
+              Posts in this subcategory<br/>
+              
+                05.01.2017 | a post inside folder posts/2017/01/05/<br/>
+              
+            
+          
+            <h5>SubCatD</h5>
+            <!-- run over posts -->
+            
+              Posts in this subcategory<br/>
+              
+                08.01.2017 | a post inside folder posts/2017/01/08/<br/>
+              
+                03.01.2017 | a post inside folder posts/20170103/<br/>
+              
+                01.01.2017 | a post inside posts<br/>
+              
+            
+          
+        
+      
+        <h4>CatE</h4>
+        <!-- run over posts -->
+        
+          Posts in this category<br/>
+          
+            17.01.2017 | post with wrong category<br/>
+          
+            05.01.2017 | a post inside folder posts/2017/01/05/<br/>
+          
+            03.01.2017 | a post inside folder posts/20170103/<br/>
+          
+        
+        <!-- run over subcategories -->
+        
+      
+        <h4></h4>
+        <!-- run over posts -->
+        
+        <!-- run over subcategories -->
+        
+          
+            <h5>SubCatF</h5>
+            <!-- run over posts -->
+            
+              Posts in this subcategory<br/>
+              
+                08.01.2017 | a post inside folder posts/2017/01/08/<br/>
+              
+            
+          
+        
+      
+    
+</div>
+
+<div>
+  <h3>print post list with categories</h3>
+  
+    <p>
+      17.01.2017 | post with wrong category<br/>
+      
+        
+         CatE <br/>
+        
+         WrongCat <br/>
+        
+      
+    </p>
+  
+    <p>
+      14.01.2017 | post without categories<br/>
+      
+    </p>
+  
+    <p>
+      08.01.2017 | a post inside folder posts/2017/01/08/<br/>
+      
+        
+         SubCatD <br/>
+        
+         SubCatF <br/>
+        
+      
+    </p>
+  
+    <p>
+      05.01.2017 | a post inside folder posts/2017/01/05/<br/>
+      
+        
+         CatE <br/>
+        
+         SubCatC <br/>
+        
+      
+    </p>
+  
+    <p>
+      03.01.2017 | a post inside folder posts/20170103/<br/>
+      
+        
+         CatE <br/>
+        
+         SubCatD <br/>
+        
+      
+    </p>
+  
+    <p>
+      01.01.2017 | a post inside posts<br/>
+      
+        
+         CatA <br/>
+        
+         SubCatD <br/>
+        
+      
+    </p>
+  
+</div>
+
+      
+    </div>
+  </body>
+  <!-- end default.liquid -->
+</html>

--- a/tests/target/posts_in_subfolder/index.html
+++ b/tests/target/posts_in_subfolder/index.html
@@ -16,18 +16,28 @@
   <div>
     
       <div>
-        <h4>a post inside posts/2017/01/08/</h4>
-        <h4><a href="posts/2017/01/08/post.html">a post inside posts/2017/01/08/</a></h4>
+        <h4>post with wrong category</h4>
+        <h4><a href="posts/post_with_wrong_category.html">post with wrong category</a></h4>
       </div>
     
       <div>
-        <h4>a post inside posts/2017/01/05/</h4>
-        <h4><a href="posts/2017/01/05/post.html">a post inside posts/2017/01/05/</a></h4>
+        <h4>post without categories</h4>
+        <h4><a href="posts/post_without_categories.html">post without categories</a></h4>
       </div>
     
       <div>
-        <h4>a post inside posts/20170103/</h4>
-        <h4><a href="posts/20170103/post.html">a post inside posts/20170103/</a></h4>
+        <h4>a post inside folder posts/2017/01/08/</h4>
+        <h4><a href="posts/2017/01/08/post.html">a post inside folder posts/2017/01/08/</a></h4>
+      </div>
+    
+      <div>
+        <h4>a post inside folder posts/2017/01/05/</h4>
+        <h4><a href="posts/2017/01/05/post.html">a post inside folder posts/2017/01/05/</a></h4>
+      </div>
+    
+      <div>
+        <h4>a post inside folder posts/20170103/</h4>
+        <h4><a href="posts/20170103/post.html">a post inside folder posts/20170103/</a></h4>
       </div>
     
       <div>

--- a/tests/target/posts_in_subfolder/posts/2017/01/05/post.html
+++ b/tests/target/posts_in_subfolder/posts/2017/01/05/post.html
@@ -3,7 +3,7 @@
   <!-- start default.liquid -->
   <head>
     
-      <title>a post inside posts/2017/01/05/</title>
+      <title>a post inside folder posts/2017/01/05/</title>
     
   </head>
   <body>
@@ -11,7 +11,7 @@
       
         <!-- start post.liquid -->
 <div>
-  <h2>a post inside posts/2017/01/05/</h2>
+  <h2>a post inside folder posts/2017/01/05/</h2>
   <p>
     <h1>a post inside posts/2017/01/05/</h1>
 <p>/posts/2017/01/05/post.md</p>

--- a/tests/target/posts_in_subfolder/posts/20170103/post.html
+++ b/tests/target/posts_in_subfolder/posts/20170103/post.html
@@ -3,7 +3,7 @@
   <!-- start default.liquid -->
   <head>
     
-      <title>a post inside posts/20170103/</title>
+      <title>a post inside folder posts/20170103/</title>
     
   </head>
   <body>
@@ -11,7 +11,7 @@
       
         <!-- start post.liquid -->
 <div>
-  <h2>a post inside posts/20170103/</h2>
+  <h2>a post inside folder posts/20170103/</h2>
   <p>
     <h1>a post inside posts/20170103/</h1>
 <p>/posts/20170103/post.md</p>

--- a/tests/target/posts_in_subfolder/posts/post_with_wrong_category.html
+++ b/tests/target/posts_in_subfolder/posts/post_with_wrong_category.html
@@ -3,7 +3,7 @@
   <!-- start default.liquid -->
   <head>
     
-      <title>a post inside folder posts/2017/01/08/</title>
+      <title>post with wrong category</title>
     
   </head>
   <body>
@@ -11,10 +11,10 @@
       
         <!-- start post.liquid -->
 <div>
-  <h2>a post inside folder posts/2017/01/08/</h2>
+  <h2>post with wrong category</h2>
   <p>
-    <h1>a post inside posts/2017/01/08/</h1>
-<p>/posts/2017/01/08//post.md</p>
+    <h1>post with wrong category</h1>
+<p>/posts/post_with_wrong_category.md</p>
 
   </p>
 </div>

--- a/tests/target/posts_in_subfolder/posts/post_without_categories.html
+++ b/tests/target/posts_in_subfolder/posts/post_without_categories.html
@@ -3,7 +3,7 @@
   <!-- start default.liquid -->
   <head>
     
-      <title>a post inside folder posts/2017/01/08/</title>
+      <title>post without categories</title>
     
   </head>
   <body>
@@ -11,10 +11,10 @@
       
         <!-- start post.liquid -->
 <div>
-  <h2>a post inside folder posts/2017/01/08/</h2>
+  <h2>post without categories</h2>
   <p>
-    <h1>a post inside posts/2017/01/08/</h1>
-<p>/posts/2017/01/08//post.md</p>
+    <h1>post without categories</h1>
+<p>/posts/post_without_categories.md</p>
 
   </p>
 </div>


### PR DESCRIPTION
Not meant for merge, just a first review round.

Please review the tests **fixtures/posts_in_subfolder**, especially **categories.liquid** if the idea off this pull request looks OK.

Also check if it is OK to add preserve_order to yaml-rust.

I will do the cleanup stuff after that. 

TODO:

   * yaml-rust preserve_order (for test and also as a requirement)
   * Make code Rust like
   * Clean up names