### PR TITLE
fix(CI): Re-enable Stable builds on Linux

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,15 @@
 sudo: false
 language: rust
-rust: stable
 
 env:
   global:
     - CRATE_NAME=cobalt
-    # default job
-    - TARGET=x86_64-unknown-linux-gnu
 
 matrix:
   fast_finish: true
   include:
     # Linux
-    # - env: TARGET=x86_64-unknown-linux-gnu  # this is the default job
+    - env: TARGET=x86_64-unknown-linux-gnu
 
     # OSX
     - env: TARGET=x86_64-apple-darwin

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ env:
     - CRATE_NAME=cobalt
 
 matrix:
-  fast_finish: true
   include:
     # Linux
     - env: TARGET=x86_64-unknown-linux-gnu


### PR DESCRIPTION
It is unclear why the default build isn't running anymore.  `trust`
explicitly calls it out now as well.