### PR TITLE
refactor: Clean up separation of old format

### DIFF
--- a/src/cobalt.rs
+++ b/src/cobalt.rs
@@ -78,16 +78,15 @@ pub fn build(config: &Config) -> Result<()> {
         let src_path = source.join(file_path.as_path());
         let is_post = src_path.starts_with(posts_path.as_path());
 
-        let default_front = frontmatter::FrontmatterBuilder::new()
+        let mut default_front = frontmatter::FrontmatterBuilder::new()
             .set_post(is_post)
             .set_draft(false)
             .set_excerpt_separator(config.excerpt_separator.clone());
+        if is_post {
+            default_front = default_front.set_permalink(config.post_path.clone());
+        }
 
-        let doc = Document::parse(source,
-                                  &file_path,
-                                  &file_path,
-                                  default_front,
-                                  &config.post_path)?;
+        let doc = Document::parse(source, &file_path, &file_path, default_front)?;
         if !doc.front.is_draft || config.include_drafts {
             documents.push(doc);
         }
@@ -113,15 +112,15 @@ pub fn build(config: &Config) -> Result<()> {
 
             let is_post = true;
 
-            let default_front = frontmatter::FrontmatterBuilder::new()
+            let mut default_front = frontmatter::FrontmatterBuilder::new()
                 .set_post(is_post)
                 .set_draft(true)
                 .set_excerpt_separator(config.excerpt_separator.clone());
-            let doc = Document::parse(&drafts_root,
-                                      &file_path,
-                                      new_path,
-                                      default_front,
-                                      &config.post_path)?;
+            if is_post {
+                default_front = default_front.set_permalink(config.post_path.clone());
+            }
+
+            let doc = Document::parse(&drafts_root, &file_path, new_path, default_front)?;
             documents.push(doc);
         }
     }

--- a/src/document.rs
+++ b/src/document.rs
@@ -231,8 +231,7 @@ impl Document {
     pub fn parse(root_path: &Path,
                  source_file: &Path,
                  dest_file: &Path,
-                 default_front: frontmatter::FrontmatterBuilder,
-                 default_post_permalink: &Option<String>)
+                 default_front: frontmatter::FrontmatterBuilder)
                  -> Result<Document> {
         trace!("Parsing {:?}", source_file);
         let content = read_document(root_path, source_file)?;
@@ -275,9 +274,6 @@ impl Document {
             .merge_draft(custom_attributes
                              .remove("draft")
                              .and_then(|v| v.as_bool()))
-            .merge_post(custom_attributes
-                            .remove("is_post")
-                            .and_then(|v| v.as_bool()))
             .merge_excerpt_separator(custom_attributes
                                          .remove("excerpt_separator")
                                          .and_then(|v| v.as_str().map(|s| s.to_owned())))
@@ -293,10 +289,6 @@ impl Document {
             .merge(default_front);
 
         front = front.merge_custom(custom_attributes);
-
-        if front.is_post.unwrap_or(false) {
-            front = front.merge_permalink(default_post_permalink.clone());
-        }
 
         let front = front.build()?;
 

--- a/src/document.rs
+++ b/src/document.rs
@@ -285,7 +285,7 @@ impl Document {
                                       .and_then(|d| {
                                                     d.as_str().and_then(datetime::DateTime::parse)
                                                 }))
-            .merge_path(dest_file)?
+            .merge_path(dest_file)
             .merge(default_front);
 
         front = front.merge_custom(custom_attributes);

--- a/src/frontmatter.rs
+++ b/src/frontmatter.rs
@@ -174,6 +174,7 @@ impl FrontmatterBuilder {
         self.merge(FrontmatterBuilder::new().set_draft(draft.into()))
     }
 
+    #[cfg(test)]
     pub fn merge_post<B: Into<Option<bool>>>(self, post: B) -> FrontmatterBuilder {
         self.merge(FrontmatterBuilder::new().set_post(post.into()))
     }

--- a/src/frontmatter.rs
+++ b/src/frontmatter.rs
@@ -255,11 +255,11 @@ impl FrontmatterBuilder {
         }
     }
 
-    pub fn merge_path<P: AsRef<path::Path>>(self, relpath: P) -> Result<FrontmatterBuilder> {
+    pub fn merge_path<P: AsRef<path::Path>>(self, relpath: P) -> FrontmatterBuilder {
         self.merge_path_ref(relpath.as_ref())
     }
 
-    fn merge_path_ref(self, relpath: &path::Path) -> Result<FrontmatterBuilder> {
+    fn merge_path_ref(self, relpath: &path::Path) -> FrontmatterBuilder {
         let mut fm = self;
 
         if fm.format.is_none() {
@@ -288,7 +288,7 @@ impl FrontmatterBuilder {
             fm.title = Some(title);
         }
 
-        Ok(fm)
+        fm
     }
 
     pub fn build(self) -> Result<Frontmatter> {
@@ -391,7 +391,6 @@ mod test {
     fn frontmatter_title_from_path() {
         let front = FrontmatterBuilder::new()
             .merge_path("./parent/file.md")
-            .unwrap()
             .build()
             .unwrap();
         assert_eq!(front.title, "File");
@@ -401,7 +400,6 @@ mod test {
     fn frontmatter_slug_from_md_path() {
         let front = FrontmatterBuilder::new()
             .merge_path("./parent/file.md")
-            .unwrap()
             .build()
             .unwrap();
         assert_eq!(front.slug, "file");
@@ -411,7 +409,6 @@ mod test {
     fn frontmatter_markdown_from_path() {
         let front = FrontmatterBuilder::new()
             .merge_path("./parent/file.md")
-            .unwrap()
             .build()
             .unwrap();
         assert_eq!(front.format, SourceFormat::Markdown);
@@ -421,7 +418,6 @@ mod test {
     fn frontmatter_raw_from_path() {
         let front = FrontmatterBuilder::new()
             .merge_path("./parent/file.liquid")
-            .unwrap()
             .build()
             .unwrap();
         assert_eq!(front.format, SourceFormat::Raw);

--- a/src/legacy/mod.rs
+++ b/src/legacy/mod.rs
@@ -1,0 +1,1 @@
+pub mod wildwest;

--- a/src/legacy/wildwest.rs
+++ b/src/legacy/wildwest.rs
@@ -1,0 +1,65 @@
+use liquid;
+
+use super::super::frontmatter;
+use super::super::datetime;
+
+#[derive(Debug, Eq, PartialEq, Default, Clone)]
+#[derive(Serialize, Deserialize)]
+pub struct FrontmatterBuilder(liquid::Object);
+
+impl FrontmatterBuilder {
+    pub fn new() -> FrontmatterBuilder {
+        FrontmatterBuilder(liquid::Object::new())
+    }
+}
+
+impl From<FrontmatterBuilder> for frontmatter::FrontmatterBuilder {
+    fn from(legacy: FrontmatterBuilder) -> Self {
+        // Convert legacy frontmatter into frontmatter (with `custom`)
+        // In some cases, we need to remove some values due to processing done by later tools
+        // Otherwise, we can remove the converted values because most frontmatter content gets
+        // populated into the final attributes (see `document_attributes`).
+        // Exceptions
+        // - excerpt_separator: internal-only
+        // - extends internal-only
+        let mut custom_attributes = legacy.0;
+        frontmatter::FrontmatterBuilder::new()
+            .merge_title(custom_attributes
+                             .remove("title")
+                             .and_then(|v| v.as_str().map(|s| s.to_owned())))
+            .merge_description(custom_attributes
+                                   .remove("description")
+                                   .and_then(|v| v.as_str().map(|s| s.to_owned())))
+            .merge_categories(custom_attributes
+                                  .remove("categories")
+                                  .and_then(|v| {
+                                                v.as_array()
+                                                    .map(|v| {
+                                                             v.iter()
+                                                                 .map(|v| v.to_string())
+                                                                 .collect()
+                                                         })
+                                            }))
+            .merge_slug(custom_attributes
+                            .remove("slug")
+                            .and_then(|v| v.as_str().map(|s| s.to_owned())))
+            .merge_permalink(custom_attributes
+                                 .remove("path")
+                                 .and_then(|v| v.as_str().map(|s| s.to_owned())))
+            .merge_draft(custom_attributes
+                             .remove("draft")
+                             .and_then(|v| v.as_bool()))
+            .merge_excerpt_separator(custom_attributes
+                                         .remove("excerpt_separator")
+                                         .and_then(|v| v.as_str().map(|s| s.to_owned())))
+            .merge_layout(custom_attributes
+                              .remove("extends")
+                              .and_then(|v| v.as_str().map(|s| s.to_owned())))
+            .merge_published_date(custom_attributes
+                                      .remove("date")
+                                      .and_then(|d| {
+                                                    d.as_str().and_then(datetime::DateTime::parse)
+                                                }))
+            .merge_custom(custom_attributes)
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,6 +57,7 @@ mod files;
 mod datetime;
 mod frontmatter;
 
+mod legacy;
 mod syntax_highlight;
 
 pub use syntax_highlight::{list_syntax_themes, list_syntaxes};

--- a/src/syntax_highlight/null.rs
+++ b/src/syntax_highlight/null.rs
@@ -14,7 +14,7 @@ pub fn list_syntax_themes<'a>() -> Vec<&'a String> {
     vec![]
 }
 
-pub fn list_syntaxes<'a>() -> Vec<String> {
+pub fn list_syntaxes() -> Vec<String> {
     vec![]
 }
 


### PR DESCRIPTION
This is preparation for changing the global config format in full preparation for breaking compatibility and providing a migration tool.