### PR TITLE
Rename the 'new' command to 'init'

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ There are a few people already using `cobalt`. Here is a list of projects and th
 ## Usage
 
 ```
-  $ cobalt new myBlog
+  $ cobalt init myBlog
   $ cobalt build -s myBlog -d path/to/your/destination
 ```
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -104,7 +104,7 @@ fn main() {
             .help("Suppress all output")
             .global(true)
             .takes_value(false))
-        .subcommand(SubCommand::with_name("new")
+        .subcommand(SubCommand::with_name("init")
             .about("create a new cobalt project")
             .arg(Arg::with_name("DIRECTORY")
                 .help("Suppress all output")
@@ -245,7 +245,7 @@ fn main() {
     config.include_drafts = matches.is_present("drafts");
 
     match command {
-        "new" => {
+        "init" => {
             let directory = matches.value_of("DIRECTORY").unwrap();
 
             match create_new_project(&directory.to_string()) {


### PR DESCRIPTION
Groundwork for #208 - `cobalt new` is now `cobalt init`