### PR TITLE
Add SCSS support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,9 +34,13 @@ script:
   - cargo -V
   - cargo check --verbose
   - cargo check --verbose --features "syntax-highlight"
+  - cargo check --verbose --features "sass"
+  - cargo check --verbose --features "syntax-highlight,sass"
   - cargo test  --verbose --features "syntax-highlight"
+  - cargo test  --verbose --features "sass"
+  - cargo test  --verbose --features "syntax-highlight,sass"
   - if which cargo-clippy ; then cargo when --channel nightly clippy -- --version ; fi
-  - if which cargo-clippy ; then cargo when --channel nightly clippy --features "syntax-highlight" ; fi
+  - if which cargo-clippy ; then cargo when --channel nightly clippy --features "syntax-highlight,sass" ; fi
   - cargo when --channel stable fmt -- --version
   - cargo when --channel stable fmt -- --write-mode=diff
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,6 +21,7 @@ dependencies = [
  "pulldown-cmark 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rss 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sass-rs 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_yaml 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "syntect 1.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -51,6 +52,14 @@ dependencies = [
  "error-chain 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "skeptic 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "aster"
+version = "0.41.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "syntex_syntax 0.58.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -107,6 +116,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "bindgen"
+version = "0.26.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "aster 0.41.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cexpr 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "clang-sys 0.19.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "clap 2.26.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "env_logger 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "peeking_take_while 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quasi 0.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quasi_codegen 0.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syntex_syntax 0.58.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "bitflags"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -157,6 +186,14 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "cexpr"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "nom 3.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "cfg-if"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -168,6 +205,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "num 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.38 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "clang-sys"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bitflags 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.31 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libloading 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -364,6 +412,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "gcc"
+version = "0.3.54"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "getopts"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -499,6 +552,16 @@ version = "0.2.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "libloading"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "linked-hash-map"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -624,6 +687,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "nom"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "memchr 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "notify"
 version = "4.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -702,6 +773,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "peeking_take_while"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "percent-encoding"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -739,6 +815,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "getopts 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "quasi"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "syntex_errors 0.58.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syntex_syntax 0.58.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "quasi_codegen"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "aster 0.41.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syntex 0.58.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syntex_errors 0.58.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syntex_syntax 0.58.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -815,6 +911,11 @@ version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "rustc-serialize"
+version = "0.3.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "safemem"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -826,6 +927,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "sass-rs"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.31 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sass-sys 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "sass-sys"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bindgen 0.26.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gcc 0.3.54 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.31 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pkg-config 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -955,11 +1076,62 @@ dependencies = [
 ]
 
 [[package]]
+name = "syntex"
+version = "0.58.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "syntex_errors 0.58.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syntex_syntax 0.58.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "syntex_errors"
+version = "0.58.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.31 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syntex_pos 0.58.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "term 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-xid 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "syntex_pos"
+version = "0.58.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "syntex_syntax"
+version = "0.58.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bitflags 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syntex_errors 0.58.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syntex_pos 0.58.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-xid 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "tempdir"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "rand 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "term"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1161,11 +1333,13 @@ dependencies = [
 "checksum aho-corasick 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)" = "500909c4f87a9e52355b26626d890833e9e1d53ac566db76c36faa984b889699"
 "checksum ansi_term 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "23ac7c30002a5accbf7e8987d0632fa6de155b7c3d39d0067317a391e00a2ef6"
 "checksum assert_cli 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "03715e49fad7a911ddbb15e105108e6e8af8dcdebbae9e583cf5f53b33e84248"
+"checksum aster 0.41.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4ccfdf7355d9db158df68f976ed030ab0f6578af811f5a7bb6dcf221ec24e0e0"
 "checksum atty 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "21e50800ec991574876040fff8ee46b136a53e985286fbe6a3bdfe6421b78860"
 "checksum backtrace 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "99f2ce94e22b8e664d95c57fff45b98a966c2252b60691d0b7aeeccd88d70983"
 "checksum backtrace-sys 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)" = "c63ea141ef8fdb10409d0f5daf30ac51f84ef43bff66f16627773d2a292cd189"
 "checksum base64 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "96434f987501f0ed4eb336a411e0631ecd1afa11574fe148587adc4ff96143c9"
 "checksum bincode 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e103c8b299b28a9c6990458b7013dc4a8356a9b854c51b9883241f5866fac36e"
+"checksum bindgen 0.26.3 (registry+https://github.com/rust-lang/crates.io-index)" = "c57d6c0f6e31f8dcf4d12720a3c2a9ffb70638772a5784976cf4fce52145f22a"
 "checksum bitflags 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8dead7461c1127cf637931a1e50934eb6eee8bff2f74433ac7909e9afcee04a3"
 "checksum bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "aad18937a628ec6abcd26d1489012cc0e18c21798210f491af69ded9b881106d"
 "checksum bitflags 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1370e9fc2a6ae53aea8b7a5110edbd08836ed87c88736dfabccade1c2b44bff4"
@@ -1175,8 +1349,10 @@ dependencies = [
 "checksum bytes 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c129aff112dcc562970abb69e2508b40850dd24c274761bb50fb8a0067ba6c27"
 "checksum cargo_metadata 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "be1057b8462184f634c3a208ee35b0f935cfd94b694b26deadccd98732088d7b"
 "checksum cc 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7db2f146208d7e0fbee761b09cd65a7f51ccc38705d4e7262dad4d73b12a76b1"
+"checksum cexpr 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "cdbb21df6ff3497a61df5059994297f746267020ba38ce237aad9c875f7b4313"
 "checksum cfg-if 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d4c819a1287eb618df47cc647173c5c4c66ba19d888a6e50d605672aed3140de"
 "checksum chrono 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7c20ebe0b2b08b0aeddba49c609fe7957ba2e33449882cb186a180bc60682fa9"
+"checksum clang-sys 0.19.0 (registry+https://github.com/rust-lang/crates.io-index)" = "611ec2e3a7623afd8a8c0d027887b6b55759d894abbf5fe11b9dc11b50d5b49a"
 "checksum clap 2.26.2 (registry+https://github.com/rust-lang/crates.io-index)" = "3451e409013178663435d6f15fdb212f14ee4424a3d74f979d081d0a66b6f1f2"
 "checksum clippy 0.0.165 (registry+https://github.com/rust-lang/crates.io-index)" = "88f67cdb6697a5d357f8f70cffdf65f4dcb6ec8bb5069f2bc347589b3869cbe8"
 "checksum clippy_lints 0.0.165 (registry+https://github.com/rust-lang/crates.io-index)" = "c8f37194e4a7cb36daeeb5727eac96e32c82965e4ae8b119817885377ddb6715"
@@ -1200,6 +1376,7 @@ dependencies = [
 "checksum fnv 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "6cc484842f1e2884faf56f529f960cc12ad8c71ce96cc7abba0a067c98fee344"
 "checksum fsevent 0.2.16 (registry+https://github.com/rust-lang/crates.io-index)" = "dfe593ebcfc76884138b25426999890b10da8e6a46d01b499d7c54c604672c38"
 "checksum fsevent-sys 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "1a772d36c338d07a032d5375a36f15f9a7043bf0cb8ce7cee658e037c6032874"
+"checksum gcc 0.3.54 (registry+https://github.com/rust-lang/crates.io-index)" = "5e33ec290da0d127825013597dbdfc28bee4964690c7ce1166cbc2a7bd08b1bb"
 "checksum getopts 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)" = "65922871abd2f101a2eb0eaebadc66668e54a87ad9c3dd82520b5f86ede5eff9"
 "checksum ghp 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "2381a505873cc9b3bc814214150a0da3193db84cdaf3c9eb2145c7a369d337f0"
 "checksum glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "8be18de09a56b60ed0edf84bc9df007e30040691af7acd1c41874faac5895bfb"
@@ -1216,6 +1393,7 @@ dependencies = [
 "checksum language-tags 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a91d884b6667cd606bb5a69aa0c99ba811a115fc68915e7056ec08a46e93199a"
 "checksum lazy_static 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)" = "c9e5e58fa1a4c3b915a561a78a22ee0cac6ab97dca2504428bc1cb074375f8d5"
 "checksum libc 0.2.31 (registry+https://github.com/rust-lang/crates.io-index)" = "d1419b2939a0bc44b77feb34661583c7546b532b192feab36249ab584b86856c"
+"checksum libloading 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "3f92926a9a4ba7aeeb01f5fba3f0d577147243b6e7fa8261c219cd1d6fbe3b1c"
 "checksum linked-hash-map 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6d262045c5b87c0861b3f004610afd0e2c851e2908d08b6c870cbb9d5f494ecd"
 "checksum linked-hash-map 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7860ec297f7008ff7a1e3382d7f7e1dcd69efc94751a2284bafc3d013c2aa939"
 "checksum liquid 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2bd0db04ca9b57c71fd20638b6290eaed9a3ba1aa9af2ee43f163a8bd98dac43"
@@ -1230,6 +1408,7 @@ dependencies = [
 "checksum miow 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "3e690c5df6b2f60acd45d56378981e827ff8295562fc8d34f573deb267a59cd1"
 "checksum net2 0.2.31 (registry+https://github.com/rust-lang/crates.io-index)" = "3a80f842784ef6c9a958b68b7516bc7e35883c614004dd94959a4dca1b716c09"
 "checksum nix 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "bfb3ddedaa14746434a02041940495bf11325c22f6d36125d3bdd56090d50a79"
+"checksum nom 3.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "06989cbd367e06f787a451f3bc67d8c3e0eaa10b461cc01152ffab24261a31b1"
 "checksum notify 4.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "298d4401ff2c6cebb7f8944c90288647c89ce59029d43b439444cf1067df55e1"
 "checksum num 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)" = "a311b77ebdc5dd4cf6449d81e4135d9f0e3b153839ac90e648a8ef538f923525"
 "checksum num-integer 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)" = "d1452e8b06e448a07f0e6ebb0bb1d92b8890eea63288c0b627331d53514d0fba"
@@ -1238,11 +1417,14 @@ dependencies = [
 "checksum num_cpus 1.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "514f0d73e64be53ff320680ca671b64fe3fb91da01e1ae2ddc99eb51d453b20d"
 "checksum onig 1.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "1271a3f93197303deda8aedcd96ed2dbb908f61c0954ae70bf7a42f536dc35d7"
 "checksum onig_sys 65.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "fbdee58fb75f5b7749ebc8f601f570961eed595dfe4c2bb9a542e2f7ae20b946"
+"checksum peeking_take_while 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 "checksum percent-encoding 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "de154f638187706bde41d9b4738748933d64e6b37bdbffc0b47a97d16a6ae356"
 "checksum pkg-config 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "3a8b4c6b8165cd1a1cd4b9b120978131389f64bdaf456435caa41e630edba903"
 "checksum plist 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "142aa1116debeb8ebeae592cf956d53165ffb0ec4c41f894208cff78a9e3ffe2"
 "checksum pulldown-cmark 0.0.15 (registry+https://github.com/rust-lang/crates.io-index)" = "378e941dbd392c101f2cb88097fa4d7167bc421d4b88de3ff7dbee503bc3233b"
 "checksum pulldown-cmark 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a656fdb8b6848f896df5e478a0eb9083681663e37dcb77dd16981ff65329fe8b"
+"checksum quasi 0.32.0 (registry+https://github.com/rust-lang/crates.io-index)" = "18c45c4854d6d1cf5d531db97c75880feb91c958b0720f4ec1057135fec358b3"
+"checksum quasi_codegen 0.32.0 (registry+https://github.com/rust-lang/crates.io-index)" = "51b9e25fa23c044c1803f43ca59c98dac608976dd04ce799411edd58ece776d4"
 "checksum quick-xml 0.9.4 (registry+https://github.com/rust-lang/crates.io-index)" = "19a3a610544419c527d5f51ae1a6ae3db533e25c117d3eed8fce6434f70c5e95"
 "checksum quine-mc_cluskey 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "07589615d719a60c8dd8a4622e7946465dfef20d1a428f969e3443e7386d5f45"
 "checksum quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6e920b65c65f10b2ae65c831a81a073a89edd28c7cce89475bff467ab4167a"
@@ -1253,8 +1435,11 @@ dependencies = [
 "checksum regex-syntax 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ad890a5eef7953f55427c50575c680c42841653abd2b028b68cd223d157f62db"
 "checksum rss 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "70294b2be2d620fed3939032067684c53b8ccae18e8ca0b8410447f0f07228c5"
 "checksum rustc-demangle 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "aee45432acc62f7b9a108cc054142dac51f979e69e71ddce7d6fc7adf29e817e"
+"checksum rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)" = "dcf128d1287d2ea9d80910b5f1120d0b8eede3fbf1abe91c40d39ea7d51e6fda"
 "checksum safemem 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e27a8b19b835f7aea908818e871f5cc3a5a186550c30773be987e155e8163d8f"
 "checksum same-file 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "d931a44fdaa43b8637009e7632a02adc4f2b2e0733c08caa4cf00e8da4a117a7"
+"checksum sass-rs 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "22498eeceeef42b0bfbf44c27bf49bc37043beddc7eac73ae9f4d17e08967e2e"
+"checksum sass-sys 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "49e6025ff142eb235157aea8d6ee8085d9f5b80e280cb54b911f6b778e64075a"
 "checksum semver 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7a3186ec9e65071a2095434b1f5bb24838d4e8e130f584c790f6033c79943537"
 "checksum semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 "checksum serde 1.0.15 (registry+https://github.com/rust-lang/crates.io-index)" = "6a7046c9d4c6c522d10b2d098f9bebe2bef227e0e74044d8c1bfcf6b476af799"
@@ -1268,7 +1453,12 @@ dependencies = [
 "checksum syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)" = "d3b891b9015c88c576343b9b3e41c2c11a51c219ef067b264bd9c8aa9b441dad"
 "checksum synom 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a393066ed9010ebaed60b9eafa373d4b1baac186dd7e008555b0f702b51945b6"
 "checksum syntect 1.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2f436345e5b6ebbfdf51b20b95cd9bcb82576262c340bad9cf815078d76b082a"
+"checksum syntex 0.58.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a8f5e3aaa79319573d19938ea38d068056b826db9883a5d47f86c1cecc688f0e"
+"checksum syntex_errors 0.58.1 (registry+https://github.com/rust-lang/crates.io-index)" = "867cc5c2d7140ae7eaad2ae9e8bf39cb18a67ca651b7834f88d46ca98faadb9c"
+"checksum syntex_pos 0.58.1 (registry+https://github.com/rust-lang/crates.io-index)" = "13ad4762fe52abc9f4008e85c4fb1b1fe3aa91ccb99ff4826a439c7c598e1047"
+"checksum syntex_syntax 0.58.1 (registry+https://github.com/rust-lang/crates.io-index)" = "6e0e4dbae163dd98989464c23dd503161b338790640e11537686f2ef0f25c791"
 "checksum tempdir 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "87974a6f5c1dfb344d733055601650059a3363de2a6104819293baff662132d6"
+"checksum term 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "fa63644f74ce96fbeb9b794f66aff2a52d601cbd5e80f4b97123e3899f4570f1"
 "checksum term_size 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e2b6b55df3198cc93372e85dd2ed817f0e38ce8cc0f22eb32391bfad9c4bf209"
 "checksum termion 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "689a3bdfaab439fd92bc87df5c4c78417d3cbe537487274e9b0b2dce76e92096"
 "checksum textwrap 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "df8e08afc40ae3459e4838f303e465aa50d823df8d7f83ca88108f6d3afe7edd"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,9 +39,12 @@ error-chain = "0.11"
 lazy_static = "0.2"
 itertools = "0.6"
 ignore = "0.2"
-sass-rs = "0.2.0"
 serde = "1.0"
 serde_yaml = "0.7"
+
+[dependencies.sass-rs]
+version = "0.2.0"
+optional = true
 
 [dependencies.hyper]
 version = "0.10"
@@ -64,4 +67,4 @@ unstable = []
 dev = []
 
 syntax-highlight = ["syntect"]
-
+sass = ['sass-rs']

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ error-chain = "0.11"
 lazy_static = "0.2"
 itertools = "0.6"
 ignore = "0.2"
+sass-rs = "0.2.0"
 serde = "1.0"
 serde_yaml = "0.7"
 

--- a/src/cobalt.rs
+++ b/src/cobalt.rs
@@ -7,7 +7,7 @@ use liquid::Value;
 use rss;
 use jsonfeed::Feed;
 use jsonfeed;
-use sass_rs::{compile_file as sass_compile_file, Options as SassOptions};
+use sass_rs;
 
 use datetime;
 use document::Document;
@@ -239,7 +239,7 @@ pub fn build(config: &Config) -> Result<()> {
     // compile SASS along the way
     {
         info!("Copying remaining assets");
-        let mut sass_opts = SassOptions::default();
+        let mut sass_opts = sass_rs::Options::default();
         //  FIXME: make this a config option
         sass_opts.include_paths =
             vec![source.join("_sass").into_os_string().into_string().unwrap()];
@@ -267,8 +267,8 @@ pub fn build(config: &Config) -> Result<()> {
             }
             let src_file = source.join(file_path.as_path());
 
-            if file_path.extension().unwrap_or_else(|| OsStr::new("")) == "scss" {
-                let content = sass_compile_file(src_file.as_path(), sass_opts.clone())?;
+            if file_path.extension() == Some(OsStr::new("scss")) {
+                let content = sass_rs::compile_file(src_file.as_path(), sass_opts.clone())?;
                 let mut dest_file = dest.join(file_path.clone());
                 dest_file.set_extension("css");
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -38,6 +38,33 @@ impl Default for SortOrder {
     }
 }
 
+#[derive(Debug, Eq, PartialEq, Hash, Copy, Clone)]
+#[derive(Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub enum SassOutputStyle {
+    Nested,
+    Expanded,
+    Compact,
+    Compressed,
+}
+
+#[derive(Debug, PartialEq)]
+#[derive(Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct SassOptions {
+    pub import_dir: String,
+    pub style: SassOutputStyle,
+}
+
+impl Default for SassOptions {
+    fn default() -> SassOptions {
+        SassOptions {
+            import_dir: "_sass".to_owned(),
+            style: SassOutputStyle::Nested,
+        }
+    }
+}
+
 #[derive(Debug, PartialEq)]
 #[derive(Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
@@ -75,6 +102,7 @@ pub struct Config {
     #[serde(skip)]
     pub dump: Vec<Dump>,
     pub syntax_highlight: SyntaxHighlight,
+    pub sass: SassOptions,
 }
 
 impl Default for Config {
@@ -98,6 +126,7 @@ impl Default for Config {
             excerpt_separator: "\n\n".to_owned(),
             dump: vec![],
             syntax_highlight: SyntaxHighlight::default(),
+            sass: SassOptions::default(),
         }
     }
 }

--- a/src/legacy/wildwest.rs
+++ b/src/legacy/wildwest.rs
@@ -67,6 +67,33 @@ impl From<FrontmatterBuilder> for frontmatter::FrontmatterBuilder {
     }
 }
 
+#[derive(Debug, Eq, PartialEq, Hash, Copy, Clone)]
+#[derive(Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub enum SassOutputStyle {
+    Nested,
+    Expanded,
+    Compact,
+    Compressed,
+}
+
+#[derive(Debug, PartialEq)]
+#[derive(Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct SassOptions {
+    pub import_dir: String,
+    pub style: SassOutputStyle,
+}
+
+impl Default for SassOptions {
+    fn default() -> SassOptions {
+        SassOptions {
+            import_dir: "_sass".to_owned(),
+            style: SassOutputStyle::Nested,
+        }
+    }
+}
+
 #[derive(Debug, PartialEq)]
 #[derive(Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
@@ -101,6 +128,7 @@ pub struct GlobalConfig {
     pub ignore: Vec<String>,
     pub excerpt_separator: String,
     pub syntax_highlight: SyntaxHighlight,
+    pub sass: SassOptions,
 }
 
 impl Default for GlobalConfig {
@@ -123,6 +151,7 @@ impl Default for GlobalConfig {
             ignore: vec![],
             excerpt_separator: "\n\n".to_owned(),
             syntax_highlight: SyntaxHighlight::default(),
+            sass: SassOptions::default(),
         }
     }
 }
@@ -147,6 +176,7 @@ impl From<GlobalConfig> for config::Config {
             ignore,
             excerpt_separator,
             syntax_highlight,
+            sass,
         } = legacy;
 
         let post_order = match post_order.as_ref() {
@@ -155,6 +185,15 @@ impl From<GlobalConfig> for config::Config {
         };
 
         let syntax_highlight = config::SyntaxHighlight { theme: syntax_highlight.theme };
+        let sass = config::SassOptions {
+            import_dir: sass.import_dir,
+            style: match sass.style {
+                SassOutputStyle::Nested => config::SassOutputStyle::Nested,
+                SassOutputStyle::Expanded => config::SassOutputStyle::Expanded,
+                SassOutputStyle::Compact => config::SassOutputStyle::Compact,
+                SassOutputStyle::Compressed => config::SassOutputStyle::Compressed,
+            },
+        };
 
         config::Config {
             source: source,
@@ -175,6 +214,7 @@ impl From<GlobalConfig> for config::Config {
             excerpt_separator: excerpt_separator,
             dump: vec![],
             syntax_highlight: syntax_highlight,
+            sass: sass,
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,6 +56,7 @@ extern crate rss;
 extern crate jsonfeed;
 extern crate walkdir;
 extern crate serde_yaml;
+extern crate sass_rs;
 
 extern crate itertools;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,6 +56,8 @@ extern crate rss;
 extern crate jsonfeed;
 extern crate walkdir;
 extern crate serde_yaml;
+
+#[cfg(feature = "sass")]
 extern crate sass_rs;
 
 extern crate itertools;

--- a/tests/fixtures/sass/_sass/_importable.scss
+++ b/tests/fixtures/sass/_sass/_importable.scss
@@ -1,0 +1,3 @@
+.main {
+	width:  100vw;
+}

--- a/tests/fixtures/sass/_sass/_nested.scss
+++ b/tests/fixtures/sass/_sass/_nested.scss
@@ -1,0 +1,5 @@
+@import "_importable";
+
+nav {
+	color: $navColor;
+}

--- a/tests/fixtures/sass/style/blog.css
+++ b/tests/fixtures/sass/style/blog.css
@@ -1,0 +1,5 @@
+.body {
+	width: 30px;
+}
+
+/* this shall be untouched */

--- a/tests/fixtures/sass/style/main.scss
+++ b/tests/fixtures/sass/style/main.scss
@@ -1,0 +1,1 @@
+@import "importable";

--- a/tests/fixtures/sass/style/nest.scss
+++ b/tests/fixtures/sass/style/nest.scss
@@ -1,0 +1,3 @@
+$navColor: blue;
+
+@import "_nested";

--- a/tests/fixtures/sass_custom_config/.cobalt.yml
+++ b/tests/fixtures/sass_custom_config/.cobalt.yml
@@ -1,0 +1,3 @@
+sass:
+  import_dir: _sass_includes
+  style: Compressed

--- a/tests/fixtures/sass_custom_config/_sass_includes/_importable.scss
+++ b/tests/fixtures/sass_custom_config/_sass_includes/_importable.scss
@@ -1,0 +1,3 @@
+.main {
+	width:  100vw;
+}

--- a/tests/fixtures/sass_custom_config/_sass_includes/_nested.scss
+++ b/tests/fixtures/sass_custom_config/_sass_includes/_nested.scss
@@ -1,0 +1,5 @@
+@import "_importable";
+
+nav {
+	color: $navColor;
+}

--- a/tests/fixtures/sass_custom_config/style/blog.css
+++ b/tests/fixtures/sass_custom_config/style/blog.css
@@ -1,0 +1,5 @@
+.body {
+	width: 30px;
+}
+
+/* this shall be untouched */

--- a/tests/fixtures/sass_custom_config/style/main.scss
+++ b/tests/fixtures/sass_custom_config/style/main.scss
@@ -1,0 +1,1 @@
+@import "importable";

--- a/tests/fixtures/sass_custom_config/style/nest.scss
+++ b/tests/fixtures/sass_custom_config/style/nest.scss
@@ -1,0 +1,3 @@
+$navColor: blue;
+
+@import "_nested";

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -250,7 +250,7 @@ pub fn querystrings() {
     run_test("querystrings").expect("Build error");
 }
 
-
+#[cfg(feature = "sass")]
 #[test]
 pub fn sass() {
     run_test("sass").expect("Build error");

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -249,3 +249,9 @@ pub fn empty_frontmatter() {
 pub fn querystrings() {
     run_test("querystrings").expect("Build error");
 }
+
+
+#[test]
+pub fn sass() {
+    run_test("sass").expect("Build error");
+}

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -255,3 +255,9 @@ pub fn querystrings() {
 pub fn sass() {
     run_test("sass").expect("Build error");
 }
+
+#[cfg(feature = "sass")]
+#[test]
+pub fn sass_custom_config() {
+    run_test("sass_custom_config").expect("Build error");
+}

--- a/tests/target/sass/style/blog.css
+++ b/tests/target/sass/style/blog.css
@@ -1,0 +1,5 @@
+.body {
+	width: 30px;
+}
+
+/* this shall be untouched */

--- a/tests/target/sass/style/main.css
+++ b/tests/target/sass/style/main.css
@@ -1,0 +1,2 @@
+.main {
+  width: 100vw; }

--- a/tests/target/sass/style/nest.css
+++ b/tests/target/sass/style/nest.css
@@ -1,0 +1,5 @@
+.main {
+  width: 100vw; }
+
+nav {
+  color: blue; }

--- a/tests/target/sass_custom_config/style/blog.css
+++ b/tests/target/sass_custom_config/style/blog.css
@@ -1,0 +1,5 @@
+.body {
+	width: 30px;
+}
+
+/* this shall be untouched */

--- a/tests/target/sass_custom_config/style/main.css
+++ b/tests/target/sass_custom_config/style/main.css
@@ -1,0 +1,1 @@
+.main{width:100vw}

--- a/tests/target/sass_custom_config/style/nest.css
+++ b/tests/target/sass_custom_config/style/nest.css
@@ -1,0 +1,1 @@
+.main{width:100vw}nav{color:blue}


### PR DESCRIPTION
This is an attempt to implement supporting of compiling SASS/SCSS files, too.

It's using the nice sass-rs (which in turn uses sass-sys, to bind to libsass)
in order to compile statics files with the extension 'scss' into css files.

Progress / todo:

 - [x] add test for scss with
   - [x] imports
   - [x] nested imports
   - [x] variables
 - [x] implement rudimentary compiling scss->css
 - [x] enable imports form default `${sourceDir}/_sass`-folder
 - [x] make sass-import folders a configuration option
 - [x] expose other libsass-rs configuration options (like compress), too
 - [x] feature-gate sass
 - [x] fix CI
 - [ ] ~~include libsass in CI bundle~~
 
Comments, Review, Feedback and help welcome!

fixes #99