### PR TITLE
Allow posts to be reverse sorted

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# ![Cobalt](https://raw.githubusercontent.com/cobalt-org/logos/master/cobald.logo.02.resize.png)  
+# ![Cobalt](https://raw.githubusercontent.com/cobalt-org/logos/master/cobald.logo.02.resize.png)
 [![](https://img.shields.io/crates/v/cobalt-bin.svg?maxAge=25920)](https://crates.io/crates/cobalt-bin)
-[![](https://travis-ci.org/cobalt-org/cobalt.rs.svg?branch=master)](https://travis-ci.org/cobalt-org/cobalt.rs) [![](https://ci.appveyor.com/api/projects/status/gp2mmvk8dpe8wsmi/branch/master?svg=true)](https://ci.appveyor.com/project/johannhof/cobalt-rs/branch/master) 
+[![](https://travis-ci.org/cobalt-org/cobalt.rs.svg?branch=master)](https://travis-ci.org/cobalt-org/cobalt.rs) [![](https://ci.appveyor.com/api/projects/status/gp2mmvk8dpe8wsmi/branch/master?svg=true)](https://ci.appveyor.com/project/johannhof/cobalt-rs/branch/master)
 [![](https://coveralls.io/repos/cobalt-org/cobalt.rs/badge.svg?branch=master&service=github)](https://coveralls.io/github/cobalt-org/cobalt.rs?branch=master)
 [![](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/cobalt-org/cobalt.rs?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
 
@@ -93,6 +93,8 @@ The content before ```---``` are meta attributes ("front matter") made accessibl
 The ```extends``` attribute specifies which layout will be used.
 
 The ```date``` attribute will be used to sort blog posts (from last to first). ```date``` must have the format `%dd %Mon %YYYY %HH:%MM:%SS %zzzz`, so for example `27 May 2016 21:00:30 +0100`.
+
+You can change the order of posts from newest first (default) to oldest first by setting ```post_order: "asc"``` in your .cobalt.yml
 
 #### Drafts
 
@@ -218,8 +220,8 @@ script:
   - cobalt build
 
 after_success: |
-  [ $TRAVIS_BRANCH = master ] &&  
-  [ $TRAVIS_PULL_REQUEST = false ] &&  
+  [ $TRAVIS_BRANCH = master ] &&
+  [ $TRAVIS_PULL_REQUEST = false ] &&
   cobalt import &&
   git config user.name "Cobalt Site Deployer" &&
   git config user.email "name@example.com" &&

--- a/src/cobalt.rs
+++ b/src/cobalt.rs
@@ -125,6 +125,10 @@ pub fn build(config: &Config) -> Result<()> {
     // fall back to the default date
     posts.sort_by(|a, b| b.date.unwrap_or(default_date).cmp(&a.date.unwrap_or(default_date)));
 
+    if &config.post_order == "asc" {
+        posts.reverse();
+    }
+
     // collect all posts attributes to pass them to other posts for rendering
     let simple_posts_data: Vec<Value> = posts.iter()
         .map(|x| Value::Object(x.attributes.clone()))

--- a/src/config.rs
+++ b/src/config.rs
@@ -15,6 +15,7 @@ pub struct Config {
     pub include_drafts: bool,
     pub posts: String,
     pub post_path: Option<String>,
+    pub post_order: String,
     pub template_extensions: Vec<String>,
     pub rss: Option<String>,
     pub name: Option<String>,
@@ -34,6 +35,7 @@ impl Default for Config {
             include_drafts: false,
             posts: "posts".to_owned(),
             post_path: None,
+            post_order: "desc".to_owned(),
             template_extensions: vec!["md".to_owned(), "liquid".to_owned()],
             rss: None,
             name: None,
@@ -87,6 +89,10 @@ impl Config {
 
         if let Some(posts) = yaml["posts"].as_str() {
             config.posts = posts.to_owned();
+        };
+
+        if let Some(post_order) = yaml["post_order"].as_str() {
+            config.post_order = post_order.to_owned();
         };
 
         if let Some(extensions) = yaml["template_extensions"].as_vec() {

--- a/tests/fixtures/post_order/.cobalt.yml
+++ b/tests/fixtures/post_order/.cobalt.yml
@@ -1,0 +1,7 @@
+name: cobalt blog
+source: "."
+dest: "build"
+post_order: "asc"
+ignore:
+  - .git/*
+  - build/*

--- a/tests/fixtures/post_order/_layouts/default.liquid
+++ b/tests/fixtures/post_order/_layouts/default.liquid
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>test</title>
+    </head>
+    <body>
+        <h1>{{ path }}</h1>
+
+        {{ content }}
+    </body>
+</html>
+

--- a/tests/fixtures/post_order/_layouts/posts.liquid
+++ b/tests/fixtures/post_order/_layouts/posts.liquid
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>My blog - {{ title }}</title>
+    </head>
+    <body>
+        {{ content }}
+    </body>
+</html>
+

--- a/tests/fixtures/post_order/index.liquid
+++ b/tests/fixtures/post_order/index.liquid
@@ -1,0 +1,7 @@
+extends: default.liquid
+---
+This is my Index page!
+
+{% for post in posts %}
+ <a href="{{post.path}}">{{ post.title }}</a>
+{% endfor %}

--- a/tests/fixtures/post_order/posts/my-first-blogpost.md
+++ b/tests/fixtures/post_order/posts/my-first-blogpost.md
@@ -1,0 +1,10 @@
+extends: posts.liquid
+
+title:   My first Blogpost
+date:    01 Jan 2016 21:00:00 +0100
+---
+# {{ title }}
+
+Hey there this is my first blogpost and this is super awesome.
+
+My Blog is lorem ipsum like, yes it is..

--- a/tests/fixtures/post_order/posts/my-fourth-blogpost.md
+++ b/tests/fixtures/post_order/posts/my-fourth-blogpost.md
@@ -1,0 +1,10 @@
+extends: posts.liquid
+
+title:   My fourth Blogpost
+date:    29 May 2016 23:00:00 +0100
+---
+# {{ title }}
+
+Hey there this is my first blogpost and this is super awesome.
+
+My Blog is lorem ipsum like, yes it is..

--- a/tests/fixtures/post_order/posts/my-second-blogpost.md
+++ b/tests/fixtures/post_order/posts/my-second-blogpost.md
@@ -1,0 +1,10 @@
+extends: posts.liquid
+
+title:   My second Blogpost
+date:    02 Jan 2016 10:00:00 +0100
+---
+# {{ title }}
+
+Hey there this is my first blogpost and this is super awesome.
+
+My Blog is lorem ipsum like, yes it is..

--- a/tests/fixtures/post_order/posts/my-third-blogpost.md
+++ b/tests/fixtures/post_order/posts/my-third-blogpost.md
@@ -1,0 +1,10 @@
+extends: posts.liquid
+
+title:   My third Blogpost
+date:    27 May 2016 23:00:00 +0100
+---
+# {{ title }}
+
+Hey there this is my first blogpost and this is super awesome.
+
+My Blog is lorem ipsum like, yes it is..

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -176,6 +176,11 @@ pub fn sort_posts() {
 }
 
 #[test]
+pub fn post_order() {
+    run_test("post_order").expect("Build error");
+}
+
+#[test]
 pub fn rss() {
     run_test("rss").expect("Build error");
 }

--- a/tests/target/post_order/index.html
+++ b/tests/target/post_order/index.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>test</title>
+    </head>
+    <body>
+        <h1>index.html</h1>
+
+        This is my Index page!
+
+
+ <a href="posts/my-first-blogpost.html">My first Blogpost</a>
+
+ <a href="posts/my-second-blogpost.html">My second Blogpost</a>
+
+ <a href="posts/my-third-blogpost.html">My third Blogpost</a>
+
+ <a href="posts/my-fourth-blogpost.html">My fourth Blogpost</a>
+
+
+    </body>
+</html>
+

--- a/tests/target/post_order/posts/my-first-blogpost.html
+++ b/tests/target/post_order/posts/my-first-blogpost.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>My blog - My first Blogpost</title>
+    </head>
+    <body>
+        <h1>My first Blogpost</h1>
+<p>Hey there this is my first blogpost and this is super awesome.</p>
+<p>My Blog is lorem ipsum like, yes it is..</p>
+
+    </body>
+</html>
+

--- a/tests/target/post_order/posts/my-fourth-blogpost.html
+++ b/tests/target/post_order/posts/my-fourth-blogpost.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>My blog - My fourth Blogpost</title>
+    </head>
+    <body>
+        <h1>My fourth Blogpost</h1>
+<p>Hey there this is my first blogpost and this is super awesome.</p>
+<p>My Blog is lorem ipsum like, yes it is..</p>
+
+    </body>
+</html>
+

--- a/tests/target/post_order/posts/my-second-blogpost.html
+++ b/tests/target/post_order/posts/my-second-blogpost.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>My blog - My second Blogpost</title>
+    </head>
+    <body>
+        <h1>My second Blogpost</h1>
+<p>Hey there this is my first blogpost and this is super awesome.</p>
+<p>My Blog is lorem ipsum like, yes it is..</p>
+
+    </body>
+</html>
+

--- a/tests/target/post_order/posts/my-third-blogpost.html
+++ b/tests/target/post_order/posts/my-third-blogpost.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>My blog - My third Blogpost</title>
+    </head>
+    <body>
+        <h1>My third Blogpost</h1>
+<p>Hey there this is my first blogpost and this is super awesome.</p>
+<p>My Blog is lorem ipsum like, yes it is..</p>
+
+    </body>
+</html>
+


### PR DESCRIPTION
Fix for #160 - post order is controlled by setting `post_order` to `asc` or `desc` in `.cobalt.yml` (default desc).