### PR TITLE
sub spaces in urls

### DIFF
--- a/src/document.rs
+++ b/src/document.rs
@@ -89,6 +89,9 @@ fn format_path(p: &str,
         }
     }
 
+    p = p.replace(" ", "-");
+    p = p.to_lowercase();
+
     let mut path = Path::new(&p);
 
     // remove the root prefix (leading slash on unix systems)


### PR DESCRIPTION
Some URLs might have spaces in them if the filenames have spaces. This patch will replace the spaces with a `-` character. 