### PR TITLE
fix(CI): Ensure CI is future compatible with new rusts

### DIFF
--- a/src/bin/cobalt/main.rs
+++ b/src/bin/cobalt/main.rs
@@ -1,14 +1,52 @@
-// Deny warnings, except in dev mode
-#![deny(warnings)]
-#![allow(unknown_lints)]
-#![allow(unused_doc_comment)] // error-chain 0.11 should fix this.
-#![cfg_attr(feature="dev", warn(warnings))]
+// Deny warnings, except in `dev` mode
 
-// stuff we want clippy to ignore
-#![cfg_attr(feature="cargo-clippy", allow(
-        cyclomatic_complexity,
-        too_many_arguments,
-        ))]
+// To update this list
+// 1. Run `rustc -W help`
+// 2. Grab all `default=warn` warnings
+// 3. Paste them here, deleting `warnings`, and any with `deprecated` in the name
+#![deny(const_err,
+        dead_code,
+        illegal_floating_point_literal_pattern,
+        improper_ctypes,
+        non_camel_case_types,
+        non_shorthand_field_patterns,
+        non_snake_case,
+        non_upper_case_globals,
+        no_mangle_generic_items,
+        overflowing_literals,
+        path_statements,
+        patterns_in_fns_without_body,
+        plugin_as_library,
+        private_in_public,
+        private_no_mangle_fns,
+        private_no_mangle_statics,
+        renamed_and_removed_lints,
+        stable_features,
+        unconditional_recursion,
+        unions_with_drop_fields,
+        unknown_lints,
+        unreachable_code,
+        unreachable_patterns,
+        unused_allocation,
+        unused_assignments,
+        unused_attributes,
+        unused_comparisons,
+        unused_features,
+        unused_imports,
+        unused_macros,
+        unused_must_use,
+        unused_mut,
+        unused_parens,
+        unused_unsafe,
+        unused_variables,
+        while_true)]
+// This list is select `allow` warnings
+#![deny(missing_debug_implementations,
+       trivial_casts,
+       trivial_numeric_casts,
+       unused_extern_crates,
+       unused_import_braces)]
+#![cfg_attr(feature="dev", warn(warnings))]
 
 extern crate cobalt;
 extern crate env_logger;

--- a/src/document.rs
+++ b/src/document.rs
@@ -9,8 +9,6 @@ use std::io::Read;
 use regex::Regex;
 use rss;
 use jsonfeed;
-use jsonfeed::Item;
-use jsonfeed::Content;
 use serde_yaml;
 use itertools;
 
@@ -289,11 +287,13 @@ impl Document {
     pub fn to_jsonfeed(&self, root_url: &str) -> jsonfeed::Item {
         let link = root_url.to_owned() + &self.url_path;
 
-        Item {
+        jsonfeed::Item {
             id: link.clone(),
             url: Some(link),
             title: Some(self.front.title.clone()),
-            content: Content::Html(self.description_to_str().unwrap_or_else(|| "".into())),
+            content: jsonfeed::Content::Html(self.description_to_str().unwrap_or_else(|| {
+                                                                                          "".into()
+                                                                                      })),
             date_published: self.front.published_date.map(|date| date.to_rfc2822()),
             // TODO completely implement categories, see Issue 131
             tags: Some(self.front.categories.clone()),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,14 +1,52 @@
-// Deny warnings, except in dev mode
-#![deny(warnings)]
-#![allow(unknown_lints)]
-#![allow(unused_doc_comment)] // error-chain 0.11 should fix this.
-#![cfg_attr(feature="dev", warn(warnings))]
+// Deny warnings, except in `dev` mode
 
-// Stuff we want clippy to ignore
-#![cfg_attr(feature="cargo-clippy", allow(
-        cyclomatic_complexity,
-        too_many_arguments,
-        ))]
+// To update this list
+// 1. Run `rustc -W help`
+// 2. Grab all `default=warn` warnings
+// 3. Paste them here, deleting `warnings`, and any with `deprecated` in the name
+#![deny(const_err,
+        dead_code,
+        illegal_floating_point_literal_pattern,
+        improper_ctypes,
+        non_camel_case_types,
+        non_shorthand_field_patterns,
+        non_snake_case,
+        non_upper_case_globals,
+        no_mangle_generic_items,
+        overflowing_literals,
+        path_statements,
+        patterns_in_fns_without_body,
+        plugin_as_library,
+        private_in_public,
+        private_no_mangle_fns,
+        private_no_mangle_statics,
+        renamed_and_removed_lints,
+        stable_features,
+        unconditional_recursion,
+        unions_with_drop_fields,
+        unknown_lints,
+        unreachable_code,
+        unreachable_patterns,
+        unused_allocation,
+        unused_assignments,
+        unused_attributes,
+        unused_comparisons,
+        unused_features,
+        unused_imports,
+        unused_macros,
+        unused_must_use,
+        unused_mut,
+        unused_parens,
+        unused_unsafe,
+        unused_variables,
+        while_true)]
+// This list is select `allow` warnings
+#![deny(missing_debug_implementations,
+       trivial_casts,
+       trivial_numeric_casts,
+       unused_extern_crates,
+       unused_import_braces)]
+#![cfg_attr(feature="dev", warn(warnings))]
 
 extern crate chrono;
 extern crate ignore;

--- a/src/syntax_highlight/null.rs
+++ b/src/syntax_highlight/null.rs
@@ -30,11 +30,12 @@ fn html_escape(input: &str) -> String {
             skip -= 1;
             continue;
         }
-        match c as char {
+        let c: char = c;
+        match c {
             '<' | '>' | '\'' | '"' | '&' => {
                 result.push_str(&input[last..i]);
                 last = i + 1;
-                let escaped = match c as char {
+                let escaped = match c {
                     '<' => "&lt;",
                     '>' => "&gt;",
                     '\'' => "&#39;",

--- a/src/syntax_highlight/syntect.rs
+++ b/src/syntax_highlight/syntect.rs
@@ -55,7 +55,7 @@ pub fn list_syntaxes<'a>() -> Vec<String> {
         .collect::<Vec<_>>();
 
     // sort alphabetically with insensitive ascii case
-    syntaxes.sort_by_key(|a| (a as &str).to_ascii_lowercase());
+    syntaxes.sort_by_key(|a| a.to_ascii_lowercase());
 
     syntaxes
 }


### PR DESCRIPTION
Explicitly listing warnings as suggested in the [anti-patterns](https://github.com/rust-unofficial/patterns/blob/master/anti_patterns/deny-warnings.md) document.

The problem with this approach is that it is prohibitive to list clippy
warnings.  What would work well is for their to be `warnings` and
`clippy` warning groups that are versioned.