### PR TITLE
Allow configuring the theme for syntax highlighting

### DIFF
--- a/src/cobalt.rs
+++ b/src/cobalt.rs
@@ -183,8 +183,12 @@ pub fn build(config: &Config) -> Result<()> {
 
         let mut context = post.get_render_context(&simple_posts_data);
 
-        post.render_excerpt(&mut context, source, config)?;
-        let post_html = post.render(&mut context, source, &layouts, &mut layouts_cache, config)?;
+        post.render_excerpt(&mut context, source, &config.syntax_theme)?;
+        let post_html = post.render(&mut context,
+                                    source,
+                                    &layouts,
+                                    &mut layouts_cache,
+                                    &config.syntax_theme)?;
         create_document_file(post_html, &post.file_path, dest)?;
     }
 
@@ -224,7 +228,11 @@ pub fn build(config: &Config) -> Result<()> {
         }
 
         let mut context = doc.get_render_context(&posts_data);
-        let doc_html = doc.render(&mut context, source, &layouts, &mut layouts_cache, config)?;
+        let doc_html = doc.render(&mut context,
+                                  source,
+                                  &layouts,
+                                  &mut layouts_cache,
+                                  &config.syntax_theme)?;
         create_document_file(doc_html, doc.file_path, dest)?;
     }
 

--- a/src/cobalt.rs
+++ b/src/cobalt.rs
@@ -183,8 +183,8 @@ pub fn build(config: &Config) -> Result<()> {
 
         let mut context = post.get_render_context(&simple_posts_data);
 
-        post.render_excerpt(&mut context, source)?;
-        let post_html = post.render(&mut context, source, &layouts, &mut layouts_cache)?;
+        post.render_excerpt(&mut context, source, config)?;
+        let post_html = post.render(&mut context, source, &layouts, &mut layouts_cache, config)?;
         create_document_file(post_html, &post.file_path, dest)?;
     }
 
@@ -224,7 +224,7 @@ pub fn build(config: &Config) -> Result<()> {
         }
 
         let mut context = doc.get_render_context(&posts_data);
-        let doc_html = doc.render(&mut context, source, &layouts, &mut layouts_cache)?;
+        let doc_html = doc.render(&mut context, source, &layouts, &mut layouts_cache, config)?;
         create_document_file(doc_html, doc.file_path, dest)?;
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -39,6 +39,7 @@ pub struct Config {
     pub ignore: Vec<String>,
     pub excerpt_separator: String,
     pub dump: Vec<Dump>,
+    pub theme: String,
 }
 
 impl Default for Config {
@@ -61,6 +62,7 @@ impl Default for Config {
             ignore: vec![],
             excerpt_separator: "\n\n".to_owned(),
             dump: vec![],
+            theme: "base16-ocean.dark".to_owned(),
         }
     }
 }
@@ -139,6 +141,10 @@ impl Config {
 
         if let Some(excerpt_separator) = yaml["excerpt_separator"].as_str() {
             config.excerpt_separator = excerpt_separator.to_owned();
+        };
+
+        if let Some(theme) = yaml["theme"].as_str() {
+            config.theme = theme.to_owned();
         };
 
         Ok(config)

--- a/src/config.rs
+++ b/src/config.rs
@@ -5,6 +5,9 @@ use std::io::Read;
 use error::Result;
 use yaml_rust::YamlLoader;
 
+#[cfg(all(feature="syntax-highlight", not(windows)))]
+use syntax_highlight::has_syntax_theme;
+
 arg_enum! {
     #[derive(Debug, PartialEq, Copy, Clone)]
     pub enum Dump {
@@ -143,9 +146,17 @@ impl Config {
             config.excerpt_separator = excerpt_separator.to_owned();
         };
 
-        if let Some(theme) = yaml["syntax-highlight"]["theme"].as_str() {
-            config.syntax_theme = theme.to_owned();
-        };
+        #[cfg(all(feature="syntax-highlight", not(windows)))]
+        {
+            if let Some(theme) = yaml["syntax-highlight"]["theme"].as_str() {
+                if has_syntax_theme(theme) {
+                    config.syntax_theme = theme.to_owned();
+                } else {
+                    warn!("Theme named '{}' is not found.  Using default 'base16-ocean.dark'.",
+                          theme);
+                }
+            };
+        }
 
         Ok(config)
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -39,7 +39,7 @@ pub struct Config {
     pub ignore: Vec<String>,
     pub excerpt_separator: String,
     pub dump: Vec<Dump>,
-    pub theme: String,
+    pub syntax_theme: String,
 }
 
 impl Default for Config {
@@ -62,7 +62,7 @@ impl Default for Config {
             ignore: vec![],
             excerpt_separator: "\n\n".to_owned(),
             dump: vec![],
-            theme: "base16-ocean.dark".to_owned(),
+            syntax_theme: "base16-ocean.dark".to_owned(),
         }
     }
 }
@@ -143,8 +143,8 @@ impl Config {
             config.excerpt_separator = excerpt_separator.to_owned();
         };
 
-        if let Some(theme) = yaml["theme"].as_str() {
-            config.theme = theme.to_owned();
+        if let Some(theme) = yaml["syntax-highlight"]["theme"].as_str() {
+            config.syntax_theme = theme.to_owned();
         };
 
         Ok(config)

--- a/src/config.rs
+++ b/src/config.rs
@@ -152,7 +152,7 @@ impl Config {
                 if has_syntax_theme(theme) {
                     config.syntax_theme = theme.to_owned();
                 } else {
-                    warn!("Theme named '{}' is not found.  Using default 'base16-ocean.dark'.",
+                    warn!("Theme named '{}' is not found.  Using default 'base16-ocean.dark'.  Run `cobalt list-syntax-themes` to see available themes.",
                           theme);
                 }
             };

--- a/src/document.rs
+++ b/src/document.rs
@@ -386,9 +386,11 @@ impl Document {
                    source: &Path,
                    config: &Config)
                    -> Result<String> {
+        let theme_name = config.syntax_theme.clone();
         let mut options = LiquidOptions::default();
         options.template_repository = Box::new(LocalTemplateRepository::new(source.to_owned()));
-        let highlight: Box<liquid::Block> = Box::new(initialize_codeblock);
+        let highlight: Box<liquid::Block> =
+            Box::new(move |_, args, tokens, _| initialize_codeblock(args, tokens, &theme_name));
         options.blocks.insert("highlight".to_string(), highlight);
         let template = try!(liquid::parse(content, options));
         let html = try!(template.render(context)).unwrap_or_default();

--- a/src/error.rs
+++ b/src/error.rs
@@ -26,5 +26,10 @@ error_chain! {
             display("name, description and link need to be defined in the config file to \
                     generate RSS")
         }
+
+        UnsupportedPlatform(functionality: &'static str, platform: &'static str) {
+            description("functionality is not implemented for this platform")
+            display("{} is not implemented for the {} platform", functionality, platform)
+        }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,5 +60,5 @@ mod frontmatter;
 #[cfg(feature="syntax-highlight")]
 mod syntax_highlight;
 
-#[cfg(all(feature="syntax-highlight", not(windows)))]
+#[cfg(all(feature="syntax-highlight"))]
 pub use syntax_highlight::list_syntax_themes;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,3 +59,6 @@ mod frontmatter;
 
 #[cfg(feature="syntax-highlight")]
 mod syntax_highlight;
+
+#[cfg(all(feature="syntax-highlight", not(windows)))]
+pub use syntax_highlight::list_syntax_themes;

--- a/src/main.rs
+++ b/src/main.rs
@@ -207,12 +207,8 @@ fn run() -> Result<()> {
                                  .value_name("COMMIT-MESSAGE")
                                  .help("Commit message that will be used on import")
                                  .default_value("cobalt site import")
-                                 .takes_value(true)));
-
-    #[cfg(all(feature="syntax-highlight"))]
-    let app_cli =
-        app_cli
-            .subcommand(SubCommand::with_name("list-syntax-themes").about("list available themes"));
+                                 .takes_value(true)))
+        .subcommand(SubCommand::with_name("list-syntax-themes").about("list available themes"));
 
     let global_matches = app_cli.get_matches();
 
@@ -418,7 +414,9 @@ fn run() -> Result<()> {
             }
 
             #[cfg(not(feature="syntax-highlight"))]
-            bail!(global_matches.usage());
+            bail!(concat!("No themes available.",
+                          "  This build of cobalt does not include",
+                          " support for syntax highlighting."));
         }
 
         _ => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -209,7 +209,7 @@ fn run() -> Result<()> {
                                  .default_value("cobalt site import")
                                  .takes_value(true)));
 
-    #[cfg(all(feature="syntax-highlight", not(windows)))]
+    #[cfg(all(feature="syntax-highlight"))]
     let app_cli =
         app_cli
             .subcommand(SubCommand::with_name("list-syntax-themes").about("list available themes"));
@@ -412,12 +412,12 @@ fn run() -> Result<()> {
         }
 
         "list-syntax-themes" => {
-            #[cfg(all(feature="syntax-highlight", not(windows)))]
+            #[cfg(all(feature="syntax-highlight"))]
             for name in list_syntax_themes() {
                 println!("{}", name);
             }
 
-            #[cfg(any(not(feature="syntax-highlight"), windows))]
+            #[cfg(not(feature="syntax-highlight"))]
             bail!(global_matches.usage());
         }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -42,6 +42,9 @@ use std::io::prelude::*;
 use std::io::Result as IoResult;
 use std::fs::File;
 
+#[cfg(all(feature="syntax-highlight", not(windows)))]
+use cobalt::list_syntax_themes;
+
 error_chain! {
 
     links {
@@ -60,7 +63,7 @@ error_chain! {
 quick_main!(run);
 
 fn run() -> Result<()> {
-    let global_matches = App::new("Cobalt")
+    let app_cli = App::new("Cobalt")
         .version(crate_version!())
         .author("Benny Klotz <r3qnbenni@gmail.com>, Johann Hofmann")
         .about("A static site generator written in Rust.")
@@ -204,8 +207,14 @@ fn run() -> Result<()> {
                                  .value_name("COMMIT-MESSAGE")
                                  .help("Commit message that will be used on import")
                                  .default_value("cobalt site import")
-                                 .takes_value(true)))
-        .get_matches();
+                                 .takes_value(true)));
+
+    #[cfg(all(feature="syntax-highlight", not(windows)))]
+    let app_cli =
+        app_cli
+            .subcommand(SubCommand::with_name("list-syntax-themes").about("list available themes"));
+
+    let global_matches = app_cli.get_matches();
 
     let (command, matches) = match global_matches.subcommand() {
         (command, Some(matches)) => (command, matches),
@@ -400,6 +409,16 @@ fn run() -> Result<()> {
             let branch = matches.value_of("branch").unwrap().to_string();
             let message = matches.value_of("message").unwrap().to_string();
             import(&config, &branch, &message);
+        }
+
+        "list-syntax-themes" => {
+            #[cfg(all(feature="syntax-highlight", not(windows)))]
+            for name in list_syntax_themes() {
+                println!("{}", name);
+            }
+
+            #[cfg(any(not(feature="syntax-highlight"), windows))]
+            bail!(global_matches.usage());
         }
 
         _ => {

--- a/src/syntax_highlight.rs
+++ b/src/syntax_highlight.rs
@@ -150,7 +150,11 @@ pub fn has_syntax_theme(name: &str) -> bool {
 }
 
 pub fn list_syntax_themes<'a>() -> Vec<&'a String> {
-    SETUP.theme_set.themes.keys().collect::<Vec<_>>()
+    #[cfg(not(windows))]
+    return SETUP.theme_set.themes.keys().collect::<Vec<_>>();
+
+    #[cfg(windows)]
+    return vec![];
 }
 
 #[cfg(test)]

--- a/src/syntax_highlight.rs
+++ b/src/syntax_highlight.rs
@@ -145,6 +145,10 @@ pub fn decorate_markdown<'a>(parser: Parser<'a>, config: &'a Config) -> Decorate
     DecoratedParser::new(parser, config)
 }
 
+pub fn has_syntax_theme(name: &str) -> bool {
+    SETUP.theme_set.themes.contains_key(name)
+}
+
 #[cfg(test)]
 mod test {
 

--- a/src/syntax_highlight.rs
+++ b/src/syntax_highlight.rs
@@ -98,9 +98,9 @@ impl<'a> Iterator for DecoratedParser<'a> {
                                 .unwrap_or_else(|| SETUP.syntax_set.find_syntax_plain_text());
                         self.h = Some(HighlightLines::new(&cur_syntax,
                                                           &SETUP.theme_set.themes
-                                                               [&self.config.theme]));
+                                                               [&self.config.syntax_theme]));
                         let snippet = start_coloured_html_snippet(&SETUP.theme_set.themes
-                                                                       [&self.config.theme]);
+                                                                       [&self.config.syntax_theme]);
                         return Some(Html(Owned(snippet)));
                     }
                     if let End(cmarkTag::CodeBlock(_)) = item {
@@ -144,7 +144,7 @@ pub fn initialize_codeblock(_: &str,
     Ok(Box::new(CodeBlock {
                     code: content,
                     lang: lang,
-                    theme: config.theme,
+                    theme: config.syntax_theme,
                 }))
 }
 

--- a/src/syntax_highlight.rs
+++ b/src/syntax_highlight.rs
@@ -149,6 +149,10 @@ pub fn has_syntax_theme(name: &str) -> bool {
     SETUP.theme_set.themes.contains_key(name)
 }
 
+pub fn list_syntax_themes<'a>() -> Vec<&'a String> {
+    SETUP.theme_set.themes.keys().collect::<Vec<_>>()
+}
+
 #[cfg(test)]
 mod test {
 

--- a/src/syntax_highlight.rs
+++ b/src/syntax_highlight.rs
@@ -2,6 +2,8 @@ extern crate syntect;
 extern crate liquid;
 extern crate pulldown_cmark as cmark;
 
+use error;
+
 use liquid::Renderable;
 use liquid::Context;
 use liquid::Token::{self, Identifier};
@@ -143,8 +145,15 @@ pub fn decorate_markdown<'a>(parser: Parser<'a>, theme_name: &str) -> DecoratedP
     DecoratedParser::new(parser, &SETUP.theme_set.themes[theme_name])
 }
 
-pub fn has_syntax_theme(name: &str) -> bool {
-    SETUP.theme_set.themes.contains_key(name)
+pub fn has_syntax_theme(name: &str) -> error::Result<bool> {
+    #[cfg(not(windows))]
+    return Ok(SETUP.theme_set.themes.contains_key(name));
+
+    #[cfg(windows)]
+    {
+        use error::ErrorKind;
+        return Err(ErrorKind::UnsupportedPlatform("syntax highlighting", "windows").into());
+    }
 }
 
 pub fn list_syntax_themes<'a>() -> Vec<&'a String> {


### PR DESCRIPTION
These patches build on @mre's initial work.  Only the default themes included by syntect are allowed.

~~I reverted @mre's changes to `Config`, `Document`, and `CodeBlock` since we only need to set the theme name once, and the `SETUP` variable already distributes themes to the `initialize_codeblock` and `decorate_markdown` functions.~~

~~I might be able to avoid the reversion with closures, but this PR is my third attempt, and I'd rather get feedback before I spend more time on this.~~

I tested the PR via the following process on Linux:

```
cd /tmp
git clone git@github.com:boxofrox/cobalt.rs.git
cd cobalt.rs
git checkout config-theme
cargo install --force cobalt-bin --path ./ --features=syntax-highlight
cd <cobalt-blog-directory>
cat "syntax-highlight:\n  theme: base16-ocean.light" >> .cobalt.yml
cobalt build
cobalt serve
# open localhost:3000 in browser
```

Use `cobalt list-syntax-themes` to view a list of available themes.

If acceptable to @mre's needs, fixes #202.  Otherwise, let's discuss what's missing.

*Updates:*

- Switch to patch set using closures instead of global `RefCell` variable.
- Syntax theme configured in `.cobalt.yml` with
    ```yaml
    syntax-highlight:
      theme: base16-eighties.dark
    ```
- Rename subcommand used to list syntax themes from `syntax-themes` to `list-syntax-themes`.
- Fix clippy lint errors.