### PR TITLE
Add timestamp to layouts for cachebusting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,6 +1,6 @@
 [root]
 name = "cobalt-bin"
-version = "0.6.1"
+version = "0.7.1"
 dependencies = [
  "assert_cli 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/src/cobalt.rs
+++ b/src/cobalt.rs
@@ -176,12 +176,14 @@ pub fn build(config: &Config) -> Result<()> {
         .collect();
 
     trace!("Generating other documents");
+    let timestamp = Value::Str(UTC::now().timestamp().to_string());
     for mut doc in documents {
         trace!("Generating {}", doc.path);
 
         if config.dump.contains(&Dump::Liquid) {
             create_liquid_dump(dest, &doc.path, &doc.content, &doc.attributes)?;
         }
+        doc.attributes.insert("timestamp".to_owned(), timestamp.clone());
 
         let mut context = doc.get_render_context(&posts_data);
         let doc_html = try!(doc.render(&mut context, source, &layouts, &mut layouts_cache));

--- a/tests/fixtures/timestamp/_layouts/default.liquid
+++ b/tests/fixtures/timestamp/_layouts/default.liquid
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>test</title>
+        <link rel="stylesheet" href="/css/main.css?v={{ timestamp }}">
+    </head>
+    <body>
+        <h1>{{ path }}</h1>
+
+        {{ content }}
+    </body>
+</html>
+

--- a/tests/fixtures/timestamp/_layouts/posts.liquid
+++ b/tests/fixtures/timestamp/_layouts/posts.liquid
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>My blog - {{ title }}</title>
+    </head>
+    <body>
+        {{ content }}
+    </body>
+</html>
+

--- a/tests/fixtures/timestamp/index.liquid
+++ b/tests/fixtures/timestamp/index.liquid
@@ -1,0 +1,7 @@
+extends: default.liquid
+---
+This is my Index page!
+
+{% for post in posts %}
+ <a href="{{post.path}}">{{ post.title }}</a>
+{% endfor %}

--- a/tests/fixtures/timestamp/posts/2014-08-24-my-first-blogpost.md
+++ b/tests/fixtures/timestamp/posts/2014-08-24-my-first-blogpost.md
@@ -1,0 +1,10 @@
+extends: posts.liquid
+
+title:   My first Blogpost
+date:    24/08/2014 at 15:36
+---
+# {{ title }}
+
+Hey there this is my first blogpost and this is super awesome.
+
+My Blog is lorem ipsum like, yes it is..

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -3,6 +3,8 @@ extern crate difference;
 extern crate cobalt;
 extern crate tempdir;
 extern crate walkdir;
+extern crate chrono;
+extern crate regex;
 
 use std::path::Path;
 use std::fs::{self, File};
@@ -11,6 +13,8 @@ use tempdir::TempDir;
 use walkdir::WalkDir;
 use std::error::Error;
 use cobalt::Config;
+use chrono::{UTC};
+use regex::{Regex};
 
 fn run_test(name: &str) -> Result<(), cobalt::Error> {
     let target = format!("tests/target/{}/", name);
@@ -225,4 +229,32 @@ pub fn empty_frontmatter() {
 #[test]
 pub fn querystrings() {
     run_test("querystrings").expect("Build error");
+}
+
+#[test]
+pub fn timestamp() {
+    // timestamp adds current ms time so need to build the target folder at run time
+    let mut config = Config::from_file("tests/fixtures/timestamp/.cobalt.yml")
+        .unwrap_or_default();
+    config.source = "tests/fixtures/timestamp/".to_string();
+    config.dest = "tests/target/timestamp/".to_string();
+
+    fs::create_dir_all(&config.dest).is_ok();
+
+    let timestamp = UTC::now().timestamp().to_string();
+    let result = cobalt::build(&config);
+
+    if result.is_ok() {
+        // check timestamp is in the target layout
+        let mut content = String::new();
+        let _file = File::open("tests/target/timestamp/index.html").unwrap().read_to_string(&mut content);
+        let re = Regex::new(&timestamp.as_str()).unwrap();
+        assert!(re.is_match(&content.as_str()));
+
+        // run standard test to make sure it doesn't fall over
+        run_test("timestamp").expect("Build error");
+
+        // delete file with timestamp otherwise next test build will fail
+        let _deleted = fs::remove_file("tests/target/timestamp/index.html");
+    }
 }

--- a/tests/target/timestamp/posts/2014-08-24-my-first-blogpost.html
+++ b/tests/target/timestamp/posts/2014-08-24-my-first-blogpost.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>My blog - My first Blogpost</title>
+    </head>
+    <body>
+        <h1>My first Blogpost</h1>
+<p>Hey there this is my first blogpost and this is super awesome.</p>
+<p>My Blog is lorem ipsum like, yes it is..</p>
+
+    </body>
+</html>
+


### PR DESCRIPTION
This allows layouts to access a millisecond timestamp which can be used for cachebusting (adding a unique string to static assets to get around long caching times in the browser).

## Notes
- I used `Value::Str` since `Value::Num` only accepts `f32` - the timestamp is `i64` so casting to `f32` trims the number to the point where it's not unique.
- There's a bit of a dance in the test since the timestamp is generated when the `build` command is run - this means the target to compare with needs to be built when `cargo test` runs.
- It might be better to add `date` instead of `timestamp` and then format in the layout file - this would give users more flexibility since they can access the Date object, but would mean each asset would have to format the date individually.