### PR TITLE
feat(debug): Dump intermediate state

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -22,6 +22,7 @@ dependencies = [
  "rss 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "syntect 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempdir 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "toml 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "walkdir 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "yaml-rust 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -861,6 +862,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "serde 0.9.11 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "traitobject"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1093,6 +1102,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum thread_local 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "c85048c6260d17cf486ceae3282d9fb6b90be220bf5b28c400f5485ffc29f0c7"
 "checksum time 0.1.36 (registry+https://github.com/rust-lang/crates.io-index)" = "211b63c112206356ef1ff9b19355f43740fc3f85960c598a93d3a3d3ba7beade"
 "checksum toml 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "736b60249cb25337bc196faa43ee12c705e426f3d55c214d73a4e7be06f92cb4"
+"checksum toml 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "bd86ad9ebee246fdedd610e0f6d0587b754a3d81438db930a244d0480ed7878f"
 "checksum traitobject 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "efd1f82c56340fdf16f2a953d7bda4f8fdffba13d93b00844c25572110b26079"
 "checksum typeable 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1410f6f91f21d1612654e7cc69193b0334f909dcf2c790c4826254fbb86f8887"
 "checksum unicase 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "13a5906ca2b98c799f4b1ab4557b76367ebd6ae5ef14930ec841c74aed5f3764"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ clippy = {version = "0.0", optional = true}
 error-chain = "0.10.0"
 lazy_static = "0.2"
 itertools = "0.5.9"
+toml = "0.3.2"
 
 [dependencies.hyper]
 version = "0.10"

--- a/src/config.rs
+++ b/src/config.rs
@@ -6,6 +6,13 @@ use glob::Pattern;
 use error::Result;
 use yaml_rust::YamlLoader;
 
+arg_enum!{
+    #[derive(Debug, PartialEq)]
+    pub enum Dump {
+        Liquid
+    }
+}
+
 #[derive(Debug, PartialEq)]
 pub struct Config {
     pub source: String,
@@ -22,6 +29,7 @@ pub struct Config {
     pub link: Option<String>,
     pub ignore: Vec<Pattern>,
     pub excerpt_separator: String,
+    pub dump: Vec<Dump>,
 }
 
 impl Default for Config {
@@ -41,6 +49,7 @@ impl Default for Config {
             link: None,
             ignore: vec![],
             excerpt_separator: "\n\n".to_owned(),
+            dump: vec![],
         }
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -3,6 +3,8 @@ use std::io;
 use yaml_rust::scanner;
 use walkdir;
 use liquid;
+use clap;
+use notify;
 
 error_chain! {
 
@@ -14,6 +16,8 @@ error_chain! {
         Liquid(liquid::Error);
         WalkDir(walkdir::Error);
         Yaml(scanner::ScanError);
+        Clap(clap::Error);
+        Notify(notify::Error);
     }
 
     errors {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,8 @@ extern crate yaml_rust;
 extern crate rss;
 extern crate glob;
 extern crate regex;
+extern crate toml;
+extern crate notify;
 
 extern crate itertools;
 
@@ -29,9 +31,13 @@ extern crate log;
 #[macro_use]
 extern crate error_chain;
 
+#[macro_use]
+extern crate clap;
+
 pub use cobalt::build;
 pub use error::Error;
 pub use config::Config;
+pub use config::Dump;
 pub use new::create_new_project;
 
 // modules


### PR DESCRIPTION
This adds a new command line flag --dump. 

Currently the only option for what you can dump is `Liquid`.  This will cause `_<file>.toml` and `_<file>.liquid` to be created in the `dest` folder next to `<file>.html`.  A user can see what variables are available.  A developer can see if cobalt is feeding liquid the right data and start debugging liquid issues with the tool from cobalt-org/liquid-rust#83.