### PR TITLE
fix(site): Rename name to title

### DIFF
--- a/src/cobalt.rs
+++ b/src/cobalt.rs
@@ -250,7 +250,7 @@ fn create_rss(path: &str, dest: &Path, config: &Config, posts: &[Document]) -> R
         .posts
         .name
         .as_ref()
-        .or_else(|| config.site.name.as_ref())
+        .or_else(|| config.site.title.as_ref())
         .ok_or(ErrorKind::ConfigFileMissingFields)?;
     let description = config
         .posts
@@ -291,14 +291,16 @@ fn create_rss(path: &str, dest: &Path, config: &Config, posts: &[Document]) -> R
 // creates a new jsonfeed file with the contents of the site blog
 fn create_jsonfeed(path: &str, dest: &Path, config: &Config, posts: &[Document]) -> Result<()> {
     let name = config
-        .site
+        .posts
         .name
         .as_ref()
+        .or_else(|| config.site.title.as_ref())
         .ok_or(ErrorKind::ConfigFileMissingFields)?;
     let description = config
-        .site
+        .posts
         .description
         .as_ref()
+        .or_else(|| config.site.description.as_ref())
         .ok_or(ErrorKind::ConfigFileMissingFields)?;
     let link = config
         .site

--- a/src/config.rs
+++ b/src/config.rs
@@ -422,7 +422,7 @@ fn test_from_file_rss() {
                        ..Default::default()
                    },
                    site: site::SiteBuilder {
-                       name: Some("My blog!".to_owned()),
+                       title: Some("My blog!".to_owned()),
                        description: Some("Blog description".to_owned()),
                        base_url: Some("http://example.com".to_owned()),
                        ..Default::default()

--- a/src/legacy/wildwest.rs
+++ b/src/legacy/wildwest.rs
@@ -244,7 +244,7 @@ impl From<GlobalConfig> for config::ConfigBuilder {
         };
 
         let site = site::SiteBuilder {
-            name: name,
+            title: name,
             description: description,
             base_url: link,
             ..Default::default()

--- a/src/site.rs
+++ b/src/site.rs
@@ -18,7 +18,7 @@ const DATA_DIR: &'static str = "_data";
 #[derive(Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct SiteBuilder {
-    pub name: Option<String>,
+    pub title: Option<String>,
     pub description: Option<String>,
     pub base_url: Option<String>,
     pub data: Option<liquid::Object>,
@@ -29,7 +29,7 @@ pub struct SiteBuilder {
 impl Default for SiteBuilder {
     fn default() -> SiteBuilder {
         SiteBuilder {
-            name: None,
+            title: None,
             description: None,
             base_url: None,
             data: None,
@@ -41,7 +41,7 @@ impl Default for SiteBuilder {
 impl SiteBuilder {
     pub fn build(self, root: &path::Path) -> Result<Site> {
         let SiteBuilder {
-            name,
+            title,
             description,
             base_url,
             data,
@@ -55,8 +55,8 @@ impl SiteBuilder {
                                     });
 
         let mut attributes = liquid::Object::new();
-        if let Some(ref name) = name {
-            attributes.insert("name".to_owned(), liquid::Value::str(name));
+        if let Some(ref title) = title {
+            attributes.insert("title".to_owned(), liquid::Value::str(title));
         }
         if let Some(ref description) = description {
             attributes.insert("description".to_owned(), liquid::Value::str(description));
@@ -71,7 +71,7 @@ impl SiteBuilder {
         }
 
         Ok(Site {
-               name,
+               title,
                description,
                base_url,
                attributes,
@@ -83,7 +83,7 @@ impl SiteBuilder {
 #[derive(Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct Site {
-    pub name: Option<String>,
+    pub title: Option<String>,
     pub description: Option<String>,
     pub base_url: Option<String>,
     pub attributes: liquid::Object,


### PR DESCRIPTION
This is consistency with page.title.

(This also slips in a fix for jsonfeed to use the blog
title/description)

See #313