### PR TITLE
Rely on Result rather than killing the process

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,6 +1,6 @@
 [root]
 name = "cobalt-bin"
-version = "0.7.2"
+version = "0.7.3"
 dependencies = [
  "assert_cli 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/src/bin/cobalt/build.rs
+++ b/src/bin/cobalt/build.rs
@@ -1,0 +1,68 @@
+use std::env;
+use std::fs;
+use std::path;
+use std::process;
+
+use clap;
+use cobalt;
+use ghp;
+
+use error::*;
+
+pub fn build_command(config: cobalt::Config, matches: &clap::ArgMatches) -> Result<()> {
+    build(&config)?;
+    info!("Build successful");
+
+    if matches.is_present("import") {
+        let branch = matches.value_of("branch").unwrap().to_string();
+        let message = matches.value_of("message").unwrap().to_string();
+        import(&config, &branch, &message)?
+    }
+
+    Ok(())
+}
+
+pub fn build(config: &cobalt::Config) -> Result<()> {
+    info!("Building from {} into {}", config.source, config.dest);
+    cobalt::build(config)?;
+
+    Ok(())
+}
+
+pub fn clean_command(config: cobalt::Config, _matches: &clap::ArgMatches) -> Result<()> {
+    let cwd = env::current_dir().unwrap_or_else(|_| path::PathBuf::new());
+    let destdir = path::PathBuf::from(&config.dest);
+    let destdir = fs::canonicalize(destdir).unwrap_or_else(|_| path::PathBuf::new());
+    if cwd == destdir {
+        error!("Destination directory is same as current directory. \
+                       Cancelling the operation");
+        process::exit(1);
+    }
+
+    fs::remove_dir_all(&config.dest)?;
+
+    info!("directory \"{}\" removed", &config.dest);
+
+    Ok(())
+}
+
+pub fn import_command(config: cobalt::Config, matches: &clap::ArgMatches) -> Result<()> {
+    let branch = matches.value_of("branch").unwrap().to_string();
+    let message = matches.value_of("message").unwrap().to_string();
+    import(&config, &branch, &message)?;
+
+    Ok(())
+}
+
+fn import(config: &cobalt::Config, branch: &str, message: &str) -> Result<()> {
+    info!("Importing {} to {}", config.dest, branch);
+
+    let meta = fs::metadata(&config.dest)?;
+
+    if !meta.is_dir() {
+        bail!("`{}` is not a directory", config.dest);
+    }
+    ghp::import_dir(&config.dest, branch, message)?;
+
+    Ok(())
+}

--- a/src/bin/cobalt/build.rs
+++ b/src/bin/cobalt/build.rs
@@ -1,7 +1,6 @@
 use std::env;
 use std::fs;
 use std::path;
-use std::process;
 
 use clap;
 use cobalt;
@@ -34,9 +33,8 @@ pub fn clean_command(config: cobalt::Config, _matches: &clap::ArgMatches) -> Res
     let destdir = path::PathBuf::from(&config.dest);
     let destdir = fs::canonicalize(destdir).unwrap_or_else(|_| path::PathBuf::new());
     if cwd == destdir {
-        error!("Destination directory is same as current directory. \
+        bail!("Destination directory is same as current directory. \
                        Cancelling the operation");
-        process::exit(1);
     }
 
     fs::remove_dir_all(&config.dest)?;

--- a/src/bin/cobalt/error.rs
+++ b/src/bin/cobalt/error.rs
@@ -1,0 +1,27 @@
+use std::io;
+use std::sync;
+
+use clap;
+use cobalt;
+use ghp;
+use hyper;
+use notify;
+
+error_chain! {
+
+    links {
+    }
+
+    foreign_links {
+        Cobalt(cobalt::Error);
+        Notify(notify::Error);
+        Clap(clap::Error);
+        Ghp(ghp::Error);
+        Io(io::Error);
+        Hyper(hyper::Error);
+        Recv(sync::mpsc::RecvError);
+    }
+
+    errors {
+    }
+}

--- a/src/bin/cobalt/main.rs
+++ b/src/bin/cobalt/main.rs
@@ -326,27 +326,30 @@ fn run() -> Result<()> {
     }
 
     match command {
-        "init" => new::init_command(config, matches)?,
-        "new" => new::new_command(config, matches)?,
-        "build" => build::build_command(config, matches)?,
-        "clean" => build::clean_command(config, matches)?,
-        "serve" => serve::serve_command(config, matches)?,
-        "watch" => serve::watch_command(config, matches)?,
-        "import" => build::import_command(config, matches)?,
-        "list-syntax-themes" => {
-            for name in list_syntax_themes() {
-                println!("{}", name);
+            "init" => new::init_command(config, matches),
+            "new" => new::new_command(config, matches),
+            "build" => build::build_command(config, matches),
+            "clean" => build::clean_command(config, matches),
+            "serve" => serve::serve_command(config, matches),
+            "watch" => serve::watch_command(config, matches),
+            "import" => build::import_command(config, matches),
+            "list-syntax-themes" => {
+                for name in list_syntax_themes() {
+                    println!("{}", name);
+                }
+                Ok(())
+            }
+            "list-syntaxes" => {
+                for name in list_syntaxes() {
+                    println!("{}", name);
+                }
+                Ok(())
+            }
+            _ => {
+                bail!(global_matches.usage());
             }
         }
-        "list-syntaxes" => {
-            for name in list_syntaxes() {
-                println!("{}", name);
-            }
-        }
-        _ => {
-            bail!(global_matches.usage());
-        }
-    };
+        .chain_err(|| format!("{} command failed", command))?;
 
     Ok(())
 }

--- a/src/bin/cobalt/new.rs
+++ b/src/bin/cobalt/new.rs
@@ -1,0 +1,23 @@
+use clap;
+use cobalt;
+
+use error::*;
+
+pub fn init_command(_config: cobalt::Config, matches: &clap::ArgMatches) -> Result<()> {
+    let directory = matches.value_of("DIRECTORY").unwrap();
+
+    cobalt::create_new_project(&directory.to_string())?;
+    info!("Created new project at {}", directory);
+
+    Ok(())
+}
+
+pub fn new_command(config: cobalt::Config, matches: &clap::ArgMatches) -> Result<()> {
+    let filetype = matches.value_of("FILETYPE").unwrap();
+    let filename = matches.value_of("FILENAME").unwrap();
+
+    cobalt::create_new_document(filetype, filename, &config)?;
+    info!("Created new {} {}", filetype, filename);
+
+    Ok(())
+}

--- a/src/bin/cobalt/new.rs
+++ b/src/bin/cobalt/new.rs
@@ -6,7 +6,8 @@ use error::*;
 pub fn init_command(_config: cobalt::Config, matches: &clap::ArgMatches) -> Result<()> {
     let directory = matches.value_of("DIRECTORY").unwrap();
 
-    cobalt::create_new_project(&directory.to_string())?;
+    cobalt::create_new_project(&directory.to_string())
+        .chain_err(|| "Could not create a new cobalt project")?;
     info!("Created new project at {}", directory);
 
     Ok(())
@@ -16,7 +17,8 @@ pub fn new_command(config: cobalt::Config, matches: &clap::ArgMatches) -> Result
     let filetype = matches.value_of("FILETYPE").unwrap();
     let filename = matches.value_of("FILENAME").unwrap();
 
-    cobalt::create_new_document(filetype, filename, &config)?;
+    cobalt::create_new_document(filetype, filename, &config)
+        .chain_err(|| format!("Could not create {}", filetype))?;
     info!("Created new {} {}", filetype, filename);
 
     Ok(())

--- a/src/bin/cobalt/serve.rs
+++ b/src/bin/cobalt/serve.rs
@@ -35,12 +35,14 @@ pub fn watch_command(config: cobalt::Config, matches: &clap::ArgMatches) -> Resu
                   });
 
     let (tx, rx) = channel();
-    let mut watcher = raw_watcher(tx)?;
-    watcher.watch(&config.source, RecursiveMode::Recursive)?;
+    let mut watcher = raw_watcher(tx).chain_err(|| "Notify error")?;
+    watcher
+        .watch(&config.source, RecursiveMode::Recursive)
+        .chain_err(|| "Notify error")?;
     info!("Watching {:?} for changes", &config.source);
 
     loop {
-        let event = rx.recv()?;
+        let event = rx.recv().chain_err(|| "Notify error")?;
         let rebuild = if let Some(ref event_path) = event.path {
             // Be as broad as possible in what can cause a rebuild to
             // ensure we don't miss anything (normal file walks will miss

--- a/src/bin/cobalt/serve.rs
+++ b/src/bin/cobalt/serve.rs
@@ -1,0 +1,169 @@
+use std::fs;
+use std::io::prelude::*;
+use std::path;
+use std::process;
+use std::sync::mpsc::channel;
+use std::thread;
+
+use clap;
+use cobalt;
+use cobalt::files;
+use hyper;
+use hyper::server::{Server, Request, Response};
+use hyper::uri::RequestUri;
+use notify::{Watcher, RecursiveMode, raw_watcher};
+
+use build;
+use error::*;
+
+pub fn watch_command(config: cobalt::Config, matches: &clap::ArgMatches) -> Result<()> {
+    build::build(&config)?;
+
+    let source = path::Path::new(&config.source);
+    let dest = path::Path::new(&config.dest).to_owned();
+    let ignore_dest = {
+        let ignore_dest = dest.join("**/*");
+        let ignore_dest = ignore_dest
+            .to_str()
+            .ok_or_else(|| format!("Cannot convert pathname {:?} to UTF-8", dest))?
+            .to_owned();
+        Some(ignore_dest)
+    };
+    let port = matches.value_of("port").unwrap().to_string();
+    thread::spawn(move || if serve(&dest, &port).is_err() {
+                      process::exit(1)
+                  });
+
+    let (tx, rx) = channel();
+    let mut watcher = raw_watcher(tx)?;
+    watcher.watch(&config.source, RecursiveMode::Recursive)?;
+    info!("Watching {:?} for changes", &config.source);
+
+    loop {
+        let event = rx.recv()?;
+        let rebuild = if let Some(ref event_path) = event.path {
+            // Be as broad as possible in what can cause a rebuild to
+            // ensure we don't miss anything (normal file walks will miss
+            // `_layouts`, etc).
+            let mut page_files = files::FilesBuilder::new(source)?;
+            page_files.add_ignore("!.*")?.add_ignore("!_*")?;
+            if let Some(ref ignore_dest) = ignore_dest {
+                page_files.add_ignore(ignore_dest)?;
+            }
+            let page_files = page_files.build()?;
+
+            if page_files.includes_file(event_path) {
+                trace!("Page changed {:?}", event);
+                true
+            } else {
+                trace!("Ignored file changed {:?}", event);
+                false
+            }
+        } else {
+            trace!("Assuming change {:?} is relevant", event);
+            true
+        };
+        if rebuild {
+            build::build(&config)?;
+        }
+    }
+}
+
+pub fn serve_command(config: cobalt::Config, matches: &clap::ArgMatches) -> Result<()> {
+    build::build(&config)?;
+    let port = matches.value_of("port").unwrap().to_string();
+    let dest = path::Path::new(&config.dest);
+    serve(&dest, &port)?;
+
+    Ok(())
+}
+
+
+fn static_file_handler(dest: &path::Path, req: Request, mut res: Response) -> Result<()> {
+    // grab the requested path
+    let mut req_path = match req.uri {
+        RequestUri::AbsolutePath(p) => p,
+        _ => {
+            // return a 400 and exit from this request
+            *res.status_mut() = hyper::status::StatusCode::BadRequest;
+            let body = b"<h1> <center> 400: Bad request </center> </h1>";
+            res.send(body)?;
+            return Ok(());
+        }
+    };
+
+    // strip off any querystrings so path.is_file() matches
+    // and doesn't stick index.html on the end of the path
+    // (querystrings often used for cachebusting)
+    if let Some(position) = req_path.rfind('?') {
+        req_path.truncate(position);
+    }
+
+    // find the path of the file in the local system
+    // (this gets rid of the '/' in `p`, so the `join()` will not replace the
+    // path)
+    let path = dest.to_path_buf().join(&req_path[1..]);
+
+    let serve_path = if path.is_file() {
+        // try to point the serve path to `path` if it corresponds to a file
+        path
+    } else {
+        // try to point the serve path into a "index.html" file in the requested
+        // path
+        path.join("index.html")
+    };
+
+    // if the request points to a file and it exists, read and serve it
+    if serve_path.exists() {
+        let mut file = fs::File::open(serve_path)?;
+
+        // buffer to store the file
+        let mut buffer: Vec<u8> = vec![];
+
+        file.read_to_end(&mut buffer)?;
+
+        res.send(&buffer)?;
+    } else {
+        // return a 404 status
+        *res.status_mut() = hyper::status::StatusCode::NotFound;
+
+        // write a simple body for the 404 page
+        let body = b"<h1> <center> 404: Page not found </center> </h1>";
+
+        res.send(body)?;
+    }
+
+    Ok(())
+}
+
+fn serve(dest: &path::Path, port: &str) -> Result<()> {
+    info!("Serving {:?} through static file server", dest);
+
+    let ip = format!("127.0.0.1:{}", port);
+    info!("Server Listening on {}", &ip);
+    info!("Ctrl-c to stop the server");
+
+    // attempts to create a server
+    let http_server = match Server::http(&*ip) {
+        Ok(server) => server,
+        Err(e) => {
+            error!("{}", e);
+            return Err(e.into());
+        }
+    };
+
+    // need a clone because of closure's lifetime
+    let dest_clone = dest.to_owned();
+
+    // bind the handle function and start serving
+    if let Err(e) = http_server.handle(move |req: Request, res: Response| if let Err(e) =
+        static_file_handler(&dest_clone, req, res) {
+                                           error!("{}", e);
+                                           process::exit(1);
+                                       }) {
+        error!("{}", e);
+        return Err(e.into());
+    };
+
+    Ok(())
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -136,7 +136,7 @@ impl Config {
                             .into())
             }
             Err(err) => {
-                warn!("Syntax theme named '{}' ignored. Reason: {:?}",
+                warn!("Syntax theme named '{}' ignored. Reason: {}",
                       config.syntax_highlight.theme,
                       err);
                 Ok(())

--- a/src/document.rs
+++ b/src/document.rs
@@ -353,7 +353,7 @@ impl Document {
     }
 
     /// Extracts references iff markdown content.
-    pub fn extract_markdown_references(&self, excerpt_separator: &str) -> String {
+    fn extract_markdown_references(&self, excerpt_separator: &str) -> String {
         let mut trail = String::new();
 
         if self.front.format == frontmatter::SourceFormat::Markdown &&

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -1,15 +1,20 @@
 #[macro_use]
 extern crate difference;
+
 extern crate cobalt;
+extern crate error_chain;
 extern crate tempdir;
 extern crate walkdir;
 
-use std::path::{Path, PathBuf};
+use std::error::Error;
 use std::fs::{self, File};
 use std::io::Read;
+use std::path::{Path, PathBuf};
+
+use error_chain::ChainedError;
 use tempdir::TempDir;
 use walkdir::WalkDir;
-use std::error::Error;
+
 use cobalt::Config;
 
 macro_rules! assert_contains {
@@ -170,8 +175,8 @@ pub fn incomplete_rss() {
 pub fn liquid_error() {
     let err = run_test("liquid_error");
     assert!(err.is_err());
-    assert_eq!(err.unwrap_err().description(),
-               "{{{ is not a valid identifier");
+    assert_contains!(format!("{}", err.unwrap_err().display_chain()),
+                     "{{{ is not a valid identifier");
 }
 
 #[test]
@@ -183,7 +188,7 @@ pub fn liquid_raw() {
 pub fn no_extends_error() {
     let err = run_test("no_extends_error");
     assert!(err.is_err());
-    assert_contains!(err.unwrap_err().description(),
+    assert_contains!(format!("{}", err.unwrap_err().display_chain()),
                      "Layout default_nonexistent.liquid can not be read (defined in \
                    \"index.html\")");
 }


### PR DESCRIPTION
This is meant as a replacement for #162.  That PR added some error handling in a few places.  This nearly replaces `process::exist` with error chaining.

While at it, I added context to some errors, like what file failed in parsing the liquid template.

For testing, I ran every command to make sure they worked correctly.