### PR TITLE
feat(debug): Link substitutions dump flag added

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -6,9 +6,17 @@ use error::Result;
 use yaml_rust::YamlLoader;
 
 arg_enum! {
-    #[derive(Debug, PartialEq)]
+    #[derive(Debug, PartialEq, Copy, Clone)]
     pub enum Dump {
-        Liquid
+        DocObject,
+        DocTemplate,
+        DocLinkObject
+    }
+}
+
+impl Dump {
+    pub fn is_doc(&self) -> bool {
+        true
     }
 }
 

--- a/src/document.rs
+++ b/src/document.rs
@@ -19,6 +19,7 @@ use syntax_highlight::{initialize_codeblock, decorate_markdown};
 
 use liquid::{Renderable, LiquidOptions, Context, Value, LocalTemplateRepository};
 
+use config;
 use frontmatter;
 use datetime;
 use pulldown_cmark as cmark;
@@ -503,6 +504,21 @@ impl Document {
             Ok(try!(template.render(context)).unwrap_or_default())
         } else {
             Ok(content_html)
+        }
+    }
+
+    pub fn render_dump(&self, dump: config::Dump) -> Result<(String, String)> {
+        match dump {
+            config::Dump::DocObject => {
+                let content = serde_yaml::to_string(&self.attributes)?;
+                Ok((content, "yml".to_owned()))
+            }
+            config::Dump::DocTemplate => Ok((self.content.clone(), "liquid".to_owned())),
+            config::Dump::DocLinkObject => {
+                let perma_attributes = permalink_attributes(&self.front, Path::new("<null>"));
+                let content = serde_yaml::to_string(&perma_attributes)?;
+                Ok((content, "yml".to_owned()))
+            }
         }
     }
 }

--- a/src/frontmatter.rs
+++ b/src/frontmatter.rs
@@ -355,7 +355,7 @@ pub struct Frontmatter {
 /// Shallow merge of `liquid::Object`'s
 fn merge_objects(primary: liquid::Object, secondary: liquid::Object) -> liquid::Object {
     let mut primary = primary;
-    for (key, value) in secondary.iter() {
+    for (key, value) in secondary {
         primary
             .entry(key.to_owned())
             .or_insert_with(|| value.clone());

--- a/src/main.rs
+++ b/src/main.rs
@@ -291,8 +291,13 @@ fn run() -> Result<()> {
     config.include_drafts = matches.is_present("drafts");
 
     if global_matches.is_present("dump") {
-        let dump = values_t!(global_matches, "dump", Dump)?;
-        config.dump = dump;
+        let mut dump = values_t!(global_matches, "dump", Dump)?;
+        config.dump.append(&mut dump);
+        info!("Setting: {:?}", config.dump);
+    }
+    if matches.is_present("dump") {
+        let mut dump = values_t!(matches, "dump", Dump)?;
+        config.dump.append(&mut dump);
         info!("Setting: {:?}", config.dump);
     }
 


### PR DESCRIPTION
Added `--dump=DocLinkObject` to dump the substitutions that are
available for creating page paths.

In addition, `--dump` can now go before or after the sub-command.

BREAKING CHANGE: `--dump=liquid` is now split into `--dump=DocObject`
and `--dump=DocTemplate`.