### PR TITLE
fix(frontmatter): Support empty frontmatters

### DIFF
--- a/src/document.rs
+++ b/src/document.rs
@@ -177,21 +177,20 @@ impl Document {
 
             let yaml_result = try!(YamlLoader::load_from_str(attribute_split));
 
-            if yaml_result.is_empty() {
-                return Err(format!("Incorrect front matter format in {:?}", file_path).into());
-            }
+            if !yaml_result.is_empty() {
+                let yaml_attributes = try!(yaml_result[0]
+                    .as_hash()
+                    .ok_or_else(|| format!("Incorrect front matter format in {:?}", file_path)));
 
-            let yaml_attributes = try!(yaml_result[0]
-                .as_hash()
-                .ok_or_else(|| format!("Incorrect front matter format in {:?}", file_path)));
-
-            for (key, value) in yaml_attributes {
-                if let Some(v) = yaml_to_liquid(value) {
-                    let key = key.as_str()
-                        .ok_or_else(|| format!("Invalid key {:?}", key))?
-                        .to_owned();
-                    attributes.insert(key, v);
+                for (key, value) in yaml_attributes {
+                    if let Some(v) = yaml_to_liquid(value) {
+                        let key = key.as_str()
+                            .ok_or_else(|| format!("Invalid key {:?}", key))?
+                            .to_owned();
+                        attributes.insert(key, v);
+                    }
                 }
+
             }
 
             content_split

--- a/src/document.rs
+++ b/src/document.rs
@@ -177,6 +177,10 @@ impl Document {
 
             let yaml_result = try!(YamlLoader::load_from_str(attribute_split));
 
+            if yaml_result.is_empty() {
+                return Err(format!("Incorrect front matter format in {:?}", file_path).into());
+            }
+
             let yaml_attributes = try!(yaml_result[0]
                 .as_hash()
                 .ok_or_else(|| format!("Incorrect front matter format in {:?}", file_path)));

--- a/tests/fixtures/empty_frontmatter/_layouts/default.liquid
+++ b/tests/fixtures/empty_frontmatter/_layouts/default.liquid
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>test</title>
+    </head>
+    <body>
+        <h1>{{ path }}</h1>
+
+        {{ content }}
+    </body>
+</html>
+

--- a/tests/fixtures/empty_frontmatter/_layouts/posts.liquid
+++ b/tests/fixtures/empty_frontmatter/_layouts/posts.liquid
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>My blog - {{ title }}</title>
+    </head>
+    <body>
+        {{ content }}
+    </body>
+</html>
+

--- a/tests/fixtures/empty_frontmatter/index.liquid
+++ b/tests/fixtures/empty_frontmatter/index.liquid
@@ -1,0 +1,7 @@
+extends: default.liquid
+---
+This is my Index page!
+
+{% for post in posts %}
+ <a href="{{post.path}}">{{ post.title }}</a>
+{% endfor %}

--- a/tests/fixtures/empty_frontmatter/posts/my-first-blogpost.md
+++ b/tests/fixtures/empty_frontmatter/posts/my-first-blogpost.md
@@ -1,0 +1,6 @@
+---
+# {{ title }}
+
+Hey there this is my first blogpost and this is super awesome.
+
+My Blog is lorem ipsum like, yes it is..

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -201,3 +201,8 @@ pub fn excerpts() {
 pub fn posts_in_subfolder() {
     run_test("posts_in_subfolder").unwrap();
 }
+
+#[test]
+pub fn empty_frontmatter() {
+    run_test("empty_frontmatter").expect("Build error");
+}

--- a/tests/target/empty_frontmatter/index.html
+++ b/tests/target/empty_frontmatter/index.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>test</title>
+    </head>
+    <body>
+        <h1>index.html</h1>
+
+        This is my Index page!
+
+
+ <a href="posts/my-first-blogpost.html">My First Blogpost</a>
+
+
+    </body>
+</html>
+

--- a/tests/target/empty_frontmatter/posts/my-first-blogpost.html
+++ b/tests/target/empty_frontmatter/posts/my-first-blogpost.html
@@ -1,0 +1,3 @@
+<h1>My First Blogpost</h1>
+<p>Hey there this is my first blogpost and this is super awesome.</p>
+<p>My Blog is lorem ipsum like, yes it is..</p>


### PR DESCRIPTION
On trying to port my site over, I encoutered crashes due to invalid index access with files that have a front matter such as:

```
---
name: ...
---
```

This gets parsed as an empty front matter due to beginning with dashes, which lead to the index error.

I'm not sure if empty frontmatter = error is the right thing or if we just want to treat it without problems.