### PR TITLE
fix(CI): Protect against timeout on Travis

### DIFF
--- a/ci/install.sh
+++ b/ci/install.sh
@@ -4,8 +4,9 @@ main() {
     curl https://sh.rustup.rs -sSf | \
         sh -s -- -y --default-toolchain $TRAVIS_RUST_VERSION
 
-    # Install rustfmt
-    cargo install rustfmt --force --vers 0.8.3
+    if [ "$TRAVIS_RUST_VERSION" = "stable" ]; then
+      travis_wait cargo install rustfmt --force --vers 0.8.3
+    fi
 
     if [ "$TRAVIS_RUST_VERSION" = "nightly" ]; then
       cargo install clippy --force


### PR DESCRIPTION
Building rustfmt was slow enough that it sometimes timed out our CI, so
switching back to downloading it but leaving it upgraded.