### PR TITLE
Ignore querystrings

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -386,10 +386,15 @@ fn static_file_handler(dest: &str, req: Request, mut res: Response) -> IoResult<
         }
     };
 
+    // strip off any querystrings so path.is_file() matches
+    // and doesn't stick index.html on the end of the path
+    // (querystrings often used for cachebusting)
+    let stripped_path = &req_path.split('?').collect::<Vec<&str>>()[0];
+    
     // find the path of the file in the local system
     // (this gets rid of the '/' in `p`, so the `join()` will not replace the
     // path)
-    let path = PathBuf::from(dest).join(&req_path[1..]);
+    let path = PathBuf::from(dest).join(&stripped_path[1..]);
 
     let serve_path = if path.is_file() {
         // try to point the serve path to `path` if it corresponds to a file

--- a/src/main.rs
+++ b/src/main.rs
@@ -389,9 +389,8 @@ fn static_file_handler(dest: &str, req: Request, mut res: Response) -> IoResult<
     // strip off any querystrings so path.is_file() matches
     // and doesn't stick index.html on the end of the path
     // (querystrings often used for cachebusting)
-    match req_path.rfind('?') {
-        Some(position) => req_path.truncate(position),
-        None => (),
+    if let Some(position) = req_path.rfind('?') {
+        req_path.truncate(position);
     }
 
     // find the path of the file in the local system

--- a/src/main.rs
+++ b/src/main.rs
@@ -390,7 +390,7 @@ fn static_file_handler(dest: &str, req: Request, mut res: Response) -> IoResult<
     // and doesn't stick index.html on the end of the path
     // (querystrings often used for cachebusting)
     let stripped_path = &req_path.split('?').collect::<Vec<&str>>()[0];
-    
+
     // find the path of the file in the local system
     // (this gets rid of the '/' in `p`, so the `join()` will not replace the
     // path)

--- a/tests/fixtures/querystrings/_layouts/default.liquid
+++ b/tests/fixtures/querystrings/_layouts/default.liquid
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>test</title>
+    </head>
+    <body>
+        <h1>{{ path }}</h1>
+
+        {{ content }}
+    </body>
+</html>
+

--- a/tests/fixtures/querystrings/_layouts/posts.liquid
+++ b/tests/fixtures/querystrings/_layouts/posts.liquid
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>My blog - {{ path }}</title>
+    </head>
+    <body>
+        {{ content }}
+    </body>
+</html>
+

--- a/tests/fixtures/querystrings/index.liquid
+++ b/tests/fixtures/querystrings/index.liquid
@@ -1,0 +1,11 @@
+extends: default.liquid
+---
+This is my Index page!
+
+{% for post in posts %}
+ <a href="{{post.path}}">{{ post.title }}</a>
+{% endfor %}
+
+{% for post in posts %}
+ <a href="{{post.path}}?v=123456">{{ post.title }}</a>
+{% endfor %}

--- a/tests/fixtures/querystrings/posts/2014-08-24-my-first-blogpost.md
+++ b/tests/fixtures/querystrings/posts/2014-08-24-my-first-blogpost.md
@@ -1,0 +1,8 @@
+extends: posts.liquid
+
+title:  Querystrings
+date:  9 May 2017 07:05:20 +0100
+---
+# {{ title }}
+
+This asserts that files can be loaded with and without querystrings

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -211,3 +211,8 @@ pub fn posts_in_subfolder() {
 pub fn empty_frontmatter() {
     run_test("empty_frontmatter").expect("Build error");
 }
+
+#[test]
+pub fn querystrings() {
+    run_test("querystrings").expect("Build error");
+}

--- a/tests/target/querystrings/index.html
+++ b/tests/target/querystrings/index.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>test</title>
+    </head>
+    <body>
+        <h1>index.html</h1>
+
+        This is my Index page!
+
+
+ <a href="posts/2014-08-24-my-first-blogpost.html">Querystrings</a>
+
+
+
+ <a href="posts/2014-08-24-my-first-blogpost.html?v=123456">Querystrings</a>
+
+
+    </body>
+</html>
+

--- a/tests/target/querystrings/posts/2014-08-24-my-first-blogpost.html
+++ b/tests/target/querystrings/posts/2014-08-24-my-first-blogpost.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>My blog - posts/2014-08-24-my-first-blogpost.html</title>
+    </head>
+    <body>
+        <h1>Querystrings</h1>
+<p>This asserts that files can be loaded with and without querystrings</p>
+
+    </body>
+</html>
+


### PR DESCRIPTION
Fix for #207 - strips querystrings from urls when serving files locally