### PR TITLE
refactor: Load `.cobalt.yml` via serde

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -26,7 +26,6 @@ dependencies = [
  "syntect 1.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempdir 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "walkdir 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "yaml-rust 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,6 @@ doc = false
 clap = "2.24"
 liquid = {version = "0.10", features=["serde"]}
 walkdir = "1.0"
-yaml-rust = "0.3"
 chrono = "0.3"
 log = "0.3"
 env_logger = "0.4"

--- a/src/cobalt.rs
+++ b/src/cobalt.rs
@@ -182,12 +182,12 @@ pub fn build(config: &Config) -> Result<()> {
 
         let mut context = post.get_render_context(&simple_posts_data);
 
-        post.render_excerpt(&mut context, source, &config.syntax_theme)?;
+        post.render_excerpt(&mut context, source, &config.syntax_highlight.theme)?;
         let post_html = post.render(&mut context,
                                     source,
                                     &layouts,
                                     &mut layouts_cache,
-                                    &config.syntax_theme)?;
+                                    &config.syntax_highlight.theme)?;
         create_document_file(post_html, &post.file_path, dest)?;
     }
 
@@ -231,7 +231,7 @@ pub fn build(config: &Config) -> Result<()> {
                                   source,
                                   &layouts,
                                   &mut layouts_cache,
-                                  &config.syntax_theme)?;
+                                  &config.syntax_highlight.theme)?;
         create_document_file(doc_html, doc.file_path, dest)?;
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -167,9 +167,8 @@ impl Config {
 
 #[test]
 fn test_from_file_ok() {
-    let result = Config::from_file("tests/fixtures/config/.cobalt.yml");
-    assert!(result.is_ok());
-    assert_eq!(result.unwrap(),
+    let result = Config::from_file("tests/fixtures/config/.cobalt.yml").unwrap();
+    assert_eq!(result,
                Config {
                    dest: "./dest".to_owned(),
                    layouts: "_my_layouts".to_owned(),
@@ -180,9 +179,8 @@ fn test_from_file_ok() {
 
 #[test]
 fn test_from_file_rss() {
-    let result = Config::from_file("tests/fixtures/config/rss.yml");
-    assert!(result.is_ok());
-    assert_eq!(result.unwrap(),
+    let result = Config::from_file("tests/fixtures/config/rss.yml").unwrap();
+    assert_eq!(result,
                Config {
                    rss: Some("rss.xml".to_owned()),
                    name: Some("My blog!".to_owned()),
@@ -194,9 +192,8 @@ fn test_from_file_rss() {
 
 #[test]
 fn test_from_file_empty() {
-    let result = Config::from_file("tests/fixtures/config/empty.yml");
-    assert!(result.is_ok());
-    assert_eq!(result.unwrap(), Config { ..Default::default() });
+    let result = Config::from_file("tests/fixtures/config/empty.yml").unwrap();
+    assert_eq!((result), Config { ..Default::default() });
 }
 
 #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -3,7 +3,7 @@ use std::path::Path;
 use std::fs::File;
 use std::io::Read;
 use error::Result;
-use yaml_rust::YamlLoader;
+use serde_yaml;
 
 use syntax_highlight::has_syntax_theme;
 
@@ -24,6 +24,21 @@ impl Dump {
 }
 
 #[derive(Debug, PartialEq)]
+#[derive(Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct SyntaxHighlight {
+    pub theme: String,
+}
+
+impl Default for SyntaxHighlight {
+    fn default() -> SyntaxHighlight {
+        SyntaxHighlight { theme: "base16-ocean.dark".to_owned() }
+    }
+}
+
+#[derive(Debug, PartialEq)]
+#[derive(Serialize, Deserialize)]
+#[serde(deny_unknown_fields, default)]
 pub struct Config {
     pub source: String,
     pub dest: String,
@@ -41,8 +56,10 @@ pub struct Config {
     pub link: Option<String>,
     pub ignore: Vec<String>,
     pub excerpt_separator: String,
+    // This is a debug-only field and should be transient rather than persistently set.
+    #[serde(skip)]
     pub dump: Vec<Dump>,
-    pub syntax_theme: String,
+    pub syntax_highlight: SyntaxHighlight,
 }
 
 impl Default for Config {
@@ -65,101 +82,51 @@ impl Default for Config {
             ignore: vec![],
             excerpt_separator: "\n\n".to_owned(),
             dump: vec![],
-            syntax_theme: "base16-ocean.dark".to_owned(),
+            syntax_highlight: SyntaxHighlight::default(),
         }
     }
 }
 
 impl Config {
     pub fn from_file<P: AsRef<Path>>(path: P) -> Result<Config> {
-        let mut buffer = String::new();
-        let mut f = try!(File::open(path));
-        try!(f.read_to_string(&mut buffer));
-
-        let yaml = try!(YamlLoader::load_from_str(&buffer));
-        let yaml = match yaml.get(0) {
-            Some(y) => y,
-            None => return Ok(Default::default()),
+        let content = {
+            let mut buffer = String::new();
+            let mut f = File::open(path)?;
+            f.read_to_string(&mut buffer)?;
+            buffer
         };
 
-        let mut config = Config {
-            name: yaml["name"].as_str().map(|s| s.to_owned()),
-            rss: yaml["rss"].as_str().map(|s| s.to_owned()),
-            jsonfeed: yaml["jsonfeed"].as_str().map(|s| s.to_owned()),
-            description: yaml["description"].as_str().map(|s| s.to_owned()),
-            post_path: yaml["post_path"].as_str().map(|s| s.to_owned()),
-            ..Default::default()
-        };
+        if content.trim().is_empty() {
+            return Ok(Config::default());
+        }
 
-        if let Some(source) = yaml["source"].as_str() {
-            config.source = source.to_owned();
-        };
+        let mut config: Config = serde_yaml::from_str(&content)?;
 
-        if let Some(dest) = yaml["dest"].as_str() {
-            config.dest = dest.to_owned();
-        };
-
-        if let Some(layouts) = yaml["layouts"].as_str() {
-            config.layouts = layouts.to_owned();
-        };
-
-        if let Some(drafts) = yaml["drafts"].as_str() {
-            config.drafts = drafts.to_owned();
-        };
-
-        if let Some(include_drafts) = yaml["include_drafts"].as_bool() {
-            config.include_drafts = include_drafts;
-        };
-
-        if let Some(posts) = yaml["posts"].as_str() {
-            config.posts = posts.to_owned();
-        };
-
-        if let Some(post_order) = yaml["post_order"].as_str() {
-            config.post_order = post_order.to_owned();
-        };
-
-        if let Some(extensions) = yaml["template_extensions"].as_vec() {
-            config.template_extensions = extensions
-                .iter()
-                .filter_map(|k| k.as_str().map(|k| k.to_owned()))
-                .collect();
-        };
-
-        if let Some(link) = yaml["link"].as_str() {
+        config.link = if let Some(ref link) = config.link {
             let mut link = link.to_owned();
             if !link.ends_with('/') {
                 link += "/";
             }
-            config.link = Some(link);
+            Some(link)
+        } else {
+            None
         };
 
-        if let Some(patterns) = yaml["ignore"].as_vec() {
-            config.ignore = patterns
-                .iter()
-                .filter_map(|k| k.as_str())
-                .map(|k| k.to_owned())
-                .collect();
+        let result: Result<()> = match has_syntax_theme(&config.syntax_highlight.theme) {
+            Ok(true) => Ok(()),
+            Ok(false) => {
+                Err(format!("Syntax theme '{}' is unsupported",
+                            config.syntax_highlight.theme)
+                            .into())
+            }
+            Err(err) => {
+                warn!("Syntax theme named '{}' ignored. Reason: {:?}",
+                      config.syntax_highlight.theme,
+                      err);
+                Ok(())
+            }
         };
-
-        if let Some(excerpt_separator) = yaml["excerpt_separator"].as_str() {
-            config.excerpt_separator = excerpt_separator.to_owned();
-        };
-
-        if let Some(theme) = yaml["syntax-highlight"]["theme"].as_str() {
-            let result: Result<()> = match has_syntax_theme(theme) {
-                Ok(true) => {
-                    config.syntax_theme = theme.to_owned();
-                    Ok(())
-                }
-                Ok(false) => Err(format!("Syntax theme '{}' is unsupported", theme).into()),
-                Err(err) => {
-                    warn!("Syntax theme named '{}' ignored. Reason: {:?}", theme, err);
-                    Ok(())
-                }
-            };
-            result?;
-        };
+        result?;
 
         Ok(config)
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -2,7 +2,6 @@
 
 use std::io;
 
-use yaml_rust::scanner;
 use walkdir;
 use liquid;
 use ignore;
@@ -17,7 +16,6 @@ error_chain! {
         Io(io::Error);
         Liquid(liquid::Error);
         WalkDir(walkdir::Error);
-        Yaml(scanner::ScanError);
         SerdeYaml(serde_yaml::Error);
         Ignore(ignore::Error);
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,7 +17,6 @@ extern crate regex;
 extern crate rss;
 extern crate jsonfeed;
 extern crate walkdir;
-extern crate yaml_rust;
 extern crate serde_yaml;
 
 extern crate itertools;

--- a/src/syntax_highlight/syntect.rs
+++ b/src/syntax_highlight/syntect.rs
@@ -82,7 +82,6 @@ pub fn initialize_codeblock(arguments: &[Token],
                             tokens: &[Element],
                             theme_name: &str)
                             -> Result<Box<liquid::Renderable>, liquid::Error> {
-
     let content = tokens
         .iter()
         .fold("".to_owned(), |a, b| {

--- a/tests/fixtures/config/.cobalt.yml
+++ b/tests/fixtures/config/.cobalt.yml
@@ -3,5 +3,3 @@ dest: ./dest
 layouts: _my_layouts
 
 posts: _my_posts
-
-ignored_field: is ignored

--- a/tests/fixtures/syntax_highlight_theme/.cobalt.yml
+++ b/tests/fixtures/syntax_highlight_theme/.cobalt.yml
@@ -1,2 +1,2 @@
-syntax-highlight:
+syntax_highlight:
   theme: Solarized (light)

--- a/tests/fixtures/syntax_highlight_theme/.cobalt.yml
+++ b/tests/fixtures/syntax_highlight_theme/.cobalt.yml
@@ -1,0 +1,2 @@
+syntax-highlight:
+  theme: Solarized (light)

--- a/tests/fixtures/syntax_highlight_theme/rust.md
+++ b/tests/fixtures/syntax_highlight_theme/rust.md
@@ -1,0 +1,23 @@
+This is a rust markdown-inline-example
+
+```rust
+
+fn hello() -> bool {
+    true
+}
+
+```
+
+
+
+{% highlight rust %}
+
+pub struct World {
+    virtual: bool
+}
+
+fn create(virtual: bool) -> World {
+    World{virtual: virtual}
+}
+
+{% endhighlight %}

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -146,7 +146,10 @@ pub fn custom_template_extensions() {
 #[cfg(feature = "syntax-highlight")]
 #[test]
 pub fn syntax_highlight() {
+    // Syntect isn't thread safe, for now run everything in the same test.
     run_test("syntax_highlight").expect("Build error");
+
+    run_test("syntax_highlight_theme").expect("Build error");
 }
 
 #[test]

--- a/tests/target/syntax_highlight_theme/rust.html
+++ b/tests/target/syntax_highlight_theme/rust.html
@@ -1,0 +1,19 @@
+<p>This is a rust markdown-inline-example</p>
+<pre style="background-color:#fdf6e3">
+<span style="background-color:#fdf6e3;color:#657b83;">
+</span><span style="background-color:#fdf6e3;color:#268bd2;">fn</span><span style="background-color:#fdf6e3;color:#657b83;"> </span><span style="background-color:#fdf6e3;color:#b58900;">hello</span><span style="background-color:#fdf6e3;color:#657b83;">(</span><span style="background-color:#fdf6e3;color:#657b83;">)</span><span style="background-color:#fdf6e3;color:#657b83;"> </span><span style="background-color:#fdf6e3;color:#657b83;">-&gt;</span><span style="background-color:#fdf6e3;color:#657b83;"> </span><span style="background-color:#fdf6e3;color:#268bd2;">bool</span><span style="background-color:#fdf6e3;color:#657b83;"> </span><span style="background-color:#fdf6e3;color:#657b83;">{</span><span style="background-color:#fdf6e3;color:#657b83;">
+</span><span style="background-color:#fdf6e3;color:#657b83;">    </span><span style="background-color:#fdf6e3;color:#b58900;">true</span><span style="background-color:#fdf6e3;color:#657b83;">
+</span><span style="background-color:#fdf6e3;color:#657b83;">}</span><span style="background-color:#fdf6e3;color:#657b83;">
+</span><span style="background-color:#fdf6e3;color:#657b83;">
+</span></pre><pre style="background-color:#fdf6e3;">
+
+
+<span style="color:#859900;">pub</span><span style="color:#657b83;"> </span><span style="color:#268bd2;">struct</span><span style="color:#657b83;"> </span><span style="color:#657b83;">World</span><span style="color:#657b83;"> </span><span style="color:#657b83;">{</span>
+<span style="color:#657b83;">    </span><span style="color:#268bd2;">virtual</span><span style="color:#657b83;">:</span><span style="color:#657b83;"> </span><span style="color:#268bd2;">bool</span>
+<span style="color:#657b83;">}</span>
+
+<span style="color:#268bd2;">fn</span><span style="color:#657b83;"> </span><span style="color:#b58900;">create</span><span style="color:#657b83;">(</span><span style="color:#268bd2;">virtual</span><span style="color:#657b83;">:</span><span style="color:#657b83;"> </span><span style="color:#268bd2;">bool</span><span style="color:#657b83;">)</span><span style="color:#657b83;"> </span><span style="color:#657b83;">-&gt;</span><span style="color:#657b83;"> World</span><span style="color:#657b83;"> </span><span style="color:#657b83;">{</span>
+<span style="color:#657b83;">    World</span><span style="color:#657b83;">{</span><span style="background-color:#ec9489;color:#657b83;">virtual</span><span style="color:#657b83;">:</span><span style="color:#657b83;"> </span><span style="background-color:#ec9489;color:#657b83;">virtual</span><span style="color:#657b83;">}</span>
+<span style="color:#657b83;">}</span>
+
+</pre>


### PR DESCRIPTION
- This simplifies the config loading code.
- This is yet another stepping stone towards a revamped config.
- This allows the removal of a direct dependency.

BREAKING CHANGE:

Unknown fields are mostly not allowed now (for some reason, incorrect
syntax-highlight fields are).  There isn't really a use case for unknown
fields but room for a lot of confusion (typos in fields leading to odd
behavior).

`syntax-highlight` has been renamed to `syntax_highlight`.  This is more
consistent with the rest of the file.