### PR TITLE
RFC: Stablize frontmatter 

### DIFF
--- a/src/cobalt.rs
+++ b/src/cobalt.rs
@@ -79,16 +79,15 @@ pub fn build(config: &Config) -> Result<()> {
         let src_path = source.join(file_path.as_path());
         let is_post = src_path.starts_with(posts_path.as_path());
 
-        let default_front = frontmatter::FrontmatterBuilder::new()
+        let mut default_front = frontmatter::FrontmatterBuilder::new()
             .set_post(is_post)
             .set_draft(false)
             .set_excerpt_separator(config.excerpt_separator.clone());
+        if is_post {
+            default_front = default_front.set_permalink(config.post_path.clone());
+        }
 
-        let doc = Document::parse(source,
-                                  &file_path,
-                                  &file_path,
-                                  default_front,
-                                  &config.post_path)?;
+        let doc = Document::parse(source, &file_path, &file_path, default_front)?;
         if !doc.front.is_draft || config.include_drafts {
             documents.push(doc);
         }
@@ -114,15 +113,15 @@ pub fn build(config: &Config) -> Result<()> {
 
             let is_post = true;
 
-            let default_front = frontmatter::FrontmatterBuilder::new()
+            let mut default_front = frontmatter::FrontmatterBuilder::new()
                 .set_post(is_post)
                 .set_draft(true)
                 .set_excerpt_separator(config.excerpt_separator.clone());
-            let doc = Document::parse(&drafts_root,
-                                      &file_path,
-                                      new_path,
-                                      default_front,
-                                      &config.post_path)?;
+            if is_post {
+                default_front = default_front.set_permalink(config.post_path.clone());
+            }
+
+            let doc = Document::parse(&drafts_root, &file_path, new_path, default_front)?;
             documents.push(doc);
         }
     }

--- a/src/document.rs
+++ b/src/document.rs
@@ -20,7 +20,6 @@ use syntax_highlight::{initialize_codeblock, decorate_markdown};
 use liquid::{Renderable, LiquidOptions, Context, Value, LocalTemplateRepository};
 
 use frontmatter;
-use datetime;
 use pulldown_cmark as cmark;
 use liquid;
 
@@ -94,7 +93,7 @@ fn permalink_attributes(front: &frontmatter::Frontmatter,
 
     let filename = dest_file.file_stem().and_then(|s| s.to_str());
     if let Some(filename) = filename {
-        attributes.insert(":filename".to_owned(), filename.to_owned());
+        attributes.insert(":name".to_owned(), filename.to_owned());
     }
 
     attributes.insert(":slug".to_owned(), front.slug.clone());
@@ -115,9 +114,8 @@ fn permalink_attributes(front: &frontmatter::Frontmatter,
         attributes.insert(":second".to_owned(), format!("{:02}", &date.second()));
     }
 
-    // Allow customizing any of the above with custom frontmatter attributes
     for (key, val) in &front.custom {
-        let key = format!(":{}", key);
+        let key = format!(":custom.{}", key);
         // HACK: We really should support nested types
         let val = val.to_string();
         attributes.insert(key, val);
@@ -177,8 +175,8 @@ fn document_attributes(front: &frontmatter::Frontmatter,
                        -> liquid::Object {
     let mut attributes = liquid::Object::new();
 
-    attributes.insert("path".to_owned(), liquid::Value::str(url_path));
-    attributes.insert("source".to_owned(), liquid::Value::str(source_file));
+    attributes.insert("url".to_owned(), liquid::Value::str(url_path));
+    attributes.insert("path".to_owned(), liquid::Value::str(source_file));
     attributes.insert("title".to_owned(), liquid::Value::str(&front.title));
     if let Some(ref description) = front.description {
         attributes.insert("description".to_owned(), liquid::Value::str(description));
@@ -190,15 +188,14 @@ fn document_attributes(front: &frontmatter::Frontmatter,
                                                .map(|c| liquid::Value::str(c))
                                                .collect()));
     if let Some(ref published_date) = front.published_date {
-        attributes.insert("date".to_owned(),
+        attributes.insert("published_date".to_owned(),
                           liquid::Value::Str(published_date.format()));
     }
-    attributes.insert("draft".to_owned(), liquid::Value::Bool(front.is_draft));
+    attributes.insert("is_draft".to_owned(), liquid::Value::Bool(front.is_draft));
     attributes.insert("is_post".to_owned(), liquid::Value::Bool(front.is_post));
 
-    for (key, val) in &front.custom {
-        attributes.insert(key.clone(), val.clone());
-    }
+    attributes.insert("custom".to_owned(),
+                      liquid::Value::Object(front.custom.clone()));
 
     attributes
 }
@@ -231,72 +228,17 @@ impl Document {
     pub fn parse(root_path: &Path,
                  source_file: &Path,
                  dest_file: &Path,
-                 default_front: frontmatter::FrontmatterBuilder,
-                 default_post_permalink: &Option<String>)
+                 default_front: frontmatter::FrontmatterBuilder)
                  -> Result<Document> {
         trace!("Parsing {:?}", source_file);
         let content = read_document(root_path, source_file)?;
         let (front, content) = split_document(&content)?;
-        let mut custom_attributes = front
+        let front = front
             .map(|s| serde_yaml::from_str(s))
             .map_or(Ok(None), |r| r.map(Some))?
-            .unwrap_or_else(liquid::Object::new);
-
-        // Convert legacy frontmatter into frontmatter (with `custom`)
-        // In some cases, we need to remove them to successfully run perma_attributes
-        // Otherwise, we can remove the converted values because most frontmatter content gets
-        // populated into the final attributes (see `document_attributes`).
-        // Exceptions
-        // - excerpt_separator: internal-only
-        // - extends internal-only
-        let mut front = frontmatter::FrontmatterBuilder::new()
-            .merge_title(custom_attributes
-                             .remove("title")
-                             .and_then(|v| v.as_str().map(|s| s.to_owned())))
-            .merge_description(custom_attributes
-                                   .remove("description")
-                                   .and_then(|v| v.as_str().map(|s| s.to_owned())))
-            .merge_categories(custom_attributes
-                                  .remove("categories")
-                                  .and_then(|v| {
-                                                v.as_array()
-                                                    .map(|v| {
-                                                             v.iter()
-                                                                 .map(|v| v.to_string())
-                                                                 .collect()
-                                                         })
-                                            }))
-            .merge_slug(custom_attributes
-                            .remove("slug")
-                            .and_then(|v| v.as_str().map(|s| s.to_owned())))
-            .merge_permalink(custom_attributes
-                                 .remove("path")
-                                 .and_then(|v| v.as_str().map(|s| s.to_owned())))
-            .merge_draft(custom_attributes
-                             .remove("draft")
-                             .and_then(|v| v.as_bool()))
-            .merge_post(custom_attributes
-                            .remove("is_post")
-                            .and_then(|v| v.as_bool()))
-            .merge_excerpt_separator(custom_attributes
-                                         .remove("excerpt_separator")
-                                         .and_then(|v| v.as_str().map(|s| s.to_owned())))
-            .merge_layout(custom_attributes
-                              .remove("extends")
-                              .and_then(|v| v.as_str().map(|s| s.to_owned())))
-            .merge_published_date(custom_attributes
-                                      .remove("date")
-                                      .and_then(|d| {
-                                                    d.as_str().and_then(datetime::DateTime::parse)
-                                                }))
-            .merge_path(dest_file)?
+            .unwrap_or_else(|| frontmatter::FrontmatterBuilder::new())
+            .merge_path(source_file)?
             .merge(default_front);
-
-        front = front.merge_custom(custom_attributes);
-
-        if front.is_post.unwrap_or(false) {
-            front = front.merge_permalink(default_post_permalink.clone());
-        }
 
         let front = front.build()?;
 
@@ -375,7 +317,7 @@ impl Document {
     /// Renders liquid templates into HTML in the context of current document.
     ///
     /// Takes `content` string and returns rendered HTML. This function doesn't
-    /// take `"extends"` attribute into account. This function can be used for
+    /// take `"layout"` attribute into account. This function can be used for
     /// rendering content or excerpt.
     #[cfg(all(feature="syntax-highlight", not(windows)))]
     fn render_html(&self, content: &str, context: &mut Context, source: &Path) -> Result<String> {

--- a/src/frontmatter.rs
+++ b/src/frontmatter.rs
@@ -52,6 +52,7 @@ impl FrontmatterBuilder {
         }
     }
 
+    #[cfg(test)]
     pub fn set_slug<S: Into<Option<String>>>(self, slug: S) -> FrontmatterBuilder {
         FrontmatterBuilder {
             slug: slug.into(),
@@ -59,6 +60,7 @@ impl FrontmatterBuilder {
         }
     }
 
+    #[cfg(test)]
     pub fn set_title<S: Into<Option<String>>>(self, title: S) -> FrontmatterBuilder {
         FrontmatterBuilder {
             title: title.into(),
@@ -66,6 +68,7 @@ impl FrontmatterBuilder {
         }
     }
 
+    #[cfg(test)]
     pub fn set_description<S: Into<Option<String>>>(self, description: S) -> FrontmatterBuilder {
         FrontmatterBuilder {
             description: description.into(),
@@ -73,6 +76,7 @@ impl FrontmatterBuilder {
         }
     }
 
+    #[cfg(test)]
     pub fn set_categories<S: Into<Option<Vec<String>>>>(self, categories: S) -> FrontmatterBuilder {
         FrontmatterBuilder {
             categories: categories.into(),
@@ -89,6 +93,7 @@ impl FrontmatterBuilder {
         }
     }
 
+    #[cfg(test)]
     pub fn set_published_date<D: Into<Option<datetime::DateTime>>>(self,
                                                                    published_date: D)
                                                                    -> FrontmatterBuilder {
@@ -106,6 +111,7 @@ impl FrontmatterBuilder {
         }
     }
 
+    #[cfg(test)]
     pub fn set_layout<S: Into<Option<String>>>(self, layout: S) -> FrontmatterBuilder {
         FrontmatterBuilder {
             layout: layout.into(),
@@ -127,34 +133,41 @@ impl FrontmatterBuilder {
         }
     }
 
+    #[cfg(test)]
     pub fn merge_permalink<S: Into<Option<String>>>(self, permalink: S) -> FrontmatterBuilder {
         self.merge(FrontmatterBuilder::new().set_permalink(permalink.into()))
     }
 
+    #[cfg(test)]
     pub fn merge_slug<S: Into<Option<String>>>(self, slug: S) -> FrontmatterBuilder {
         self.merge(FrontmatterBuilder::new().set_slug(slug.into()))
     }
 
+    #[cfg(test)]
     pub fn merge_title<S: Into<Option<String>>>(self, title: S) -> FrontmatterBuilder {
         self.merge(FrontmatterBuilder::new().set_title(title.into()))
     }
 
+    #[cfg(test)]
     pub fn merge_description<S: Into<Option<String>>>(self, description: S) -> FrontmatterBuilder {
         self.merge(FrontmatterBuilder::new().set_description(description.into()))
     }
 
+    #[cfg(test)]
     pub fn merge_categories<S: Into<Option<Vec<String>>>>(self,
                                                           categories: S)
                                                           -> FrontmatterBuilder {
         self.merge(FrontmatterBuilder::new().set_categories(categories.into()))
     }
 
+    #[cfg(test)]
     pub fn merge_excerpt_separator<S: Into<Option<String>>>(self,
                                                             excerpt_separator: S)
                                                             -> FrontmatterBuilder {
         self.merge(FrontmatterBuilder::new().set_excerpt_separator(excerpt_separator.into()))
     }
 
+    #[cfg(test)]
     pub fn merge_published_date<D: Into<Option<datetime::DateTime>>>(self,
                                                                      published_date: D)
                                                                      -> FrontmatterBuilder {
@@ -166,18 +179,22 @@ impl FrontmatterBuilder {
         self.merge(FrontmatterBuilder::new().set_format(format.into()))
     }
 
+    #[cfg(test)]
     pub fn merge_layout<S: Into<Option<String>>>(self, layout: S) -> FrontmatterBuilder {
         self.merge(FrontmatterBuilder::new().set_layout(layout.into()))
     }
 
+    #[cfg(test)]
     pub fn merge_draft<B: Into<Option<bool>>>(self, draft: B) -> FrontmatterBuilder {
         self.merge(FrontmatterBuilder::new().set_draft(draft.into()))
     }
 
+    #[cfg(test)]
     pub fn merge_post<B: Into<Option<bool>>>(self, post: B) -> FrontmatterBuilder {
         self.merge(FrontmatterBuilder::new().set_post(post.into()))
     }
 
+    #[cfg(test)]
     pub fn merge_custom(self, other_custom: liquid::Object) -> FrontmatterBuilder {
         let FrontmatterBuilder {
             path,
@@ -267,9 +284,10 @@ impl FrontmatterBuilder {
                 .and_then(|os| os.to_str())
                 .unwrap_or("");
             let format = match ext {
-                "md" => SourceFormat::Markdown,
-                _ => SourceFormat::Raw,
-            };
+                "md" => Ok(SourceFormat::Markdown),
+                "liquid" => Ok(SourceFormat::Raw),
+                _ => Err(format!("Unsupported format '{}'", ext)),
+            }?;
             fm.format = Some(format);
         }
 
@@ -309,10 +327,14 @@ impl FrontmatterBuilder {
         let is_post = is_post.unwrap_or(false);
 
         let path = path.unwrap_or_else(|| {
-                                           let default_path = "/:path/:filename:output_ext";
+            let default_path = if is_post {
+                "/:categories/:year/:month/:day/:slug.html"
+            } else {
+                "/:path/:name:output_ext"
+            };
 
-                                           default_path.to_owned()
-                                       });
+            default_path.to_owned()
+        });
 
         let fm = Frontmatter {
             path: path,


### PR DESCRIPTION
Steps before submission
- [x] Submit #262 and rebase this
- [ ] Write migration tool
- [ ] Update tests
- [ ] excerpt overriding (if needed?)


The frontmatter is now a strictly defined format with a `custom` field
for any user-provided values.  Access to this in path formatting or
liquid templates mirrors the documents structure.

Fixes #257

BREAKING CHANGES
- fronmatter
  - excerpt is unsupported
  - is_post is unsupported
  - date is renamed to published_date and the format is validated.
  - extends is renamed to layout
  - draft is renamed to is_draft
  - ext is now exposed as format
- page (liquid)
  - path renamed to url
  - source renamed to path
  - date renamed to published_date
  - draft is renamed to is_draft
  - custom frontmatter attributes parented under `custom`
- path variables
  - filename renamed to name
  - custom frontmatter attributes parented under `custom`
  - permalink default is changed to `/:categories/:year/:month/:day/:slug.html` for posts