### PR TITLE
refactor: Use enum to describe post_order

### DIFF
--- a/src/cobalt.rs
+++ b/src/cobalt.rs
@@ -11,7 +11,7 @@ use jsonfeed;
 use datetime;
 use document::Document;
 use error::{ErrorKind, Result};
-use config::Config;
+use config::{Config, SortOrder};
 use files::FilesBuilder;
 use frontmatter;
 
@@ -140,8 +140,9 @@ pub fn build(config: &Config) -> Result<()> {
                           .cmp(&a.front.published_date.unwrap_or(default_date))
                   });
 
-    if &config.post_order == "asc" {
-        posts.reverse();
+    match config.post_order {
+        SortOrder::Asc => posts.reverse(),
+        SortOrder::Desc => (),
     }
 
     // collect all posts attributes to pass them to other posts for rendering

--- a/src/config.rs
+++ b/src/config.rs
@@ -23,6 +23,20 @@ impl Dump {
     }
 }
 
+#[derive(Debug, Eq, PartialEq, Hash, Copy, Clone)]
+#[derive(Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub enum SortOrder {
+    Asc,
+    Desc,
+}
+
+impl Default for SortOrder {
+    fn default() -> SortOrder {
+        SortOrder::Desc
+    }
+}
+
 #[derive(Debug, PartialEq)]
 #[derive(Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
@@ -47,7 +61,7 @@ pub struct Config {
     pub include_drafts: bool,
     pub posts: String,
     pub post_path: Option<String>,
-    pub post_order: String,
+    pub post_order: SortOrder,
     pub template_extensions: Vec<String>,
     pub rss: Option<String>,
     pub jsonfeed: Option<String>,
@@ -72,7 +86,7 @@ impl Default for Config {
             include_drafts: false,
             posts: "posts".to_owned(),
             post_path: None,
-            post_order: "desc".to_owned(),
+            post_order: SortOrder::default(),
             template_extensions: vec!["md".to_owned(), "liquid".to_owned()],
             rss: None,
             jsonfeed: None,

--- a/tests/fixtures/post_order/.cobalt.yml
+++ b/tests/fixtures/post_order/.cobalt.yml
@@ -1,7 +1,7 @@
 name: cobalt blog
 source: "."
 dest: "build"
-post_order: "asc"
+post_order: Asc
 ignore:
   - .git/*
   - build/*


### PR DESCRIPTION
In theory, this makes the checking more strict.  In practice, serde
isn't erroring out for invalid enum values as I'd expect.

BREAKING CHANGE: `post_order` now takes `Asc` and `Desc` instead of
`asc` and `desc`.