### PR TITLE
Massively change configuration

### DIFF
--- a/src/bin/cobalt/build.rs
+++ b/src/bin/cobalt/build.rs
@@ -51,7 +51,7 @@ pub fn build_command(matches: &clap::ArgMatches) -> Result<()> {
 }
 
 pub fn build(config: &cobalt::Config) -> Result<()> {
-    info!("Building from {:?} into {:?}", config.source, config.dest);
+    info!("Building from {:?} into {:?}", config.source, config.destination);
     cobalt::build(config)?;
 
     Ok(())
@@ -69,7 +69,7 @@ pub fn clean_command(matches: &clap::ArgMatches) -> Result<()> {
 
     let cwd = env::current_dir().unwrap_or_else(|_| path::PathBuf::new());
     let destdir = config
-        .dest
+        .destination
         .canonicalize()
         .unwrap_or_else(|_| path::PathBuf::new());
     if cwd.starts_with(&destdir) {
@@ -116,12 +116,12 @@ pub fn import_command(matches: &clap::ArgMatches) -> Result<()> {
 }
 
 fn import(config: &cobalt::Config, branch: &str, message: &str) -> Result<()> {
-    info!("Importing {:?} to {}", config.dest, branch);
+    info!("Importing {:?} to {}", config.destination, branch);
 
-    if !config.dest.is_dir() {
-        bail!("`{:?}` is not a directory", config.dest);
+    if !config.destination.is_dir() {
+        bail!("`{:?}` is not a directory", config.destination);
     }
-    ghp::import_dir(&config.dest, branch, message)?;
+    ghp::import_dir(&config.destination, branch, message)?;
 
     Ok(())
 }

--- a/src/bin/cobalt/build.rs
+++ b/src/bin/cobalt/build.rs
@@ -51,7 +51,9 @@ pub fn build_command(matches: &clap::ArgMatches) -> Result<()> {
 }
 
 pub fn build(config: &cobalt::Config) -> Result<()> {
-    info!("Building from {:?} into {:?}", config.source, config.destination);
+    info!("Building from {:?} into {:?}",
+          config.source,
+          config.destination);
     cobalt::build(config)?;
 
     Ok(())

--- a/src/bin/cobalt/serve.rs
+++ b/src/bin/cobalt/serve.rs
@@ -35,13 +35,17 @@ pub fn watch_command(matches: &clap::ArgMatches) -> Result<()> {
 
     build::build(&config)?;
 
-    let source = path::Path::new(&config.source);
+    // canonicalize is to ensure there is no question that `watcher`s paths come back safe for
+    // Files::includes_file
+    let source = path::Path::new(&config.source)
+        .canonicalize()
+        .chain_err(|| "Failed in processing source")?;
     let dest = path::Path::new(&config.destination).to_owned();
 
     // Be as broad as possible in what can cause a rebuild to
     // ensure we don't miss anything (normal file walks will miss
     // `_layouts`, etc).
-    let mut site_files = files::FilesBuilder::new(source)?;
+    let mut site_files = files::FilesBuilder::new(&source)?;
     site_files.ignore_hidden(false)?;
     for line in &config.ignore {
         site_files.add_ignore(line.as_str())?;
@@ -56,7 +60,7 @@ pub fn watch_command(matches: &clap::ArgMatches) -> Result<()> {
     let (tx, rx) = channel();
     let mut watcher = raw_watcher(tx).chain_err(|| "Notify error")?;
     watcher
-        .watch(&config.source, RecursiveMode::Recursive)
+        .watch(&source, RecursiveMode::Recursive)
         .chain_err(|| "Notify error")?;
     info!("Watching {:?} for changes", &config.source);
 

--- a/src/bin/cobalt/serve.rs
+++ b/src/bin/cobalt/serve.rs
@@ -68,7 +68,7 @@ pub fn watch_command(matches: &clap::ArgMatches) -> Result<()> {
         let event = rx.recv().chain_err(|| "Notify error")?;
         let rebuild = if let Some(ref event_path) = event.path {
             if site_files.includes_file(event_path) {
-                trace!("Page changed {:?}", event);
+                debug!("Page changed {:?}", event);
                 true
             } else {
                 trace!("Ignored file changed {:?}", event);

--- a/src/bin/cobalt/serve.rs
+++ b/src/bin/cobalt/serve.rs
@@ -36,7 +36,7 @@ pub fn watch_command(matches: &clap::ArgMatches) -> Result<()> {
     build::build(&config)?;
 
     let source = path::Path::new(&config.source);
-    let dest = path::Path::new(&config.dest).to_owned();
+    let dest = path::Path::new(&config.destination).to_owned();
     let ignore_dest = {
         let ignore_dest = dest.join("**/*");
         let ignore_dest = ignore_dest
@@ -106,7 +106,7 @@ pub fn serve_command(matches: &clap::ArgMatches) -> Result<()> {
 
     build::build(&config)?;
     let port = matches.value_of("port").unwrap().to_string();
-    let dest = path::Path::new(&config.dest);
+    let dest = path::Path::new(&config.destination);
     serve(dest, &port)?;
 
     Ok(())

--- a/src/bin/cobalt/serve.rs
+++ b/src/bin/cobalt/serve.rs
@@ -37,14 +37,17 @@ pub fn watch_command(matches: &clap::ArgMatches) -> Result<()> {
 
     let source = path::Path::new(&config.source);
     let dest = path::Path::new(&config.destination).to_owned();
-    let ignore_dest = {
-        let ignore_dest = dest.join("**/*");
-        let ignore_dest = ignore_dest
-            .to_str()
-            .ok_or_else(|| format!("Cannot convert pathname {:?} to UTF-8", dest))?
-            .to_owned();
-        Some(ignore_dest)
-    };
+
+    // Be as broad as possible in what can cause a rebuild to
+    // ensure we don't miss anything (normal file walks will miss
+    // `_layouts`, etc).
+    let mut site_files = files::FilesBuilder::new(source)?;
+    site_files.ignore_hidden(false)?;
+    for line in &config.ignore {
+        site_files.add_ignore(line.as_str())?;
+    }
+    let site_files = site_files.build()?;
+
     let port = matches.value_of("port").unwrap().to_string();
     thread::spawn(move || if serve(&dest, &port).is_err() {
                       process::exit(1)
@@ -60,17 +63,7 @@ pub fn watch_command(matches: &clap::ArgMatches) -> Result<()> {
     loop {
         let event = rx.recv().chain_err(|| "Notify error")?;
         let rebuild = if let Some(ref event_path) = event.path {
-            // Be as broad as possible in what can cause a rebuild to
-            // ensure we don't miss anything (normal file walks will miss
-            // `_layouts`, etc).
-            let mut page_files = files::FilesBuilder::new(source)?;
-            page_files.add_ignore("!.*")?.add_ignore("!_*")?;
-            if let Some(ref ignore_dest) = ignore_dest {
-                page_files.add_ignore(ignore_dest)?;
-            }
-            let page_files = page_files.build()?;
-
-            if page_files.includes_file(event_path) {
+            if site_files.includes_file(event_path) {
                 trace!("Page changed {:?}", event);
                 true
             } else {

--- a/src/cobalt.rs
+++ b/src/cobalt.rs
@@ -263,13 +263,13 @@ fn create_rss(path: &str, dest: &Path, config: &Config, posts: &[Document]) -> R
         .posts
         .name
         .as_ref()
-        .or(config.site.name.as_ref())
+        .or_else(|| config.site.name.as_ref())
         .ok_or(ErrorKind::ConfigFileMissingFields)?;
     let description = config
         .posts
         .description
         .as_ref()
-        .or(config.site.description.as_ref())
+        .or_else(|| config.site.description.as_ref())
         .ok_or(ErrorKind::ConfigFileMissingFields)?;
     let link = config
         .site

--- a/src/cobalt.rs
+++ b/src/cobalt.rs
@@ -69,7 +69,7 @@ pub fn build(config: &Config) -> Result<()> {
     trace!("Build configuration: {:?}", config);
 
     let source = config.source.as_path();
-    let dest = config.dest.as_path();
+    let dest = config.destination.as_path();
 
     let template_extensions: Vec<&OsStr> =
         config.template_extensions.iter().map(OsStr::new).collect();

--- a/src/cobalt.rs
+++ b/src/cobalt.rs
@@ -39,15 +39,6 @@ pub fn build(config: &Config) -> Result<()> {
 
     let mut documents = vec![];
 
-    let ignore_dest = {
-        let ignore_dest = dest.join("**/*");
-        let ignore_dest = ignore_dest
-            .to_str()
-            .ok_or_else(|| format!("Cannot convert pathname {:?} to UTF-8", dest))?
-            .to_owned();
-        Some(ignore_dest)
-    };
-
     let mut page_files = FilesBuilder::new(source)?;
     page_files
         .add_ignore(&format!("!{}", config.posts.dir))?
@@ -56,9 +47,6 @@ pub fn build(config: &Config) -> Result<()> {
         .add_ignore(&format!("{}/**/_*/**", config.posts.dir))?;
     for line in &config.ignore {
         page_files.add_ignore(line.as_str())?;
-    }
-    if let Some(ref ignore_dest) = ignore_dest {
-        page_files.add_ignore(ignore_dest)?;
     }
     let page_files = page_files.build()?;
     for file_path in page_files.files().filter(|p| {
@@ -237,9 +225,6 @@ pub fn build(config: &Config) -> Result<()> {
         let mut asset_files = FilesBuilder::new(source)?;
         for line in &config.ignore {
             asset_files.add_ignore(line.as_str())?;
-        }
-        if let Some(ref ignore_dest) = ignore_dest {
-            asset_files.add_ignore(ignore_dest)?;
         }
         let asset_files = asset_files.build()?;
         for file_path in asset_files.files().filter(|p| {

--- a/src/cobalt.rs
+++ b/src/cobalt.rs
@@ -74,7 +74,7 @@ pub fn build(config: &Config) -> Result<()> {
     let template_extensions: Vec<&OsStr> =
         config.template_extensions.iter().map(OsStr::new).collect();
 
-    let layouts = source.join(&config.layouts);
+    let layouts = source.join(&config.layouts_dir);
     let mut layouts_cache = HashMap::new();
     let posts_path = source.join(&config.posts);
 

--- a/src/cobalt.rs
+++ b/src/cobalt.rs
@@ -167,7 +167,7 @@ pub fn build(config: &Config) -> Result<()> {
 
     // load data files
     let mut data_map: HashMap<String, Value> = HashMap::new();
-    let data_root = source.join(&config.data);
+    let data_root = source.join(&config.site.data_dir);
     let data_files_builder = FilesBuilder::new(data_root.as_path())?;
     let data_files = data_files_builder.build()?;
 
@@ -354,15 +354,18 @@ pub fn build(config: &Config) -> Result<()> {
 // creates a new RSS file with the contents of the site blog
 fn create_rss(path: &str, dest: &Path, config: &Config, posts: &[Document]) -> Result<()> {
     let name = config
+        .site
         .name
         .as_ref()
         .ok_or(ErrorKind::ConfigFileMissingFields)?;
     let description = config
+        .site
         .description
         .as_ref()
         .ok_or(ErrorKind::ConfigFileMissingFields)?;
     let link = config
-        .link
+        .site
+        .base_url
         .as_ref()
         .ok_or(ErrorKind::ConfigFileMissingFields)?;
 
@@ -393,15 +396,18 @@ fn create_rss(path: &str, dest: &Path, config: &Config, posts: &[Document]) -> R
 // creates a new jsonfeed file with the contents of the site blog
 fn create_jsonfeed(path: &str, dest: &Path, config: &Config, posts: &[Document]) -> Result<()> {
     let name = config
+        .site
         .name
         .as_ref()
         .ok_or(ErrorKind::ConfigFileMissingFields)?;
     let description = config
+        .site
         .description
         .as_ref()
         .ok_or(ErrorKind::ConfigFileMissingFields)?;
     let link = config
-        .link
+        .site
+        .base_url
         .as_ref()
         .ok_or(ErrorKind::ConfigFileMissingFields)?;
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -142,23 +142,23 @@ pub struct ConfigBuilder {
     #[serde(skip)]
     pub abs_dest: Option<String>,
     #[serde(skip)]
-    pub layouts: &'static str,
-    pub drafts: String,
     pub include_drafts: bool,
     pub posts: String,
+    pub drafts: String,
     pub post_path: Option<String>,
     pub post_order: SortOrder,
-    pub template_extensions: Vec<String>,
     pub rss: Option<String>,
     pub jsonfeed: Option<String>,
     pub site: SiteBuilder,
+    pub template_extensions: Vec<String>,
     pub ignore: Vec<String>,
     pub excerpt_separator: String,
+    pub syntax_highlight: SyntaxHighlight,
+    pub layouts: &'static str,
+    pub sass: SassOptions,
     // This is a debug-only field and should be transient rather than persistently set.
     #[serde(skip)]
     pub dump: Vec<Dump>,
-    pub syntax_highlight: SyntaxHighlight,
-    pub sass: SassOptions,
 }
 
 impl Default for ConfigBuilder {
@@ -168,21 +168,21 @@ impl Default for ConfigBuilder {
             source: "./".to_owned(),
             destination: "./".to_owned(),
             abs_dest: None,
-            layouts: LAYOUTS_DIR,
-            drafts: "_drafts".to_owned(),
             include_drafts: false,
             posts: "posts".to_owned(),
+            drafts: "_drafts".to_owned(),
             post_path: None,
             post_order: SortOrder::default(),
-            template_extensions: vec!["md".to_owned(), "liquid".to_owned()],
             rss: None,
             jsonfeed: None,
             site: SiteBuilder::default(),
+            template_extensions: vec!["md".to_owned(), "liquid".to_owned()],
             ignore: vec![],
             excerpt_separator: "\n\n".to_owned(),
-            dump: vec![],
             syntax_highlight: SyntaxHighlight::default(),
+            layouts: LAYOUTS_DIR,
             sass: SassOptions::default(),
+            dump: vec![],
         }
     }
 }
@@ -239,21 +239,21 @@ impl ConfigBuilder {
             source,
             destination,
             abs_dest,
-            layouts,
-            drafts,
             include_drafts,
             posts,
+            drafts,
             post_path,
             post_order,
-            template_extensions,
             rss,
             jsonfeed,
             site,
+            template_extensions,
             ignore,
             excerpt_separator,
-            dump,
             syntax_highlight,
+            layouts,
             sass,
+            dump,
         } = self;
 
         let result: Result<()> = match has_syntax_theme(&syntax_highlight.theme) {
@@ -275,21 +275,21 @@ impl ConfigBuilder {
             destination: abs_dest
                 .map(|s| s.into())
                 .unwrap_or_else(|| root.join(destination)),
-            layouts,
-            drafts,
             include_drafts,
             posts,
+            drafts,
             post_path,
             post_order,
-            template_extensions,
             rss,
             jsonfeed,
             site: site.build()?,
             ignore,
+            template_extensions,
             excerpt_separator,
-            dump,
             syntax_highlight,
+            layouts,
             sass,
+            dump,
         };
 
         Ok(config)
@@ -302,21 +302,21 @@ impl ConfigBuilder {
 pub struct Config {
     pub source: path::PathBuf,
     pub destination: path::PathBuf,
-    pub layouts: &'static str,
-    pub drafts: String,
     pub include_drafts: bool,
     pub posts: String,
+    pub drafts: String,
     pub post_path: Option<String>,
     pub post_order: SortOrder,
-    pub template_extensions: Vec<String>,
     pub rss: Option<String>,
     pub jsonfeed: Option<String>,
     pub site: SiteBuilder,
+    pub template_extensions: Vec<String>,
     pub ignore: Vec<String>,
     pub excerpt_separator: String,
-    pub dump: Vec<Dump>,
     pub syntax_highlight: SyntaxHighlight,
+    pub layouts: &'static str,
     pub sass: SassOptions,
+    pub dump: Vec<Dump>,
 }
 
 impl Default for Config {

--- a/src/config.rs
+++ b/src/config.rs
@@ -261,7 +261,7 @@ impl ConfigBuilder {
         if let Ok(rel_dest) = path::Path::new(&destination).strip_prefix(&source) {
             let rel_dest = rel_dest.to_str().expect("started as a utf-8 string");
             if !rel_dest.is_empty() {
-                ignore.push(rel_dest.to_owned());
+                ignore.push(format!("/{}", rel_dest.to_owned()));
             }
         }
 
@@ -454,7 +454,7 @@ fn test_build_dest() {
                            .set_post(true),
                        ..Default::default()
                    },
-                   ignore: ["dest".to_owned()].to_vec(),
+                   ignore: ["/dest".to_owned()].to_vec(),
                    ..Default::default()
                });
 }
@@ -477,7 +477,7 @@ fn test_build_abs_dest() {
                            .set_post(true),
                        ..Default::default()
                    },
-                   ignore: ["dest".to_owned()].to_vec(),
+                   ignore: ["/dest".to_owned()].to_vec(),
                    ..Default::default()
                });
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -92,7 +92,7 @@ pub struct ConfigBuilder {
     #[serde(skip)]
     pub root: path::PathBuf,
     pub source: String,
-    pub dest: String,
+    pub destination: String,
     #[serde(skip)]
     pub abs_dest: Option<String>,
     #[serde(skip)]
@@ -124,7 +124,7 @@ impl Default for ConfigBuilder {
         ConfigBuilder {
             root: path::PathBuf::new(),
             source: "./".to_owned(),
-            dest: "./".to_owned(),
+            destination: "./".to_owned(),
             abs_dest: None,
             layouts: LAYOUTS_DIR,
             drafts: "_drafts".to_owned(),
@@ -198,7 +198,7 @@ impl ConfigBuilder {
         let ConfigBuilder {
             root,
             source,
-            dest,
+            destination,
             abs_dest,
             layouts,
             drafts,
@@ -243,9 +243,9 @@ impl ConfigBuilder {
 
         let config = Config {
             source: root.join(source),
-            dest: abs_dest
+            destination: abs_dest
                 .map(|s| s.into())
-                .unwrap_or_else(|| root.join(dest)),
+                .unwrap_or_else(|| root.join(destination)),
             layouts,
             drafts,
             data,
@@ -275,7 +275,7 @@ impl ConfigBuilder {
 #[serde(deny_unknown_fields, default)]
 pub struct Config {
     pub source: path::PathBuf,
-    pub dest: path::PathBuf,
+    pub destination: path::PathBuf,
     pub layouts: &'static str,
     pub drafts: String,
     pub data: &'static str,
@@ -349,7 +349,7 @@ fn test_from_file_ok() {
     assert_eq!(result,
                ConfigBuilder {
                    root: path::Path::new("tests/fixtures/config").to_path_buf(),
-                   dest: "./dest".to_owned(),
+                   destination: "./dest".to_owned(),
                    posts: "_my_posts".to_owned(),
                    ..Default::default()
                });
@@ -393,7 +393,7 @@ fn test_from_cwd_ok() {
     assert_eq!(result,
                ConfigBuilder {
                    root: path::Path::new("tests/fixtures/config").to_path_buf(),
-                   dest: "./dest".to_owned(),
+                   destination: "./dest".to_owned(),
                    posts: "_my_posts".to_owned(),
                    ..Default::default()
                });
@@ -416,7 +416,7 @@ fn test_build_dest() {
     assert_eq!(result,
                Config {
                    source: path::Path::new("tests/fixtures/config").to_path_buf(),
-                   dest: path::Path::new("tests/fixtures/config/./dest").to_path_buf(),
+                   destination: path::Path::new("tests/fixtures/config/./dest").to_path_buf(),
                    posts: "_my_posts".to_owned(),
                    ..Default::default()
                });
@@ -430,7 +430,7 @@ fn test_build_abs_dest() {
     assert_eq!(result,
                Config {
                    source: path::Path::new("tests/fixtures/config").to_path_buf(),
-                   dest: path::Path::new("hello/world").to_path_buf(),
+                   destination: path::Path::new("hello/world").to_path_buf(),
                    posts: "_my_posts".to_owned(),
                    ..Default::default()
                });

--- a/src/config.rs
+++ b/src/config.rs
@@ -7,6 +7,7 @@ use serde_yaml;
 
 use frontmatter;
 use legacy::wildwest;
+use site;
 use syntax_highlight::has_syntax_theme;
 
 arg_enum! {
@@ -83,53 +84,6 @@ impl Default for SyntaxHighlight {
     }
 }
 
-const DATA_DIR: &'static str = "_data";
-
-#[derive(Debug, PartialEq)]
-#[derive(Serialize, Deserialize)]
-#[serde(deny_unknown_fields)]
-pub struct SiteBuilder {
-    pub name: Option<String>,
-    pub description: Option<String>,
-    pub base_url: Option<String>,
-    #[serde(skip)]
-    pub data_dir: &'static str,
-}
-
-impl Default for SiteBuilder {
-    fn default() -> SiteBuilder {
-        SiteBuilder {
-            name: None,
-            description: None,
-            base_url: None,
-            data_dir: DATA_DIR,
-        }
-    }
-}
-
-impl SiteBuilder {
-    pub fn build(self) -> Result<SiteBuilder> {
-        let SiteBuilder {
-            name,
-            description,
-            base_url,
-            data_dir,
-        } = self;
-        let base_url = base_url.map(|mut l| {
-                                        if l.ends_with('/') {
-                                            l.pop();
-                                        }
-                                        l
-                                    });
-        Ok(SiteBuilder {
-               name,
-               description,
-               base_url,
-               data_dir,
-           })
-    }
-}
-
 #[derive(Debug, PartialEq, Default)]
 #[derive(Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
@@ -183,7 +137,7 @@ pub struct ConfigBuilder {
     pub default: frontmatter::FrontmatterBuilder,
     pub pages: PageBuilder,
     pub posts: PostBuilder,
-    pub site: SiteBuilder,
+    pub site: site::SiteBuilder,
     pub template_extensions: Vec<String>,
     pub ignore: Vec<String>,
     pub syntax_highlight: SyntaxHighlight,
@@ -208,7 +162,7 @@ impl Default for ConfigBuilder {
                 .set_post(false),
             pages: PageBuilder::default(),
             posts: PostBuilder::default(),
-            site: SiteBuilder::default(),
+            site: site::SiteBuilder::default(),
             template_extensions: vec!["md".to_owned(), "liquid".to_owned()],
             ignore: vec![],
             syntax_highlight: SyntaxHighlight::default(),
@@ -333,7 +287,7 @@ pub struct Config {
     pub include_drafts: bool,
     pub pages: PageBuilder,
     pub posts: PostBuilder,
-    pub site: SiteBuilder,
+    pub site: site::SiteBuilder,
     pub template_extensions: Vec<String>,
     pub ignore: Vec<String>,
     pub syntax_highlight: SyntaxHighlight,
@@ -416,7 +370,7 @@ fn test_from_file_rss() {
                        rss: Some("rss.xml".to_owned()),
                        ..Default::default()
                    },
-                   site: SiteBuilder {
+                   site: site::SiteBuilder {
                        name: Some("My blog!".to_owned()),
                        description: Some("Blog description".to_owned()),
                        base_url: Some("http://example.com".to_owned()),

--- a/src/config.rs
+++ b/src/config.rs
@@ -257,15 +257,20 @@ impl ConfigBuilder {
         let mut posts = posts;
         posts.default = posts.default.merge(default);
 
+        let source = root.join(source);
+        let destination = abs_dest
+            .map(|s| s.into())
+            .unwrap_or_else(|| root.join(destination));
+
+        let site = site.build(&source)?;
+
         let config = Config {
-            source: root.join(source),
-            destination: abs_dest
-                .map(|s| s.into())
-                .unwrap_or_else(|| root.join(destination)),
+            source,
+            destination,
             include_drafts,
             pages,
             posts,
-            site: site.build()?,
+            site,
             ignore,
             template_extensions,
             syntax_highlight,
@@ -287,7 +292,7 @@ pub struct Config {
     pub include_drafts: bool,
     pub pages: PageBuilder,
     pub posts: PostBuilder,
-    pub site: site::SiteBuilder,
+    pub site: site::Site,
     pub template_extensions: Vec<String>,
     pub ignore: Vec<String>,
     pub syntax_highlight: SyntaxHighlight,

--- a/src/config.rs
+++ b/src/config.rs
@@ -257,6 +257,14 @@ impl ConfigBuilder {
         let mut posts = posts;
         posts.default = posts.default.merge(default);
 
+        let mut ignore = ignore;
+        if let Ok(rel_dest) = path::Path::new(&destination).strip_prefix(&source) {
+            let rel_dest = rel_dest.to_str().expect("started as a utf-8 string");
+            if !rel_dest.is_empty() {
+                ignore.push(rel_dest.to_owned());
+            }
+        }
+
         let source = root.join(source);
         let destination = abs_dest
             .map(|s| s.into())
@@ -446,6 +454,7 @@ fn test_build_dest() {
                            .set_post(true),
                        ..Default::default()
                    },
+                   ignore: ["dest".to_owned()].to_vec(),
                    ..Default::default()
                });
 }
@@ -468,6 +477,7 @@ fn test_build_abs_dest() {
                            .set_post(true),
                        ..Default::default()
                    },
+                   ignore: ["dest".to_owned()].to_vec(),
                    ..Default::default()
                });
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -154,7 +154,7 @@ pub struct ConfigBuilder {
     pub ignore: Vec<String>,
     pub excerpt_separator: String,
     pub syntax_highlight: SyntaxHighlight,
-    pub layouts: &'static str,
+    pub layouts_dir: &'static str,
     pub sass: SassOptions,
     // This is a debug-only field and should be transient rather than persistently set.
     #[serde(skip)]
@@ -180,7 +180,7 @@ impl Default for ConfigBuilder {
             ignore: vec![],
             excerpt_separator: "\n\n".to_owned(),
             syntax_highlight: SyntaxHighlight::default(),
-            layouts: LAYOUTS_DIR,
+            layouts_dir: LAYOUTS_DIR,
             sass: SassOptions::default(),
             dump: vec![],
         }
@@ -251,7 +251,7 @@ impl ConfigBuilder {
             ignore,
             excerpt_separator,
             syntax_highlight,
-            layouts,
+            layouts_dir,
             sass,
             dump,
         } = self;
@@ -287,7 +287,7 @@ impl ConfigBuilder {
             template_extensions,
             excerpt_separator,
             syntax_highlight,
-            layouts,
+            layouts_dir,
             sass,
             dump,
         };
@@ -314,7 +314,7 @@ pub struct Config {
     pub ignore: Vec<String>,
     pub excerpt_separator: String,
     pub syntax_highlight: SyntaxHighlight,
-    pub layouts: &'static str,
+    pub layouts_dir: &'static str,
     pub sass: SassOptions,
     pub dump: Vec<Dump>,
 }

--- a/src/files.rs
+++ b/src/files.rs
@@ -62,12 +62,7 @@ impl<'a> FilesIterator<'a> {
             .filter_entry(move |e| files.includes_entry(e))
             .filter_map(|e| e.ok())
             .filter(|e| e.file_type().is_file())
-            .filter_map(move |e| {
-                            e.path()
-                                .strip_prefix(files.root_dir.as_path())
-                                .ok()
-                                .map(|p| p.to_path_buf())
-                        });
+            .map(move |e| e.path().to_path_buf());
         FilesIterator { inner: Box::new(walker) }
     }
 }
@@ -431,7 +426,10 @@ mod tests {
     fn files_iter_matches_include() {
         let root_dir = Path::new("tests/fixtures/hidden_files");
         let files = FilesBuilder::new(root_dir).unwrap().build().unwrap();
-        let mut actual: Vec<_> = files.files().collect();
+        let mut actual: Vec<_> = files
+            .files()
+            .map(|f| f.strip_prefix(root_dir).unwrap().to_owned())
+            .collect();
         actual.sort();
 
         let expected = vec![Path::new("child/child.txt").to_path_buf(),

--- a/src/files.rs
+++ b/src/files.rs
@@ -24,7 +24,7 @@ impl FilesBuilder {
     }
 
     pub fn add_ignore(&mut self, line: &str) -> Result<&mut FilesBuilder> {
-        debug!("{:?}: adding '{}' ignore pattern", self.root_dir, line);
+        trace!("{:?}: adding '{}' ignore pattern", self.root_dir, line);
         self.ignore.push(line.to_owned());
         Ok(self)
     }
@@ -131,11 +131,11 @@ impl Files {
         match self.ignore.matched(path, is_dir) {
             Match::None => true,
             Match::Ignore(glob) => {
-                debug!("{:?}: ignored {:?}", path, glob.original());
+                trace!("{:?}: ignored {:?}", path, glob.original());
                 false
             }
             Match::Whitelist(glob) => {
-                debug!("{:?}: allowed {:?}", path, glob.original());
+                trace!("{:?}: allowed {:?}", path, glob.original());
                 true
             }
         }

--- a/src/legacy/wildwest.rs
+++ b/src/legacy/wildwest.rs
@@ -238,7 +238,7 @@ impl From<GlobalConfig> for config::ConfigBuilder {
 
         config::ConfigBuilder {
             source: source,
-            dest: dest,
+            destination: dest,
             drafts: drafts,
             include_drafts: include_drafts,
             posts: posts,

--- a/src/legacy/wildwest.rs
+++ b/src/legacy/wildwest.rs
@@ -236,6 +236,13 @@ impl From<GlobalConfig> for config::ConfigBuilder {
             ..Default::default()
         };
 
+        let site = config::SiteBuilder {
+            name: name,
+            description: description,
+            base_url: link,
+            ..Default::default()
+        };
+
         config::ConfigBuilder {
             source: source,
             destination: dest,
@@ -247,9 +254,7 @@ impl From<GlobalConfig> for config::ConfigBuilder {
             template_extensions: template_extensions,
             rss: rss,
             jsonfeed: jsonfeed,
-            name: name,
-            description: description,
-            link: link,
+            site: site,
             ignore: ignore,
             excerpt_separator: excerpt_separator,
             dump: vec![],

--- a/src/legacy/wildwest.rs
+++ b/src/legacy/wildwest.rs
@@ -225,6 +225,30 @@ impl From<GlobalConfig> for config::ConfigBuilder {
             _ => config::SortOrder::Desc,
         };
 
+        let default = frontmatter::FrontmatterBuilder::new()
+            .set_excerpt_separator(excerpt_separator)
+            .set_draft(false)
+            .set_post(false);
+        let posts = config::PostBuilder {
+            name: None,
+            description: None,
+            dir: posts,
+            drafts_dir: Some(drafts),
+            order: post_order,
+            rss: rss,
+            jsonfeed: jsonfeed,
+            default: frontmatter::FrontmatterBuilder::new()
+                .set_permalink(post_path)
+                .set_post(true),
+        };
+
+        let site = config::SiteBuilder {
+            name: name,
+            description: description,
+            base_url: link,
+            ..Default::default()
+        };
+
         let syntax_highlight = config::SyntaxHighlight { theme: syntax_highlight.theme };
         let sass = config::SassOptions {
             style: match sass.style {
@@ -236,30 +260,19 @@ impl From<GlobalConfig> for config::ConfigBuilder {
             ..Default::default()
         };
 
-        let site = config::SiteBuilder {
-            name: name,
-            description: description,
-            base_url: link,
-            ..Default::default()
-        };
-
         config::ConfigBuilder {
             source: source,
             destination: dest,
-            drafts: drafts,
             include_drafts: include_drafts,
-            posts: posts,
-            post_path: post_path,
-            post_order: post_order,
-            template_extensions: template_extensions,
-            rss: rss,
-            jsonfeed: jsonfeed,
+            default,
+            pages: config::PageBuilder::default(),
+            posts,
             site: site,
+            template_extensions: template_extensions,
             ignore: ignore,
-            excerpt_separator: excerpt_separator,
-            dump: vec![],
             syntax_highlight: syntax_highlight,
             sass: sass,
+            dump: vec![],
             ..Default::default()
         }
     }

--- a/src/legacy/wildwest.rs
+++ b/src/legacy/wildwest.rs
@@ -3,8 +3,9 @@ use std::default::Default;
 use liquid;
 
 use super::super::config;
-use super::super::frontmatter;
 use super::super::datetime;
+use super::super::frontmatter;
+use super::super::site;
 
 #[derive(Debug, Eq, PartialEq, Default, Clone)]
 #[derive(Serialize, Deserialize)]
@@ -242,7 +243,7 @@ impl From<GlobalConfig> for config::ConfigBuilder {
                 .set_post(true),
         };
 
-        let site = config::SiteBuilder {
+        let site = site::SiteBuilder {
             name: name,
             description: description,
             base_url: link,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -99,6 +99,7 @@ mod cobalt;
 mod config;
 mod document;
 mod new;
+mod site;
 mod slug;
 mod datetime;
 mod frontmatter;

--- a/src/new.rs
+++ b/src/new.rs
@@ -91,7 +91,7 @@ pub fn create_new_project_for_path(dest: &Path) -> Result<()> {
 
 pub fn create_new_document(doc_type: &str, name: &str, config: &Config) -> Result<()> {
     let path = Path::new(&config.source);
-    let full_path = &path.join(&config.posts).join(name);
+    let full_path = &path.join(&config.posts.dir).join(name);
 
     match doc_type {
         "page" => create_file(name, INDEX_LIQUID)?,

--- a/src/site.rs
+++ b/src/site.rs
@@ -156,16 +156,19 @@ fn load_data(data_path: &path::Path) -> Result<liquid::Value> {
 fn insert_data_dir(data: &mut liquid::Object, data_root: &path::Path) -> Result<()> {
     let data_files_builder = files::FilesBuilder::new(data_root)?;
     let data_files = data_files_builder.build()?;
-    for df in data_files.files() {
-        let file_stem = df.file_stem()
+    for full_path in data_files.files() {
+        let rel_path = full_path
+            .strip_prefix(data_root)
+            .expect("file was found under the root");
+
+        let file_stem = full_path
+            .file_stem()
             .expect("Files will always return with a stem");
         let file_stem = String::from(file_stem.to_str().unwrap());
 
-        let full_path = data_root.join(df.clone());
-
         let data_fragment = load_data(&full_path)?;
 
-        deep_insert(data, &df, file_stem, data_fragment)?;
+        deep_insert(data, rel_path, file_stem, data_fragment)?;
     }
 
     Ok(())

--- a/src/site.rs
+++ b/src/site.rs
@@ -1,0 +1,50 @@
+use std::default::Default;
+
+use error::*;
+
+const DATA_DIR: &'static str = "_data";
+
+#[derive(Debug, PartialEq)]
+#[derive(Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct SiteBuilder {
+    pub name: Option<String>,
+    pub description: Option<String>,
+    pub base_url: Option<String>,
+    #[serde(skip)]
+    pub data_dir: &'static str,
+}
+
+impl Default for SiteBuilder {
+    fn default() -> SiteBuilder {
+        SiteBuilder {
+            name: None,
+            description: None,
+            base_url: None,
+            data_dir: DATA_DIR,
+        }
+    }
+}
+
+impl SiteBuilder {
+    pub fn build(self) -> Result<SiteBuilder> {
+        let SiteBuilder {
+            name,
+            description,
+            base_url,
+            data_dir,
+        } = self;
+        let base_url = base_url.map(|mut l| {
+                                        if l.ends_with('/') {
+                                            l.pop();
+                                        }
+                                        l
+                                    });
+        Ok(SiteBuilder {
+               name,
+               description,
+               base_url,
+               data_dir,
+           })
+    }
+}

--- a/src/site.rs
+++ b/src/site.rs
@@ -21,6 +21,7 @@ pub struct SiteBuilder {
     pub name: Option<String>,
     pub description: Option<String>,
     pub base_url: Option<String>,
+    pub data: Option<liquid::Object>,
     #[serde(skip)]
     pub data_dir: &'static str,
 }
@@ -31,6 +32,7 @@ impl Default for SiteBuilder {
             name: None,
             description: None,
             base_url: None,
+            data: None,
             data_dir: DATA_DIR,
         }
     }
@@ -42,6 +44,7 @@ impl SiteBuilder {
             name,
             description,
             base_url,
+            data,
             data_dir,
         } = self;
         let base_url = base_url.map(|mut l| {
@@ -61,7 +64,7 @@ impl SiteBuilder {
         if let Some(ref base_url) = base_url {
             attributes.insert("base_url".to_owned(), liquid::Value::str(base_url));
         }
-        let mut data = liquid::Object::new();
+        let mut data = data.unwrap_or_default();
         insert_data_dir(&mut data, &root.join(data_dir))?;
         if !data.is_empty() {
             attributes.insert("data".to_owned(), liquid::Value::Object(data));

--- a/src/site.rs
+++ b/src/site.rs
@@ -52,6 +52,15 @@ impl SiteBuilder {
                                     });
 
         let mut attributes = liquid::Object::new();
+        if let Some(ref name) = name {
+            attributes.insert("name".to_owned(), liquid::Value::str(name));
+        }
+        if let Some(ref description) = description {
+            attributes.insert("description".to_owned(), liquid::Value::str(description));
+        }
+        if let Some(ref base_url) = base_url {
+            attributes.insert("base_url".to_owned(), liquid::Value::str(base_url));
+        }
         let mut data = liquid::Object::new();
         insert_data_dir(&mut data, &root.join(data_dir))?;
         if !data.is_empty() {

--- a/src/site.rs
+++ b/src/site.rs
@@ -1,10 +1,20 @@
 use std::default::Default;
+use std::ffi::OsStr;
+use std::fs;
+use std::io::Read;
+use std::path;
+
+use liquid;
+use serde_json;
+use serde_yaml;
+use toml;
 
 use error::*;
+use files;
 
 const DATA_DIR: &'static str = "_data";
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Clone)]
 #[derive(Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct SiteBuilder {
@@ -27,7 +37,7 @@ impl Default for SiteBuilder {
 }
 
 impl SiteBuilder {
-    pub fn build(self) -> Result<SiteBuilder> {
+    pub fn build(self, root: &path::Path) -> Result<Site> {
         let SiteBuilder {
             name,
             description,
@@ -40,11 +50,111 @@ impl SiteBuilder {
                                         }
                                         l
                                     });
-        Ok(SiteBuilder {
+
+        let mut attributes = liquid::Object::new();
+        let mut data = liquid::Object::new();
+        insert_data_dir(&mut data, &root.join(data_dir))?;
+        if !data.is_empty() {
+            attributes.insert("data".to_owned(), liquid::Value::Object(data));
+        }
+
+        Ok(Site {
                name,
                description,
                base_url,
-               data_dir,
+               attributes,
            })
     }
+}
+
+#[derive(Debug, PartialEq, Default, Clone)]
+#[derive(Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Site {
+    pub name: Option<String>,
+    pub description: Option<String>,
+    pub base_url: Option<String>,
+    pub attributes: liquid::Object,
+}
+
+fn deep_insert(data_map: &mut liquid::Object,
+               file_path: &path::Path,
+               target_key: String,
+               data: liquid::Value)
+               -> Result<()> {
+    // now find the nested map it is supposed to be in
+    let target_map = if let Some(path) = file_path.parent() {
+        let mut map = data_map;
+        for part in path.iter() {
+            let key = part.to_str().ok_or_else(|| {
+                format!("The data from {:?} can't be loaded as it contains non utf-8 characters",
+                        path)
+            })?;
+            let cur_map = map;
+            map = cur_map
+                .entry(String::from(key))
+                .or_insert_with(|| liquid::Value::Object(liquid::Object::new()))
+                .as_object_mut()
+                .ok_or_else(|| {
+                                format!("Aborting: Duplicate in data tree. Would overwrite {:?} ",
+                                        path)
+                            })?;
+        }
+        map
+    } else {
+        data_map
+    };
+
+    match target_map.insert(target_key, data) {
+        None => Ok(()),
+        _ => {
+            Err(format!("The data from {:?} can't be loaded: the key already exists",
+                        file_path)
+                    .into())
+        }
+    }
+}
+
+fn load_data(data_path: &path::Path) -> Result<liquid::Value> {
+    let ext = data_path.extension().unwrap_or_else(|| OsStr::new(""));
+
+    let data: liquid::Value;
+
+    if ext == OsStr::new("yml") || ext == OsStr::new("yaml") {
+        let reader = fs::File::open(data_path)?;
+        data = serde_yaml::from_reader(reader)?;
+    } else if ext == OsStr::new("json") {
+        let reader = fs::File::open(data_path)?;
+        data = serde_json::from_reader(reader)?;
+    } else if ext == OsStr::new("toml") {
+        let mut reader = fs::File::open(data_path)?;
+        let mut text = String::new();
+        reader.read_to_string(&mut text)?;
+        data = toml::from_str(&text)?;
+    } else {
+        bail!("Failed to load of data {:?}: unknown file type '{:?}'.\n\
+              Supported data files extensions are: yml, yaml, json and toml.",
+              data_path,
+              ext);
+    }
+
+    Ok(data)
+}
+
+fn insert_data_dir(data: &mut liquid::Object, data_root: &path::Path) -> Result<()> {
+    let data_files_builder = files::FilesBuilder::new(data_root)?;
+    let data_files = data_files_builder.build()?;
+    for df in data_files.files() {
+        let file_stem = df.file_stem()
+            .expect("Files will always return with a stem");
+        let file_stem = String::from(file_stem.to_str().unwrap());
+
+        let full_path = data_root.join(df.clone());
+
+        let data_fragment = load_data(&full_path)?;
+
+        deep_insert(data, &df, file_stem, data_fragment)?;
+    }
+
+    Ok(())
 }

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -89,12 +89,12 @@ fn run_test(name: &str) -> Result<(), cobalt::Error> {
     let config = config.build()?;
 
     // try to create the target directory, ignore errors
-    fs::create_dir_all(&config.dest).is_ok();
+    fs::create_dir_all(&config.destination).is_ok();
 
     let result = cobalt::build(&config);
 
     if result.is_ok() {
-        assert_dirs_eq(&config.dest, &target);
+        assert_dirs_eq(&config.destination, &target);
     }
 
     // clean up


### PR DESCRIPTION
The focus was on ground work for #199.

As part of this
- cobalt now exposes the following liquid variabes
  - `site.name`
  - `site.description`
  - `site.base_url`
    - Can be used to make correct paths, for example `{{site.base_url}}/{{post.path}}`.
  - Fixes #171, #216 
- `watch` will now respect the `ignore` field
  - Helps in people implementing workarounds
  - Shouldn't break anything because ignored content shouldn't be used by cobalt anyways (unless someone ignores a normally-hidden-except-for-watch directory like `_data`)
- Fix ignoring `dest` in both `build` and `watch`
  - Broken in #308.  It was adding an absolute path to be ignored rather than a relative
  - Also ensured we didn't ignore non-dest directories that look like them
  - Also hardened our detection of dest being a child of source
- (internal-config-only) Support writing `site.data` directly in config
- (internal-config-only) Allow setting default frontmatter fields globally or just posts/pages