### PR TITLE
Add list-syntaxes subcommand to list file types supported by syntect

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,4 +61,4 @@ mod frontmatter;
 mod syntax_highlight;
 
 #[cfg(all(feature="syntax-highlight"))]
-pub use syntax_highlight::list_syntax_themes;
+pub use syntax_highlight::{list_syntax_themes, list_syntaxes};

--- a/src/main.rs
+++ b/src/main.rs
@@ -43,7 +43,7 @@ use std::io::Result as IoResult;
 use std::fs::File;
 
 #[cfg(all(feature="syntax-highlight", not(windows)))]
-use cobalt::list_syntax_themes;
+use cobalt::{list_syntaxes, list_syntax_themes};
 
 error_chain! {
 
@@ -208,7 +208,8 @@ fn run() -> Result<()> {
                                  .help("Commit message that will be used on import")
                                  .default_value("cobalt site import")
                                  .takes_value(true)))
-        .subcommand(SubCommand::with_name("list-syntax-themes").about("list available themes"));
+        .subcommand(SubCommand::with_name("list-syntax-themes").about("list available themes"))
+        .subcommand(SubCommand::with_name("list-syntaxes").about("list supported syntaxes"));
 
     let global_matches = app_cli.get_matches();
 
@@ -415,6 +416,18 @@ fn run() -> Result<()> {
 
             #[cfg(not(feature="syntax-highlight"))]
             bail!(concat!("No themes available.",
+                          "  This build of cobalt does not include",
+                          " support for syntax highlighting."));
+        }
+
+        "list-syntaxes" => {
+            #[cfg(all(feature="syntax-highlight"))]
+            for name in list_syntaxes() {
+                println!("{}", name);
+            }
+
+            #[cfg(not(feature="syntax-highlight"))]
+            bail!(concat!("No syntaxes available.",
                           "  This build of cobalt does not include",
                           " support for syntax highlighting."));
         }


### PR DESCRIPTION
I wrote this patch when I was messing around with #259.  Figured I'd toss it on here in case it could be of use to someone.  I think I wrote this when I was curious what keyword was needed on a code block I wanted to highlight, so it does that well, at least.

Would have provided the list of what languages are included in #200 (spoiler: not vimscript).

Format of output for `cobalt --list-syntaxes` is:

```
SyntaxName [FileExtension, ...]
...
```

From what I gleaned from the *syntect* docs/code, one can use the `SyntaxName` or `FileExtension` as the language token on a code block.  e.g.

    ```rust
    fn main() {}
    ```
    
    ```rs
    fn main() {}
    ```

However, I doubt that works for the `SyntaxName` or `FileExtension` that contains spaces.  I am baffled how one highlights regular expressions for javascript and python.

```sh
$ cobalt list-syntaxes | grep 'Regular Expressions'
Regular Expression [re]
Regular Expressions (Javascript) []
Regular Expressions (Python) []
```