### PR TITLE
fix: Bump syntect version to 1.7.0 and enable dump-load feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,6 +1,6 @@
 [root]
 name = "cobalt-bin"
-version = "0.6.1"
+version = "0.7.1"
 dependencies = [
  "assert_cli 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -22,7 +22,7 @@ dependencies = [
  "rss 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_yaml 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "syntect 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syntect 1.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempdir 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "walkdir 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "yaml-rust 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -841,7 +841,7 @@ dependencies = [
 
 [[package]]
 name = "syntect"
-version = "1.5.0"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bincode 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1150,7 +1150,7 @@ dependencies = [
 "checksum strsim 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b4d15c810519a91cf877e7e36e63fe068815c678181439f2f29e2562147c3694"
 "checksum syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)" = "d3b891b9015c88c576343b9b3e41c2c11a51c219ef067b264bd9c8aa9b441dad"
 "checksum synom 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a393066ed9010ebaed60b9eafa373d4b1baac186dd7e008555b0f702b51945b6"
-"checksum syntect 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fed7a5661c5c42fe998c561efb12137381a4486702f41c95a1d7269f3cc8ca6a"
+"checksum syntect 1.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2f436345e5b6ebbfdf51b20b95cd9bcb82576262c340bad9cf815078d76b082a"
 "checksum tempdir 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "87974a6f5c1dfb344d733055601650059a3363de2a6104819293baff662132d6"
 "checksum term_size 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e2b6b55df3198cc93372e85dd2ed817f0e38ce8cc0f22eb32391bfad9c4bf209"
 "checksum thread-id 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8df7875b676fddfadffd96deea3b1124e5ede707d4884248931077518cf1f773"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,10 +47,10 @@ version = "0.10"
 default-features = false
 
 [dependencies.syntect]
-version = "1.5"
+version = "1.7.0"
 optional = true
 default-features = false
-features =  ["parsing", "assets", "html", "static-onig"]
+features =  ["parsing", "assets", "html", "static-onig", "dump-load"]
 
 [dev-dependencies]
 assert_cli = "0.3"


### PR DESCRIPTION
Spoke with @trishume, and projects disabling syntect's default features
may run into API-breaking changes with minor version releases.  Bind
crate to patch version to avoid further incidents.

Syntect v1.7 adds dump-load and dump-load-rs options.  Select dump-load
since it's in syntect's default feature list and suspected to be
compatible with v1.5.  Consider switching to dump-load-rs after
sufficient testing.

Install successfully tested via:

```
cd path/to/cobalt/fork
cargo install --path ./ cobalt-bin --feature=syntax-highlight
```

Fixes #252 