### PR TITLE
chore: Refactor in preparation for #257

### DIFF
--- a/src/cobalt.rs
+++ b/src/cobalt.rs
@@ -4,13 +4,12 @@ use std::io::Write;
 use std::path::Path;
 use std::ffi::OsStr;
 use liquid::{Value, Object};
-use chrono::{UTC, FixedOffset};
-use chrono::offset::TimeZone;
 use rss::{Channel, Rss};
 use jsonfeed::Feed;
 use jsonfeed;
 use serde_yaml;
 
+use datetime;
 use document::Document;
 use error::{ErrorKind, Result};
 use config::{Config, Dump};
@@ -116,7 +115,7 @@ pub fn build(config: &Config) -> Result<()> {
     }
 
     // January 1, 1970 0:00:00 UTC, the beginning of time
-    let default_date = UTC.timestamp(0, 0).with_timezone(&FixedOffset::east(0));
+    let default_date = datetime::DateTime::default();
 
     let (mut posts, documents): (Vec<Document>, Vec<Document>) =
         documents.into_iter().partition(|x| x.is_post);

--- a/src/cobalt.rs
+++ b/src/cobalt.rs
@@ -133,7 +133,7 @@ pub fn build(config: &Config) -> Result<()> {
 
     trace!("Generating posts");
     for (i, mut post) in &mut posts.iter_mut().enumerate() {
-        trace!("Generating {}", post.path);
+        trace!("Generating {}", post.url_path);
 
         // posts are in reverse date order, so previous post is the next in the list (+1)
         if let Some(previous) = simple_posts_data.get(i + 1) {
@@ -147,14 +147,14 @@ pub fn build(config: &Config) -> Result<()> {
         }
 
         if config.dump.contains(&Dump::Liquid) {
-            create_liquid_dump(dest, &post.path, &post.content, &post.attributes)?;
+            create_liquid_dump(dest, &post.file_path, &post.content, &post.attributes)?;
         }
 
         let mut context = post.get_render_context(&simple_posts_data);
 
-        try!(post.render_excerpt(&mut context, source, &config.excerpt_separator));
-        let post_html = try!(post.render(&mut context, source, &layouts, &mut layouts_cache));
-        try!(create_document_file(&post_html, &post.path, dest));
+        post.render_excerpt(&mut context, source, &config.excerpt_separator)?;
+        let post_html = post.render(&mut context, source, &layouts, &mut layouts_cache)?;
+        create_document_file(post_html, &post.file_path, dest)?;
     }
 
     // check if we should create an RSS file and create it!
@@ -175,15 +175,15 @@ pub fn build(config: &Config) -> Result<()> {
 
     trace!("Generating other documents");
     for mut doc in documents {
-        trace!("Generating {}", doc.path);
+        trace!("Generating {}", doc.url_path);
 
         if config.dump.contains(&Dump::Liquid) {
-            create_liquid_dump(dest, &doc.path, &doc.content, &doc.attributes)?;
+            create_liquid_dump(dest, &doc.file_path, &doc.content, &doc.attributes)?;
         }
 
         let mut context = doc.get_render_context(&posts_data);
-        let doc_html = try!(doc.render(&mut context, source, &layouts, &mut layouts_cache));
-        try!(create_document_file(&doc_html, &doc.path, dest));
+        let doc_html = doc.render(&mut context, source, &layouts, &mut layouts_cache)?;
+        create_document_file(doc_html, doc.file_path, dest)?;
     }
 
     // copy all remaining files in the source to the destination

--- a/src/cobalt.rs
+++ b/src/cobalt.rs
@@ -79,7 +79,7 @@ pub fn build(config: &Config) -> Result<()> {
         let is_post = src_path.starts_with(posts_path.as_path());
 
         let doc = Document::parse(source, &file_path, &file_path, is_post, &config.post_path)?;
-        if !doc.is_draft || config.include_drafts {
+        if !doc.front.is_draft || config.include_drafts {
             documents.push(doc);
         }
     }
@@ -111,14 +111,15 @@ pub fn build(config: &Config) -> Result<()> {
     let default_date = datetime::DateTime::default();
 
     let (mut posts, documents): (Vec<Document>, Vec<Document>) =
-        documents.into_iter().partition(|x| x.is_post);
+        documents.into_iter().partition(|x| x.front.is_post);
 
     // sort documents by date, if there's no date (none was provided or it couldn't be read) then
     // fall back to the default date
     posts.sort_by(|a, b| {
-                      b.date
+                      b.front
+                          .published_date
                           .unwrap_or(default_date)
-                          .cmp(&a.date.unwrap_or(default_date))
+                          .cmp(&a.front.published_date.unwrap_or(default_date))
                   });
 
     if &config.post_order == "asc" {

--- a/src/cobalt.rs
+++ b/src/cobalt.rs
@@ -74,17 +74,11 @@ pub fn build(config: &Config) -> Result<()> {
                         template_extensions
                             .contains(&p.extension().unwrap_or_else(|| OsStr::new("")))
                     }) {
-        let src_path = source.join(file_path.as_path());
-
-        let new_path = source.join(file_path);
-        let new_path = new_path
-            .strip_prefix(source)
-            .expect("Entry not in source folder");
-
         // if the document is in the posts folder it's considered a post
+        let src_path = source.join(file_path.as_path());
         let is_post = src_path.starts_with(posts_path.as_path());
 
-        let doc = Document::parse(src_path.as_path(), new_path, is_post, &config.post_path)?;
+        let doc = Document::parse(source, &file_path, &file_path, is_post, &config.post_path)?;
         if !doc.is_draft || config.include_drafts {
             documents.push(doc);
         }
@@ -103,13 +97,12 @@ pub fn build(config: &Config) -> Result<()> {
                             template_extensions
                                 .contains(&p.extension().unwrap_or_else(|| OsStr::new("")))
                         }) {
-            let src_path = drafts_root.join(file_path.as_path());
-
-            let new_path = posts_path.join(file_path);
+            let new_path = posts_path.join(&file_path);
             let new_path = new_path
                 .strip_prefix(source)
                 .expect("Entry not in source folder");
-            let doc = try!(Document::parse(src_path.as_path(), new_path, true, &config.post_path));
+            let doc =
+                try!(Document::parse(&drafts_root, &file_path, new_path, true, &config.post_path));
             documents.push(doc);
         }
     }

--- a/src/datetime.rs
+++ b/src/datetime.rs
@@ -10,6 +10,10 @@ pub struct DateTime(chrono::DateTime<chrono::FixedOffset>);
 
 impl DateTime {
     pub fn parse<S: AsRef<str>>(d: S) -> Option<DateTime> {
+        DateTime::parse_str(d.as_ref())
+    }
+
+    fn parse_str(d: &str) -> Option<DateTime> {
         chrono::DateTime::parse_from_str(d.as_ref(), "%d %B %Y %H:%M:%S %z")
             .ok()
             .map(DateTime)

--- a/src/datetime.rs
+++ b/src/datetime.rs
@@ -1,0 +1,249 @@
+use std::fmt;
+use std::ops;
+use std::convert;
+use chrono;
+use chrono::TimeZone;
+use serde;
+
+#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Hash)]
+pub struct DateTime(chrono::DateTime<chrono::FixedOffset>);
+
+impl DateTime {
+    pub fn parse<S: AsRef<str>>(d: S) -> Option<DateTime> {
+        chrono::DateTime::parse_from_str(d.as_ref(), "%d %B %Y %H:%M:%S %z")
+            .ok()
+            .map(DateTime)
+    }
+
+    pub fn format(&self) -> String {
+        self.0.format("%d %B %Y %H:%M:%S %z").to_string()
+    }
+
+    pub fn with_offset(&self, secs: i32) -> Option<DateTime> {
+        let timezone = chrono::FixedOffset::east_opt(secs);
+        timezone.map(|tz| self.0.with_timezone(&tz).into())
+    }
+}
+
+impl Default for DateTime {
+    fn default() -> DateTime {
+        let d = chrono::UTC
+            .timestamp(0, 0)
+            .with_timezone(&chrono::FixedOffset::east(0));
+        DateTime(d)
+    }
+}
+
+impl ops::Deref for DateTime {
+    type Target = chrono::DateTime<chrono::FixedOffset>;
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl ops::DerefMut for DateTime {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+impl convert::From<chrono::DateTime<chrono::FixedOffset>> for DateTime {
+    fn from(v: chrono::DateTime<chrono::FixedOffset>) -> Self {
+        DateTime(v)
+    }
+}
+
+impl convert::From<DateTime> for chrono::DateTime<chrono::FixedOffset> {
+    fn from(v: DateTime) -> Self {
+        v.0
+    }
+}
+
+impl chrono::Datelike for DateTime {
+    #[inline]
+    fn year(&self) -> i32 {
+        self.0.year()
+    }
+    #[inline]
+    fn month(&self) -> u32 {
+        self.0.month()
+    }
+    #[inline]
+    fn month0(&self) -> u32 {
+        self.0.month0()
+    }
+    #[inline]
+    fn day(&self) -> u32 {
+        self.0.day()
+    }
+    #[inline]
+    fn day0(&self) -> u32 {
+        self.0.day0()
+    }
+    #[inline]
+    fn ordinal(&self) -> u32 {
+        self.0.ordinal()
+    }
+    #[inline]
+    fn ordinal0(&self) -> u32 {
+        self.0.ordinal0()
+    }
+    #[inline]
+    fn weekday(&self) -> chrono::Weekday {
+        self.0.weekday()
+    }
+    #[inline]
+    fn isoweekdate(&self) -> (i32, u32, chrono::Weekday) {
+        self.0.isoweekdate()
+    }
+
+    #[inline]
+    fn with_year(&self, year: i32) -> Option<DateTime> {
+        self.0.with_year(year).map(|d| d.into())
+    }
+
+    #[inline]
+    fn with_month(&self, month: u32) -> Option<DateTime> {
+        self.0.with_month(month).map(|d| d.into())
+    }
+
+    #[inline]
+    fn with_month0(&self, month0: u32) -> Option<DateTime> {
+        self.0.with_month0(month0).map(|d| d.into())
+    }
+
+    #[inline]
+    fn with_day(&self, day: u32) -> Option<DateTime> {
+        self.0.with_day(day).map(|d| d.into())
+    }
+
+    #[inline]
+    fn with_day0(&self, day0: u32) -> Option<DateTime> {
+        self.0.with_day(day0).map(|d| d.into())
+    }
+
+    #[inline]
+    fn with_ordinal(&self, ordinal: u32) -> Option<DateTime> {
+        self.0.with_ordinal(ordinal).map(|d| d.into())
+    }
+
+    #[inline]
+    fn with_ordinal0(&self, ordinal0: u32) -> Option<DateTime> {
+        self.0.with_ordinal0(ordinal0).map(|d| d.into())
+    }
+}
+
+impl chrono::Timelike for DateTime {
+    #[inline]
+    fn hour(&self) -> u32 {
+        self.0.hour()
+    }
+    #[inline]
+    fn minute(&self) -> u32 {
+        self.0.minute()
+    }
+    #[inline]
+    fn second(&self) -> u32 {
+        self.0.second()
+    }
+    #[inline]
+    fn nanosecond(&self) -> u32 {
+        self.0.nanosecond()
+    }
+
+    #[inline]
+    fn with_hour(&self, hour: u32) -> Option<DateTime> {
+        self.0.with_hour(hour).map(|d| d.into())
+    }
+
+    #[inline]
+    fn with_minute(&self, min: u32) -> Option<DateTime> {
+        self.0.with_minute(min).map(|d| d.into())
+    }
+
+    #[inline]
+    fn with_second(&self, sec: u32) -> Option<DateTime> {
+        self.0.with_second(sec).map(|d| d.into())
+    }
+
+    #[inline]
+    fn with_nanosecond(&self, nano: u32) -> Option<DateTime> {
+        self.0.with_nanosecond(nano).map(|d| d.into())
+    }
+}
+
+impl serde::Serialize for DateTime {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+        where S: serde::Serializer
+    {
+        serializer.collect_str(&self.format())
+    }
+}
+
+struct DateTimeVisitor;
+
+impl<'de> serde::de::Visitor<'de> for DateTimeVisitor {
+    type Value = DateTime;
+
+    fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        write!(formatter, "a formatted date and time string")
+    }
+
+    fn visit_str<E>(self, value: &str) -> Result<DateTime, E>
+        where E: serde::de::Error
+    {
+        DateTime::parse(value).ok_or_else(|| E::custom(format!("Invalid datetime '{}'", value)))
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for DateTime {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+        where D: serde::de::Deserializer<'de>
+    {
+        deserializer.deserialize_str(DateTimeVisitor)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::{Datelike, Timelike};
+
+    #[test]
+    fn format() {
+        let d = DateTime::default()
+            .with_year(2016)
+            .and_then(|d| d.with_month(1))
+            .and_then(|d| d.with_day(1))
+            .and_then(|d| d.with_hour(20))
+            .and_then(|d| d.with_offset(1 * 60 * 60))
+            .unwrap();
+        assert_eq!(d.format(), "01 January 2016 21:00:00 +0100");
+    }
+
+    #[test]
+    fn parse_short_month() {
+        let expected = DateTime::default()
+            .with_year(2016)
+            .and_then(|d| d.with_month(1))
+            .and_then(|d| d.with_day(1))
+            .and_then(|d| d.with_hour(20))
+            .and_then(|d| d.with_offset(1 * 60 * 60))
+            .unwrap();
+        assert_eq!(DateTime::parse("01 Jan 2016 21:00:00 +0100").unwrap(),
+                   expected);
+    }
+
+    #[test]
+    fn parse_long_month() {
+        let expected = DateTime::default()
+            .with_year(2016)
+            .and_then(|d| d.with_month(1))
+            .and_then(|d| d.with_day(1))
+            .and_then(|d| d.with_hour(20))
+            .and_then(|d| d.with_offset(1 * 60 * 60))
+            .unwrap();
+        assert_eq!(DateTime::parse("01 January 2016 21:00:00 +0100").unwrap(),
+                   expected);
+    }
+}

--- a/src/document.rs
+++ b/src/document.rs
@@ -76,7 +76,7 @@ fn format_path_variable(source_file: &Path) -> String {
     if path.starts_with("./") {
         path.remove(0);
     }
-    if path.starts_with("/") {
+    if path.starts_with('/') {
         path.remove(0);
     }
     path
@@ -116,7 +116,7 @@ fn permalink_attributes(front: &frontmatter::Frontmatter,
     }
 
     // Allow customizing any of the above with custom frontmatter attributes
-    for (key, val) in front.custom.iter() {
+    for (key, val) in &front.custom {
         let key = format!(":{}", key);
         // HACK: We really should support nested types
         let val = val.to_string();
@@ -140,7 +140,7 @@ fn explode_permalink_string(permalink: String, attributes: HashMap<String, Strin
     // Handle cases where substutions were blank
     p = p.replace("//", "/");
 
-    if p.starts_with("/") {
+    if p.starts_with('/') {
         p.remove(0);
     }
 
@@ -196,7 +196,7 @@ fn document_attributes(front: &frontmatter::Frontmatter,
     attributes.insert("draft".to_owned(), liquid::Value::Bool(front.is_draft));
     attributes.insert("is_post".to_owned(), liquid::Value::Bool(front.is_post));
 
-    for (key, val) in front.custom.iter() {
+    for (key, val) in &front.custom {
         attributes.insert(key.clone(), val.clone());
     }
 
@@ -240,7 +240,7 @@ impl Document {
         let attributes = front
             .map(|s| serde_yaml::from_str(s))
             .map_or(Ok(None), |r| r.map(Some))?
-            .unwrap_or_else(|| liquid::Object::new());
+            .unwrap_or_else(liquid::Object::new);
 
         let mut front = frontmatter::FrontmatterBuilder::new()
             .merge_title(attributes

--- a/src/document.rs
+++ b/src/document.rs
@@ -4,7 +4,7 @@ use std::collections::hash_map::Entry;
 use std::path::{Path, PathBuf};
 use std::default::Default;
 use error::Result;
-use chrono::{DateTime, FixedOffset, Datelike, Timelike};
+use chrono::{Datelike, Timelike};
 use yaml_rust::{Yaml, YamlLoader};
 use std::io::Read;
 use regex::Regex;
@@ -18,6 +18,7 @@ use syntax_highlight::{initialize_codeblock, decorate_markdown};
 
 use liquid::{Renderable, LiquidOptions, Context, Value, LocalTemplateRepository};
 
+use datetime;
 use pulldown_cmark as cmark;
 use liquid;
 
@@ -38,7 +39,7 @@ pub struct Document {
     pub layout: Option<String>,
     pub is_post: bool,
     pub is_draft: bool,
-    pub date: Option<DateTime<FixedOffset>>,
+    pub date: Option<datetime::DateTime>,
     file_path: String,
     markdown: bool,
 }
@@ -66,7 +67,7 @@ fn yaml_to_liquid(yaml: &Yaml) -> Option<Value> {
 /// and "exploding" the URL.
 fn format_path(p: &str,
                attributes: &HashMap<String, Value>,
-               date: &Option<DateTime<FixedOffset>>)
+               date: &Option<datetime::DateTime>)
                -> Result<String> {
     let mut p = p.to_owned();
 
@@ -125,7 +126,7 @@ impl Document {
                layout: Option<String>,
                is_post: bool,
                is_draft: bool,
-               date: Option<DateTime<FixedOffset>>,
+               date: Option<datetime::DateTime>,
                file_path: String,
                markdown: bool)
                -> Document {
@@ -201,7 +202,7 @@ impl Document {
         let date = attributes
             .get("date")
             .and_then(|d| d.as_str())
-            .and_then(|d| DateTime::parse_from_str(d, "%d %B %Y %H:%M:%S %z").ok());
+            .and_then(datetime::DateTime::parse);
 
         let file_stem = file_stem(new_path);
         let slug = slug::slugify(&file_stem);

--- a/src/document.rs
+++ b/src/document.rs
@@ -215,6 +215,10 @@ impl Document {
                              .get("title")
                              .and_then(|v| v.as_str())
                              .map(|s| s.to_owned()))
+            .merge_description(attributes
+                                   .get("description")
+                                   .and_then(|v| v.as_str())
+                                   .map(|s| s.to_owned()))
             .merge_slug(attributes
                             .get("slug")
                             .and_then(|v| v.as_str())

--- a/src/document.rs
+++ b/src/document.rs
@@ -12,6 +12,7 @@ use jsonfeed;
 use jsonfeed::Item;
 use jsonfeed::Content;
 use serde_yaml;
+use itertools;
 
 #[cfg(all(feature="syntax-highlight", not(windows)))]
 use syntax_highlight::{initialize_codeblock, decorate_markdown};
@@ -97,6 +98,9 @@ fn permalink_attributes(front: &frontmatter::Frontmatter,
     }
 
     attributes.insert(":slug".to_owned(), front.slug.clone());
+
+    attributes.insert(":categories".to_owned(),
+                      itertools::join(front.categories.iter(), "/"));
 
     attributes.insert(":output_ext".to_owned(), ".html".to_owned());
 

--- a/src/document.rs
+++ b/src/document.rs
@@ -304,7 +304,7 @@ impl Document {
             id: link.clone(),
             url: Some(link),
             title: Some(self.title_to_str().unwrap_or("unknown title".into())),
-            content: Content::Html(self.description_to_str().unwrap_or("".into())),
+            content: Content::Html(self.description_to_str().unwrap_or_else(|| "".into())),
             date_published: self.date.map(|date| date.to_rfc2822()),
             // TODO completely implement categories, see Issue 131
             tags: Some(cat),

--- a/src/frontmatter.rs
+++ b/src/frontmatter.rs
@@ -270,8 +270,6 @@ impl FrontmatterBuilder {
                 .unwrap_or("");
             let format = match ext {
                 "md" => SourceFormat::Markdown,
-                "liquid" => SourceFormat::Raw,
-                // TODO Evaluate making this an error when we break compatibility
                 _ => SourceFormat::Raw,
             };
             fm.format = Some(format);
@@ -356,7 +354,7 @@ pub struct Frontmatter {
     pub custom: liquid::Object,
 }
 
-/// Shallow merge of liquid::Object's
+/// Shallow merge of `liquid::Object`'s
 fn merge_objects(primary: liquid::Object, secondary: &liquid::Object) -> liquid::Object {
     let mut primary = primary;
     for (key, value) in secondary.iter() {

--- a/src/frontmatter.rs
+++ b/src/frontmatter.rs
@@ -182,6 +182,37 @@ impl FrontmatterBuilder {
         self.merge(FrontmatterBuilder::new().set_post(post.into()))
     }
 
+    pub fn merge_custom(self, other_custom: &liquid::Object) -> FrontmatterBuilder {
+        let FrontmatterBuilder {
+            path,
+            slug,
+            title,
+            description,
+            categories,
+            excerpt_separator,
+            published_date,
+            format,
+            layout,
+            is_draft,
+            is_post,
+            custom,
+        } = self;
+        FrontmatterBuilder {
+            path: path,
+            slug: slug,
+            title: title,
+            description: description,
+            categories: categories,
+            excerpt_separator: excerpt_separator,
+            published_date: published_date,
+            format: format,
+            layout: layout,
+            is_draft: is_draft,
+            is_post: is_post,
+            custom: merge_objects(custom, other_custom),
+        }
+    }
+
     pub fn merge(self, other: FrontmatterBuilder) -> FrontmatterBuilder {
         let FrontmatterBuilder {
             path,
@@ -284,14 +315,10 @@ impl FrontmatterBuilder {
         let is_post = is_post.unwrap_or(false);
 
         let path = path.unwrap_or_else(|| {
-            let default_path = if is_post {
-                "/:categories/:year/:month/:day/:slug.html"
-            } else {
-                "/:path/:slug.:output_ext"
-            };
+                                           let default_path = "/:path/:filename:output_ext";
 
-            default_path.to_owned()
-        });
+                                           default_path.to_owned()
+                                       });
 
         let fm = Frontmatter {
             path: path,

--- a/src/frontmatter.rs
+++ b/src/frontmatter.rs
@@ -178,7 +178,7 @@ impl FrontmatterBuilder {
         self.merge(FrontmatterBuilder::new().set_post(post.into()))
     }
 
-    pub fn merge_custom(self, other_custom: &liquid::Object) -> FrontmatterBuilder {
+    pub fn merge_custom(self, other_custom: liquid::Object) -> FrontmatterBuilder {
         let FrontmatterBuilder {
             path,
             slug,
@@ -250,7 +250,7 @@ impl FrontmatterBuilder {
             layout: layout.or_else(|| other_layout),
             is_draft: is_draft.or_else(|| other_is_draft),
             is_post: is_post.or_else(|| other_is_post),
-            custom: merge_objects(custom, &other_custom),
+            custom: merge_objects(custom, other_custom),
         }
     }
 
@@ -353,7 +353,7 @@ pub struct Frontmatter {
 }
 
 /// Shallow merge of `liquid::Object`'s
-fn merge_objects(primary: liquid::Object, secondary: &liquid::Object) -> liquid::Object {
+fn merge_objects(primary: liquid::Object, secondary: liquid::Object) -> liquid::Object {
     let mut primary = primary;
     for (key, value) in secondary.iter() {
         primary

--- a/src/frontmatter.rs
+++ b/src/frontmatter.rs
@@ -66,7 +66,6 @@ impl FrontmatterBuilder {
         }
     }
 
-    #[cfg(test)]
     pub fn set_description<S: Into<Option<String>>>(self, description: S) -> FrontmatterBuilder {
         FrontmatterBuilder {
             description: description.into(),
@@ -141,7 +140,6 @@ impl FrontmatterBuilder {
         self.merge(FrontmatterBuilder::new().set_title(title.into()))
     }
 
-    #[cfg(test)]
     pub fn merge_description<S: Into<Option<String>>>(self, description: S) -> FrontmatterBuilder {
         self.merge(FrontmatterBuilder::new().set_description(description.into()))
     }

--- a/src/frontmatter.rs
+++ b/src/frontmatter.rs
@@ -1,0 +1,505 @@
+use std::path;
+use liquid;
+
+use error::Result;
+use datetime;
+use slug;
+
+#[derive(Debug, Eq, PartialEq, Hash, Copy, Clone)]
+#[derive(Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub enum SourceFormat {
+    Raw,
+    Markdown,
+}
+
+impl Default for SourceFormat {
+    fn default() -> SourceFormat {
+        SourceFormat::Raw
+    }
+}
+
+#[derive(Debug, Eq, PartialEq, Default, Clone)]
+#[derive(Serialize, Deserialize)]
+#[serde(deny_unknown_fields, default)]
+pub struct FrontmatterBuilder {
+    pub path: Option<String>,
+    pub slug: Option<String>,
+    pub title: Option<String>,
+    pub description: Option<String>,
+    pub categories: Option<Vec<String>>,
+    pub excerpt_separator: Option<String>,
+    pub published_date: Option<datetime::DateTime>,
+    pub format: Option<SourceFormat>,
+    pub layout: Option<String>,
+    pub is_draft: Option<bool>,
+    // Controlled by where the file is found.  We might allow control over the type at a later
+    // point but we need to first define those semantics.
+    #[serde(skip)]
+    pub is_post: Option<bool>,
+    pub custom: liquid::Object,
+}
+
+impl FrontmatterBuilder {
+    pub fn new() -> FrontmatterBuilder {
+        FrontmatterBuilder::default()
+    }
+
+    #[cfg(test)]
+    pub fn set_permalink<S: Into<Option<String>>>(self, permalink: S) -> FrontmatterBuilder {
+        FrontmatterBuilder {
+            path: permalink.into(),
+            ..self
+        }
+    }
+
+    pub fn set_slug<S: Into<Option<String>>>(self, slug: S) -> FrontmatterBuilder {
+        FrontmatterBuilder {
+            slug: slug.into(),
+            ..self
+        }
+    }
+
+    pub fn set_title<S: Into<Option<String>>>(self, title: S) -> FrontmatterBuilder {
+        FrontmatterBuilder {
+            title: title.into(),
+            ..self
+        }
+    }
+
+    #[cfg(test)]
+    pub fn set_description<S: Into<Option<String>>>(self, description: S) -> FrontmatterBuilder {
+        FrontmatterBuilder {
+            description: description.into(),
+            ..self
+        }
+    }
+
+    #[cfg(test)]
+    pub fn set_categories<S: Into<Option<Vec<String>>>>(self, categories: S) -> FrontmatterBuilder {
+        FrontmatterBuilder {
+            categories: categories.into(),
+            ..self
+        }
+    }
+
+    #[cfg(test)]
+    pub fn set_excerpt_separator<S: Into<Option<String>>>(self,
+                                                          excerpt_separator: S)
+                                                          -> FrontmatterBuilder {
+        FrontmatterBuilder {
+            excerpt_separator: excerpt_separator.into(),
+            ..self
+        }
+    }
+
+    pub fn set_published_date<D: Into<Option<datetime::DateTime>>>(self,
+                                                                   published_date: D)
+                                                                   -> FrontmatterBuilder {
+        FrontmatterBuilder {
+            published_date: published_date.into(),
+            ..self
+        }
+    }
+
+    #[cfg(test)]
+    pub fn set_format<S: Into<Option<SourceFormat>>>(self, format: S) -> FrontmatterBuilder {
+        FrontmatterBuilder {
+            format: format.into(),
+            ..self
+        }
+    }
+
+    pub fn set_layout<S: Into<Option<String>>>(self, layout: S) -> FrontmatterBuilder {
+        FrontmatterBuilder {
+            layout: layout.into(),
+            ..self
+        }
+    }
+
+    pub fn set_draft<B: Into<Option<bool>>>(self, is_draft: B) -> FrontmatterBuilder {
+        FrontmatterBuilder {
+            is_draft: is_draft.into(),
+            ..self
+        }
+    }
+
+    pub fn set_post<B: Into<Option<bool>>>(self, is_post: B) -> FrontmatterBuilder {
+        FrontmatterBuilder {
+            is_post: is_post.into(),
+            ..self
+        }
+    }
+
+    #[cfg(test)]
+    pub fn merge_permalink<S: Into<Option<String>>>(self, permalink: S) -> FrontmatterBuilder {
+        self.merge(&FrontmatterBuilder::new().set_permalink(permalink.into()))
+    }
+
+    pub fn merge_slug<S: Into<Option<String>>>(self, slug: S) -> FrontmatterBuilder {
+        self.merge(&FrontmatterBuilder::new().set_slug(slug.into()))
+    }
+
+    pub fn merge_title<S: Into<Option<String>>>(self, title: S) -> FrontmatterBuilder {
+        self.merge(&FrontmatterBuilder::new().set_title(title.into()))
+    }
+
+    #[cfg(test)]
+    pub fn merge_description<S: Into<Option<String>>>(self, description: S) -> FrontmatterBuilder {
+        self.merge(&FrontmatterBuilder::new().set_description(description.into()))
+    }
+
+    #[cfg(test)]
+    pub fn merge_categories<S: Into<Option<Vec<String>>>>(self,
+                                                          categories: S)
+                                                          -> FrontmatterBuilder {
+        self.merge(&FrontmatterBuilder::new().set_categories(categories.into()))
+    }
+
+    #[cfg(test)]
+    pub fn merge_excerpt_separator<S: Into<Option<String>>>(self,
+                                                            excerpt_separator: S)
+                                                            -> FrontmatterBuilder {
+        self.merge(&FrontmatterBuilder::new().set_excerpt_separator(excerpt_separator.into()))
+    }
+
+    pub fn merge_published_date<D: Into<Option<datetime::DateTime>>>(self,
+                                                                     published_date: D)
+                                                                     -> FrontmatterBuilder {
+        self.merge(&FrontmatterBuilder::new().set_published_date(published_date.into()))
+    }
+
+    #[cfg(test)]
+    pub fn merge_format<S: Into<Option<SourceFormat>>>(self, format: S) -> FrontmatterBuilder {
+        self.merge(&FrontmatterBuilder::new().set_format(format.into()))
+    }
+
+    pub fn merge_layout<S: Into<Option<String>>>(self, layout: S) -> FrontmatterBuilder {
+        self.merge(&FrontmatterBuilder::new().set_layout(layout.into()))
+    }
+
+    pub fn merge_draft<B: Into<Option<bool>>>(self, draft: B) -> FrontmatterBuilder {
+        self.merge(&FrontmatterBuilder::new().set_draft(draft.into()))
+    }
+
+    pub fn merge_post<B: Into<Option<bool>>>(self, post: B) -> FrontmatterBuilder {
+        self.merge(&FrontmatterBuilder::new().set_post(post.into()))
+    }
+
+    pub fn merge(self, other: &FrontmatterBuilder) -> FrontmatterBuilder {
+        let FrontmatterBuilder {
+            path,
+            slug,
+            title,
+            description,
+            categories,
+            excerpt_separator,
+            published_date,
+            format,
+            layout,
+            is_draft,
+            is_post,
+            custom,
+        } = self;
+        FrontmatterBuilder {
+            path: path.or_else(|| other.path.clone()),
+            slug: slug.or_else(|| other.slug.clone()),
+            title: title.or_else(|| other.title.clone()),
+            description: description.or_else(|| other.description.clone()),
+            categories: categories.or_else(|| other.categories.clone()),
+            excerpt_separator: excerpt_separator.or_else(|| other.excerpt_separator.clone()),
+            published_date: published_date.or_else(|| other.published_date.clone()),
+            format: format.or_else(|| other.format.clone()),
+            layout: layout.or_else(|| other.layout.clone()),
+            is_draft: is_draft.or_else(|| other.is_draft.clone()),
+            is_post: is_post.or_else(|| other.is_post.clone()),
+            custom: merge_objects(custom, &other.custom),
+        }
+    }
+
+    pub fn merge_path<P: AsRef<path::Path>>(self, relpath: P) -> Result<FrontmatterBuilder> {
+        self.merge_path_ref(relpath.as_ref())
+    }
+
+    fn merge_path_ref(self, relpath: &path::Path) -> Result<FrontmatterBuilder> {
+        let mut fm = self;
+
+        if fm.format.is_none() {
+            let ext = relpath
+                .extension()
+                .and_then(|os| os.to_str())
+                .unwrap_or("");
+            let format = match ext {
+                "md" => SourceFormat::Markdown,
+                "liquid" => SourceFormat::Raw,
+                // TODO Evaluate making this an error when we break compatibility
+                _ => SourceFormat::Raw,
+            };
+            fm.format = Some(format);
+        }
+
+        if fm.slug.is_none() {
+            let file_stem = file_stem(relpath);
+            let slug = slug::slugify(file_stem);
+            fm.slug = Some(slug);
+        }
+
+        if fm.title.is_none() {
+            let slug = fm.slug
+                .as_ref()
+                .expect("slug has been unconditionally initialized");
+            let title = slug::titleize_slug(slug);
+            fm.title = Some(title);
+        }
+
+        Ok(fm)
+    }
+
+    pub fn build(self) -> Result<Frontmatter> {
+        let FrontmatterBuilder {
+            path,
+            slug,
+            title,
+            description,
+            categories,
+            excerpt_separator,
+            published_date,
+            format,
+            layout,
+            is_draft,
+            is_post,
+            custom,
+        } = self;
+
+        let is_post = is_post.unwrap_or(false);
+
+        let path = path.unwrap_or_else(|| {
+            let default_path = if is_post {
+                "/:categories/:year/:month/:day/:slug.html"
+            } else {
+                "/:path/:slug.:output_ext"
+            };
+
+            default_path.to_owned()
+        });
+
+        let fm = Frontmatter {
+            path: path,
+            slug: slug.ok_or_else(|| "No slug")?,
+            title: title.ok_or_else(|| "No title")?,
+            description: description,
+            categories: categories.unwrap_or_else(|| vec![]),
+            excerpt_separator: excerpt_separator.unwrap_or_else(|| "\n\n".to_owned()),
+            published_date: published_date,
+            format: format.unwrap_or_else(SourceFormat::default),
+            layout: layout,
+            is_draft: is_draft.unwrap_or(false),
+            is_post: is_post,
+            custom: custom,
+        };
+
+        Ok(fm)
+    }
+}
+
+#[derive(Debug, Eq, PartialEq, Default, Clone)]
+#[derive(Serialize, Deserialize)]
+#[serde(deny_unknown_fields, default)]
+pub struct Frontmatter {
+    pub path: String,
+    pub slug: String,
+    pub title: String,
+    pub description: Option<String>,
+    pub categories: Vec<String>,
+    pub excerpt_separator: String,
+    pub published_date: Option<datetime::DateTime>,
+    pub format: SourceFormat,
+    pub layout: Option<String>,
+    pub is_draft: bool,
+    #[serde(skip)]
+    pub is_post: bool,
+    pub custom: liquid::Object,
+}
+
+/// Shallow merge of liquid::Object's
+fn merge_objects(primary: liquid::Object, secondary: &liquid::Object) -> liquid::Object {
+    let mut primary = primary;
+    for (key, value) in secondary.iter() {
+        primary
+            .entry(key.to_owned())
+            .or_insert_with(|| value.clone());
+    }
+    primary
+}
+
+/// The base-name without an extension.  Correlates to Jekyll's :name path tag
+fn file_stem<P: AsRef<path::Path>>(p: P) -> String {
+    file_stem_path(p.as_ref())
+}
+
+fn file_stem_path(p: &path::Path) -> String {
+    p.file_stem()
+        .map(|os| os.to_string_lossy().into_owned())
+        .unwrap_or_else(|| "".to_owned())
+}
+
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn file_stem_absolute_path() {
+        let input = path::PathBuf::from("/embedded/path/___filE-worlD-__09___.md");
+        let actual = file_stem(input.as_path());
+        assert_eq!(actual, "___filE-worlD-__09___");
+    }
+
+    #[test]
+    fn frontmatter_title_from_path() {
+        let front = FrontmatterBuilder::new()
+            .merge_path("./parent/file.md")
+            .unwrap()
+            .build()
+            .unwrap();
+        assert_eq!(front.title, "File");
+    }
+
+    #[test]
+    fn frontmatter_slug_from_md_path() {
+        let front = FrontmatterBuilder::new()
+            .merge_path("./parent/file.md")
+            .unwrap()
+            .build()
+            .unwrap();
+        assert_eq!(front.slug, "file");
+    }
+
+    #[test]
+    fn frontmatter_markdown_from_path() {
+        let front = FrontmatterBuilder::new()
+            .merge_path("./parent/file.md")
+            .unwrap()
+            .build()
+            .unwrap();
+        assert_eq!(front.format, SourceFormat::Markdown);
+    }
+
+    #[test]
+    fn frontmatter_raw_from_path() {
+        let front = FrontmatterBuilder::new()
+            .merge_path("./parent/file.liquid")
+            .unwrap()
+            .build()
+            .unwrap();
+        assert_eq!(front.format, SourceFormat::Raw);
+    }
+
+    #[test]
+    fn frontmatter_global_merge() {
+        let empty = FrontmatterBuilder::new();
+        let a = FrontmatterBuilder {
+            path: Some("path a".to_owned()),
+            slug: Some("slug a".to_owned()),
+            title: Some("title a".to_owned()),
+            description: Some("description a".to_owned()),
+            categories: Some(vec!["a".to_owned(), "b".to_owned()]),
+            excerpt_separator: Some("excerpt_separator a".to_owned()),
+            published_date: Some(datetime::DateTime::default()),
+            format: Some(SourceFormat::Markdown),
+            layout: Some("layout a".to_owned()),
+            is_draft: Some(true),
+            is_post: Some(false),
+            custom: liquid::Object::new(),
+        };
+        let b = FrontmatterBuilder {
+            path: Some("path b".to_owned()),
+            slug: Some("slug b".to_owned()),
+            title: Some("title b".to_owned()),
+            description: Some("description b".to_owned()),
+            categories: Some(vec!["b".to_owned(), "a".to_owned()]),
+            excerpt_separator: Some("excerpt_separator b".to_owned()),
+            published_date: Some(datetime::DateTime::default()),
+            format: Some(SourceFormat::Raw),
+            layout: Some("layout b".to_owned()),
+            is_draft: Some(true),
+            is_post: Some(false),
+            custom: liquid::Object::new(),
+        };
+
+        let merge_b_into_a = a.clone().merge(&b);
+        assert_eq!(merge_b_into_a, a);
+
+        let merge_empty_into_a = a.clone().merge(&empty);
+        assert_eq!(merge_empty_into_a, a);
+
+        let merge_a_into_empty = empty.clone().merge(&a);
+        assert_eq!(merge_a_into_empty, a);
+    }
+
+    #[test]
+    fn frontmatter_local_merge() {
+        let a = FrontmatterBuilder {
+            path: Some("path a".to_owned()),
+            slug: Some("slug a".to_owned()),
+            title: Some("title a".to_owned()),
+            description: Some("description a".to_owned()),
+            categories: Some(vec!["a".to_owned(), "b".to_owned()]),
+            excerpt_separator: Some("excerpt_separator a".to_owned()),
+            published_date: None,
+            format: Some(SourceFormat::Markdown),
+            layout: Some("layout a".to_owned()),
+            is_draft: Some(true),
+            is_post: Some(false),
+            custom: liquid::Object::new(),
+        };
+
+        let merge_b_into_a = a.clone()
+            .merge_permalink("path b".to_owned())
+            .merge_slug("slug b".to_owned())
+            .merge_title("title b".to_owned())
+            .merge_description("description b".to_owned())
+            .merge_categories(vec!["a".to_owned(), "b".to_owned()])
+            .merge_excerpt_separator("excerpt_separator b".to_owned())
+            .merge_format(SourceFormat::Raw)
+            .merge_layout("layout b".to_owned())
+            .merge_draft(true)
+            .merge_post(false);
+        assert_eq!(merge_b_into_a, a);
+
+        let merge_empty_into_a = a.clone()
+            .merge_permalink(None)
+            .merge_slug(None)
+            .merge_title(None)
+            .merge_description(None)
+            .merge_categories(None)
+            .merge_excerpt_separator(None)
+            .merge_format(None)
+            .merge_layout(None)
+            .merge_draft(None)
+            .merge_post(None);
+        assert_eq!(merge_empty_into_a, a);
+
+        let merge_a_into_empty = FrontmatterBuilder::new()
+            .merge_permalink("path a".to_owned())
+            .merge_slug("slug a".to_owned())
+            .merge_title("title a".to_owned())
+            .merge_description("description a".to_owned())
+            .merge_categories(vec!["a".to_owned(), "b".to_owned()])
+            .merge_excerpt_separator("excerpt_separator a".to_owned())
+            .merge_format(SourceFormat::Markdown)
+            .merge_layout("layout a".to_owned())
+            .merge_draft(true)
+            .merge_post(false);
+        assert_eq!(merge_a_into_empty, a);
+    }
+
+    #[test]
+    fn frontmatter_defaults() {
+        FrontmatterBuilder::new()
+            .set_title("Title".to_owned())
+            .set_slug("Slug".to_owned())
+            .build()
+            .unwrap();
+    }
+}

--- a/src/frontmatter.rs
+++ b/src/frontmatter.rs
@@ -73,7 +73,6 @@ impl FrontmatterBuilder {
         }
     }
 
-    #[cfg(test)]
     pub fn set_categories<S: Into<Option<Vec<String>>>>(self, categories: S) -> FrontmatterBuilder {
         FrontmatterBuilder {
             categories: categories.into(),
@@ -144,7 +143,6 @@ impl FrontmatterBuilder {
         self.merge(FrontmatterBuilder::new().set_description(description.into()))
     }
 
-    #[cfg(test)]
     pub fn merge_categories<S: Into<Option<Vec<String>>>>(self,
                                                           categories: S)
                                                           -> FrontmatterBuilder {

--- a/src/frontmatter.rs
+++ b/src/frontmatter.rs
@@ -45,7 +45,6 @@ impl FrontmatterBuilder {
         FrontmatterBuilder::default()
     }
 
-    #[cfg(test)]
     pub fn set_permalink<S: Into<Option<String>>>(self, permalink: S) -> FrontmatterBuilder {
         FrontmatterBuilder {
             path: permalink.into(),
@@ -83,7 +82,6 @@ impl FrontmatterBuilder {
         }
     }
 
-    #[cfg(test)]
     pub fn set_excerpt_separator<S: Into<Option<String>>>(self,
                                                           excerpt_separator: S)
                                                           -> FrontmatterBuilder {
@@ -131,62 +129,60 @@ impl FrontmatterBuilder {
         }
     }
 
-    #[cfg(test)]
     pub fn merge_permalink<S: Into<Option<String>>>(self, permalink: S) -> FrontmatterBuilder {
-        self.merge(&FrontmatterBuilder::new().set_permalink(permalink.into()))
+        self.merge(FrontmatterBuilder::new().set_permalink(permalink.into()))
     }
 
     pub fn merge_slug<S: Into<Option<String>>>(self, slug: S) -> FrontmatterBuilder {
-        self.merge(&FrontmatterBuilder::new().set_slug(slug.into()))
+        self.merge(FrontmatterBuilder::new().set_slug(slug.into()))
     }
 
     pub fn merge_title<S: Into<Option<String>>>(self, title: S) -> FrontmatterBuilder {
-        self.merge(&FrontmatterBuilder::new().set_title(title.into()))
+        self.merge(FrontmatterBuilder::new().set_title(title.into()))
     }
 
     #[cfg(test)]
     pub fn merge_description<S: Into<Option<String>>>(self, description: S) -> FrontmatterBuilder {
-        self.merge(&FrontmatterBuilder::new().set_description(description.into()))
+        self.merge(FrontmatterBuilder::new().set_description(description.into()))
     }
 
     #[cfg(test)]
     pub fn merge_categories<S: Into<Option<Vec<String>>>>(self,
                                                           categories: S)
                                                           -> FrontmatterBuilder {
-        self.merge(&FrontmatterBuilder::new().set_categories(categories.into()))
+        self.merge(FrontmatterBuilder::new().set_categories(categories.into()))
     }
 
-    #[cfg(test)]
     pub fn merge_excerpt_separator<S: Into<Option<String>>>(self,
                                                             excerpt_separator: S)
                                                             -> FrontmatterBuilder {
-        self.merge(&FrontmatterBuilder::new().set_excerpt_separator(excerpt_separator.into()))
+        self.merge(FrontmatterBuilder::new().set_excerpt_separator(excerpt_separator.into()))
     }
 
     pub fn merge_published_date<D: Into<Option<datetime::DateTime>>>(self,
                                                                      published_date: D)
                                                                      -> FrontmatterBuilder {
-        self.merge(&FrontmatterBuilder::new().set_published_date(published_date.into()))
+        self.merge(FrontmatterBuilder::new().set_published_date(published_date.into()))
     }
 
     #[cfg(test)]
     pub fn merge_format<S: Into<Option<SourceFormat>>>(self, format: S) -> FrontmatterBuilder {
-        self.merge(&FrontmatterBuilder::new().set_format(format.into()))
+        self.merge(FrontmatterBuilder::new().set_format(format.into()))
     }
 
     pub fn merge_layout<S: Into<Option<String>>>(self, layout: S) -> FrontmatterBuilder {
-        self.merge(&FrontmatterBuilder::new().set_layout(layout.into()))
+        self.merge(FrontmatterBuilder::new().set_layout(layout.into()))
     }
 
     pub fn merge_draft<B: Into<Option<bool>>>(self, draft: B) -> FrontmatterBuilder {
-        self.merge(&FrontmatterBuilder::new().set_draft(draft.into()))
+        self.merge(FrontmatterBuilder::new().set_draft(draft.into()))
     }
 
     pub fn merge_post<B: Into<Option<bool>>>(self, post: B) -> FrontmatterBuilder {
-        self.merge(&FrontmatterBuilder::new().set_post(post.into()))
+        self.merge(FrontmatterBuilder::new().set_post(post.into()))
     }
 
-    pub fn merge(self, other: &FrontmatterBuilder) -> FrontmatterBuilder {
+    pub fn merge(self, other: FrontmatterBuilder) -> FrontmatterBuilder {
         let FrontmatterBuilder {
             path,
             slug,
@@ -201,19 +197,33 @@ impl FrontmatterBuilder {
             is_post,
             custom,
         } = self;
+        let FrontmatterBuilder {
+            path: other_path,
+            slug: other_slug,
+            title: other_title,
+            description: other_description,
+            categories: other_categories,
+            excerpt_separator: other_excerpt_separator,
+            published_date: other_published_date,
+            format: other_format,
+            layout: other_layout,
+            is_draft: other_is_draft,
+            is_post: other_is_post,
+            custom: other_custom,
+        } = other;
         FrontmatterBuilder {
-            path: path.or_else(|| other.path.clone()),
-            slug: slug.or_else(|| other.slug.clone()),
-            title: title.or_else(|| other.title.clone()),
-            description: description.or_else(|| other.description.clone()),
-            categories: categories.or_else(|| other.categories.clone()),
-            excerpt_separator: excerpt_separator.or_else(|| other.excerpt_separator.clone()),
-            published_date: published_date.or_else(|| other.published_date.clone()),
-            format: format.or_else(|| other.format.clone()),
-            layout: layout.or_else(|| other.layout.clone()),
-            is_draft: is_draft.or_else(|| other.is_draft.clone()),
-            is_post: is_post.or_else(|| other.is_post.clone()),
-            custom: merge_objects(custom, &other.custom),
+            path: path.or_else(|| other_path),
+            slug: slug.or_else(|| other_slug),
+            title: title.or_else(|| other_title),
+            description: description.or_else(|| other_description),
+            categories: categories.or_else(|| other_categories),
+            excerpt_separator: excerpt_separator.or_else(|| other_excerpt_separator),
+            published_date: published_date.or_else(|| other_published_date),
+            format: format.or_else(|| other_format),
+            layout: layout.or_else(|| other_layout),
+            is_draft: is_draft.or_else(|| other_is_draft),
+            is_post: is_post.or_else(|| other_is_post),
+            custom: merge_objects(custom, &other_custom),
         }
     }
 
@@ -427,13 +437,13 @@ mod test {
             custom: liquid::Object::new(),
         };
 
-        let merge_b_into_a = a.clone().merge(&b);
+        let merge_b_into_a = a.clone().merge(b.clone());
         assert_eq!(merge_b_into_a, a);
 
-        let merge_empty_into_a = a.clone().merge(&empty);
+        let merge_empty_into_a = a.clone().merge(empty.clone());
         assert_eq!(merge_empty_into_a, a);
 
-        let merge_a_into_empty = empty.clone().merge(&a);
+        let merge_a_into_empty = empty.clone().merge(a.clone());
         assert_eq!(merge_a_into_empty, a);
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,7 +18,6 @@ extern crate rss;
 extern crate jsonfeed;
 extern crate walkdir;
 extern crate yaml_rust;
-extern crate serde;
 extern crate serde_yaml;
 
 extern crate itertools;
@@ -38,6 +37,9 @@ extern crate error_chain;
 #[macro_use]
 extern crate lazy_static;
 
+#[macro_use]
+extern crate serde;
+
 pub use cobalt::build;
 pub use error::Error;
 pub use config::Config;
@@ -53,6 +55,7 @@ mod new;
 mod slug;
 mod files;
 mod datetime;
+mod frontmatter;
 
 #[cfg(feature="syntax-highlight")]
 mod syntax_highlight;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,6 +52,7 @@ mod document;
 mod new;
 mod slug;
 mod files;
+mod datetime;
 
 #[cfg(feature="syntax-highlight")]
 mod syntax_highlight;

--- a/src/slug.rs
+++ b/src/slug.rs
@@ -6,7 +6,11 @@ lazy_static!{
 }
 
 /// Create a slug for a given file.  Correlates to Jekyll's :slug path tag
-pub fn slugify(name: &str) -> String {
+pub fn slugify<S: AsRef<str>>(name: S) -> String {
+    slugify_str(name.as_ref())
+}
+
+fn slugify_str(name: &str) -> String {
     let slug = SLUG_INVALID_CHARS.replace_all(name, "-");
     slug.trim_matches('-').to_lowercase()
 }
@@ -25,7 +29,11 @@ fn title_case(s: &str) -> String {
 }
 
 /// Format a user-visible title out of a slug.  Correlates to Jekyll's "title" attribute
-pub fn titleize_slug(slug: &str) -> String {
+pub fn titleize_slug<S: AsRef<str>>(slug: S) -> String {
+    titleize_slug_str(slug.as_ref())
+}
+
+fn titleize_slug_str(slug: &str) -> String {
     slug.split('-').map(title_case).join(" ")
 }
 

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -172,7 +172,7 @@ pub fn no_extends_error() {
     assert!(err.unwrap_err()
                 .description()
                 .contains("Layout default_nonexistent.liquid can not be read (defined in \
-                   tests/fixtures/no_extends_error/index.liquid)"));
+                   index.liquid)"));
 }
 
 #[test]

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -12,6 +12,14 @@ use walkdir::WalkDir;
 use std::error::Error;
 use cobalt::Config;
 
+macro_rules! assert_contains {
+    ($haystack: expr, $needle: expr) => {
+        let text = $haystack.to_owned();
+        println!("{}", text);
+        assert!(text.contains($needle))
+    }
+}
+
 fn run_test(name: &str) -> Result<(), cobalt::Error> {
     let target = format!("tests/target/{}/", name);
     let mut config = Config::from_file(format!("tests/fixtures/{}/.cobalt.yml", name))
@@ -169,10 +177,9 @@ pub fn liquid_raw() {
 pub fn no_extends_error() {
     let err = run_test("no_extends_error");
     assert!(err.is_err());
-    assert!(err.unwrap_err()
-                .description()
-                .contains("Layout default_nonexistent.liquid can not be read (defined in \
-                   index.liquid)"));
+    assert_contains!(err.unwrap_err().description(),
+                     "Layout default_nonexistent.liquid can not be read (defined in \
+                   \"index.html\")");
 }
 
 #[test]

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -216,7 +216,7 @@ pub fn ignore_files() {
 pub fn yaml_error() {
     let err = run_test("yaml_error");
     assert!(err.is_err());
-    assert_eq!(err.unwrap_err().description(), "unexpected character: `@'");
+    assert_eq!(err.unwrap_err().description(), "scan error");
 }
 
 #[test]

--- a/tests/target/custom_paths/2015/05/5/03/3/01/05/20/index.html
+++ b/tests/target/custom_paths/2015/05/5/03/3/01/05/20/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
     <head>
-        <title>My blog - 2015/05/5/03/3/01/05/20/index.html</title>
+        <title>My blog - 2015/05/5/03/3/01/05/20/</title>
     </head>
     <body>
         <h1>All date variables</h1>

--- a/tests/target/custom_paths/2015/hello/index.html
+++ b/tests/target/custom_paths/2015/hello/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
     <head>
-        <title>My blog - 2015/hello/index.html</title>
+        <title>My blog - 2015/hello/</title>
     </head>
     <body>
         <h1>Date variables</h1>

--- a/tests/target/custom_paths/index.html
+++ b/tests/target/custom_paths/index.html
@@ -11,21 +11,21 @@
 
  <a href="test/hello/world.abc">Variables file name</a>
 
- <a href="test/hello/index.html">Variables</a>
+ <a href="test/hello/">Variables</a>
 
  <a href="posts/no-path.html">Custom paths</a>
 
- <a href="test/thing3/index.html">Boom</a>
+ <a href="test/thing3/">Boom</a>
 
- <a href="test/thing4/index.html">Boom without trailing slash</a>
+ <a href="test/thing4">Boom without trailing slash</a>
 
- <a href="2015/hello/index.html">Date variables</a>
+ <a href="2015/hello/">Date variables</a>
 
  <a href="test/thing.html">Custom paths</a>
 
  <a href="test/thing2.html">Custom paths with leading slash</a>
 
- <a href="2015/05/5/03/3/01/05/20/index.html">All date variables</a>
+ <a href="2015/05/5/03/3/01/05/20/">All date variables</a>
 
 
     </body>

--- a/tests/target/custom_paths/test/hello/index.html
+++ b/tests/target/custom_paths/test/hello/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
     <head>
-        <title>My blog - test/hello/index.html</title>
+        <title>My blog - test/hello/</title>
     </head>
     <body>
         <h1>Variables</h1>

--- a/tests/target/custom_paths/test/thing3/index.html
+++ b/tests/target/custom_paths/test/thing3/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
     <head>
-        <title>My blog - test/thing3/index.html</title>
+        <title>My blog - test/thing3/</title>
     </head>
     <body>
         <h1>Boom</h1>

--- a/tests/target/custom_paths/test/thing4/index.html
+++ b/tests/target/custom_paths/test/thing4/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
     <head>
-        <title>My blog - test/thing4/index.html</title>
+        <title>My blog - test/thing4</title>
     </head>
     <body>
         <h1>Boom without trailing slash</h1>

--- a/tests/target/custom_post_path/index.html
+++ b/tests/target/custom_post_path/index.html
@@ -9,13 +9,13 @@
         This is my Index page!
 
 
- <a href="blog/2016/05/29/index.html">My fourth Blogpost</a>
+ <a href="blog/2016/05/29/">My fourth Blogpost</a>
 
- <a href="blog/2016/05/27/index.html">My third Blogpost</a>
+ <a href="blog/2016/05/27/">My third Blogpost</a>
 
- <a href="blog/2016/01/02/index.html">My second Blogpost</a>
+ <a href="blog/2016/01/02/">My second Blogpost</a>
 
- <a href="blog/2016/01/01/index.html">My first Blogpost</a>
+ <a href="blog/2016/01/01/">My first Blogpost</a>
 
 
     </body>


### PR DESCRIPTION
While this makes the code less optimal and a little weird in places (but cleaner in others), this gets all of the plumbing in place for #257 where cobalt uses serde to load a very strict frontmatter.

The other benefit to this gradual approach is that the old attributes -> frontmatter conversion is being heavily tested before the break.  As part of the break, it will be pulled out into a migration tool.

Cheap features we got while at it:
- Support `:categories` in permalinks
- Support nested frontmatter yaml

Breaking changes
- page `path` attribute no longer has an auto-appended "index.html".  The placement on disk doesn't change though.
- `slug`, `excerpt_separator`, `ext`, and `extends` are no longer page attributes.  The assumption is that these weren't even really needed except for internal book keeping for cobalt.