### PR TITLE
Update configuration in prep for major breaking changes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -835,7 +835,6 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "getopts 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2,10 +2,10 @@
 name = "cobalt-bin"
 version = "0.7.5"
 dependencies = [
- "assert_cli 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "assert_cli 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "clap 2.26.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "clippy 0.0.165 (registry+https://github.com/rust-lang/crates.io-index)",
+ "clap 2.27.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "clippy 0.0.168 (registry+https://github.com/rust-lang/crates.io-index)",
  "difference 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "error-chain 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -17,13 +17,13 @@ dependencies = [
  "lazy_static 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "liquid 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "notify 4.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "notify 4.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "pulldown-cmark 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rss 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "sass-rs 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.15 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_yaml 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "syntect 1.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempdir 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -36,7 +36,7 @@ name = "aho-corasick"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "memchr 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -46,14 +46,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "assert_cli"
-version = "0.5.2"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "colored 1.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "colored 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "difference 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "environment 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "error-chain 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "skeptic 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "skeptic 0.13.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -70,7 +71,7 @@ version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.31 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
  "termion 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -80,22 +81,22 @@ name = "backtrace"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "backtrace-sys 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "backtrace-sys 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "cfg-if 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "dbghelp-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.31 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-demangle 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "backtrace-sys"
-version = "0.1.14"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "cc 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.31 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -114,7 +115,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "byteorder 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.18 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -126,7 +127,7 @@ dependencies = [
  "cexpr 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "cfg-if 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "clang-sys 0.19.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "clap 2.26.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "clap 2.27.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -177,14 +178,26 @@ name = "cargo_metadata"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "serde 1.0.15 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.15 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "cargo_metadata"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "error-chain 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "semver 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "cc"
-version = "1.0.0"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -192,7 +205,7 @@ name = "cexpr"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "nom 3.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "nom 3.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -216,39 +229,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.31 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
  "libloading 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "clap"
-version = "2.26.2"
+version = "2.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "ansi_term 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "atty 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "bitflags 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "strsim 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "term_size 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "textwrap 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "textwrap 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-width 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "vec_map 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "clippy"
-version = "0.0.165"
+version = "0.0.168"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cargo_metadata 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "clippy_lints 0.0.165 (registry+https://github.com/rust-lang/crates.io-index)",
+ "clippy_lints 0.0.168 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "clippy_lints"
-version = "0.0.165"
+version = "0.0.168"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
+ "if_chain 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "matches 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -256,10 +269,11 @@ dependencies = [
  "quine-mc_cluskey 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex-syntax 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "semver 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.15 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-normalization 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -267,33 +281,20 @@ name = "cmake"
 version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "cc 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "colored"
-version = "1.5.3"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "lazy_static 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
-name = "conv"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "custom_derive 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "crossbeam"
 version = "0.2.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "custom_derive"
-version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -336,12 +337,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "either"
-version = "1.2.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "encoding_rs"
-version = "0.7.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cfg-if 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -355,6 +356,11 @@ dependencies = [
  "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "environment"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "error-chain"
@@ -374,10 +380,11 @@ dependencies = [
 
 [[package]]
 name = "filetime"
-version = "0.1.12"
+version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.31 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
  "redox_syscall 0.1.31 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -386,7 +393,7 @@ name = "flate2"
 version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.31 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
  "miniz-sys 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -397,12 +404,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "fsevent"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "fsevent-sys 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.31 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -410,7 +417,23 @@ name = "fsevent-sys"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.31 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "fuchsia-zircon"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "fuchsia-zircon-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "fuchsia-zircon-sys"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -439,13 +462,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "globset"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "aho-corasick 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "memchr 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -469,7 +492,7 @@ dependencies = [
  "traitobject 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "typeable 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicase 1.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "url 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -483,15 +506,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "if_chain"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "ignore"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "crossbeam 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "globset 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "globset 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "memchr 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "thread_local 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "walkdir 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -502,7 +530,7 @@ name = "inotify"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.31 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -510,7 +538,7 @@ name = "itertools"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "either 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "either 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -524,9 +552,9 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "error-chain 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.15 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.15 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -550,7 +578,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "libc"
-version = "0.2.31"
+version = "0.2.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -582,10 +610,10 @@ dependencies = [
  "itertools 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.15 (registry+https://github.com/rust-lang/crates.io-index)",
- "skeptic 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "skeptic 0.13.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-segmentation 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "url 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -594,33 +622,24 @@ version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "magenta"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "conv 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "magenta-sys 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "magenta-sys"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "matches"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "memchr"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.31 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "memchr"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -636,8 +655,8 @@ name = "miniz-sys"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "cc 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.31 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -646,7 +665,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bytes 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.31 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "miow 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "net2 0.2.31 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -674,7 +693,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cfg-if 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.31 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "ws2_32-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -685,29 +704,29 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.31 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "nom"
-version = "3.2.0"
+version = "3.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "memchr 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "notify"
-version = "4.0.1"
+version = "4.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "filetime 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "fsevent 0.2.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "filetime 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fsevent 0.2.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "fsevent-sys 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "inotify 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.31 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
  "mio 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "walkdir 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -750,7 +769,7 @@ name = "num_cpus"
 version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.31 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -760,7 +779,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.31 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
  "onig_sys 65.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -770,7 +789,7 @@ version = "65.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cmake 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.31 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
  "pkg-config 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -797,7 +816,7 @@ dependencies = [
  "base64 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "xml-rs 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -844,9 +863,9 @@ name = "quick-xml"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "encoding_rs 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "encoding_rs 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "error-chain 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "memchr 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -861,11 +880,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "rand"
-version = "0.3.16"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.31 (registry+https://github.com/rust-lang/crates.io-index)",
- "magenta 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fuchsia-zircon 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -887,7 +906,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "aho-corasick 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "memchr 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex-syntax 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "thread_local 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "utf8-ranges 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -936,7 +955,7 @@ name = "sass-rs"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.31 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
  "sass-sys 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -947,7 +966,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bindgen 0.26.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "gcc 0.3.54 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.31 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
  "pkg-config 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -960,21 +979,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "semver"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.18 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "semver-parser"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "serde"
-version = "1.0.15"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "serde_derive 1.0.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.18 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.15"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -993,13 +1021,13 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.3"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "dtoa 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "itoa 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.18 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1009,24 +1037,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "linked-hash-map 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "yaml-rust 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "skeptic"
-version = "0.13.0"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bytecount 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cargo_metadata 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "error-chain 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "pulldown-cmark 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.15 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.15 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempdir 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "toml 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "walkdir 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1071,9 +1097,9 @@ dependencies = [
  "onig 1.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "plist 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex-syntax 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.15 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.15 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "walkdir 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1091,7 +1117,7 @@ name = "syntex_errors"
 version = "0.58.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.31 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "syntex_pos 0.58.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "term 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1124,7 +1150,7 @@ name = "tempdir"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "rand 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.3.17 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1137,31 +1163,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "term_size"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.31 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "termion"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.31 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
  "redox_syscall 0.1.31 (registry+https://github.com/rust-lang/crates.io-index)",
  "redox_termios 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "textwrap"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "term_size 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-width 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1180,7 +1195,7 @@ version = "0.1.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.31 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
  "redox_syscall 0.1.31 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1190,7 +1205,7 @@ name = "toml"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "serde 1.0.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.18 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1249,7 +1264,7 @@ dependencies = [
 
 [[package]]
 name = "url"
-version = "1.5.1"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "idna 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1334,11 +1349,11 @@ dependencies = [
 [metadata]
 "checksum aho-corasick 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)" = "500909c4f87a9e52355b26626d890833e9e1d53ac566db76c36faa984b889699"
 "checksum ansi_term 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "23ac7c30002a5accbf7e8987d0632fa6de155b7c3d39d0067317a391e00a2ef6"
-"checksum assert_cli 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "03715e49fad7a911ddbb15e105108e6e8af8dcdebbae9e583cf5f53b33e84248"
+"checksum assert_cli 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)" = "72342c21057a3cb5f7c2d849bf7999a83795434dd36d74fa8c24680581bd1930"
 "checksum aster 0.41.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4ccfdf7355d9db158df68f976ed030ab0f6578af811f5a7bb6dcf221ec24e0e0"
 "checksum atty 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "21e50800ec991574876040fff8ee46b136a53e985286fbe6a3bdfe6421b78860"
 "checksum backtrace 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "99f2ce94e22b8e664d95c57fff45b98a966c2252b60691d0b7aeeccd88d70983"
-"checksum backtrace-sys 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)" = "c63ea141ef8fdb10409d0f5daf30ac51f84ef43bff66f16627773d2a292cd189"
+"checksum backtrace-sys 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "44585761d6161b0f57afc49482ab6bd067e4edef48c12a152c237eb0203f7661"
 "checksum base64 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "96434f987501f0ed4eb336a411e0631ecd1afa11574fe148587adc4ff96143c9"
 "checksum bincode 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e103c8b299b28a9c6990458b7013dc4a8356a9b854c51b9883241f5866fac36e"
 "checksum bindgen 0.26.3 (registry+https://github.com/rust-lang/crates.io-index)" = "c57d6c0f6e31f8dcf4d12720a3c2a9ffb70638772a5784976cf4fce52145f22a"
@@ -1350,42 +1365,45 @@ dependencies = [
 "checksum byteorder 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ff81738b726f5d099632ceaffe7fb65b90212e8dce59d518729e7e8634032d3d"
 "checksum bytes 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c129aff112dcc562970abb69e2508b40850dd24c274761bb50fb8a0067ba6c27"
 "checksum cargo_metadata 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "be1057b8462184f634c3a208ee35b0f935cfd94b694b26deadccd98732088d7b"
-"checksum cc 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7db2f146208d7e0fbee761b09cd65a7f51ccc38705d4e7262dad4d73b12a76b1"
+"checksum cargo_metadata 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "54a7180f3a48da3542c6054adee54bd43c2242630b3842eabbf44971f68a5a03"
+"checksum cc 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a9b13a57efd6b30ecd6598ebdb302cca617930b5470647570468a65d12ef9719"
 "checksum cexpr 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "cdbb21df6ff3497a61df5059994297f746267020ba38ce237aad9c875f7b4313"
 "checksum cfg-if 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d4c819a1287eb618df47cc647173c5c4c66ba19d888a6e50d605672aed3140de"
 "checksum chrono 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7c20ebe0b2b08b0aeddba49c609fe7957ba2e33449882cb186a180bc60682fa9"
 "checksum clang-sys 0.19.0 (registry+https://github.com/rust-lang/crates.io-index)" = "611ec2e3a7623afd8a8c0d027887b6b55759d894abbf5fe11b9dc11b50d5b49a"
-"checksum clap 2.26.2 (registry+https://github.com/rust-lang/crates.io-index)" = "3451e409013178663435d6f15fdb212f14ee4424a3d74f979d081d0a66b6f1f2"
-"checksum clippy 0.0.165 (registry+https://github.com/rust-lang/crates.io-index)" = "88f67cdb6697a5d357f8f70cffdf65f4dcb6ec8bb5069f2bc347589b3869cbe8"
-"checksum clippy_lints 0.0.165 (registry+https://github.com/rust-lang/crates.io-index)" = "c8f37194e4a7cb36daeeb5727eac96e32c82965e4ae8b119817885377ddb6715"
+"checksum clap 2.27.1 (registry+https://github.com/rust-lang/crates.io-index)" = "1b8c532887f1a292d17de05ae858a8fe50a301e196f9ef0ddb7ccd0d1d00f180"
+"checksum clippy 0.0.168 (registry+https://github.com/rust-lang/crates.io-index)" = "9adee585714cd9978cfa31c81ee5863f46603cd7986a8e27a67857351a97c410"
+"checksum clippy_lints 0.0.168 (registry+https://github.com/rust-lang/crates.io-index)" = "fc8d09341065d0d87e4da7421047fba1bd655c68d673706fce7279a6db984a7e"
 "checksum cmake 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)" = "357c07e7a1fc95732793c1edb5901e1a1f305cfcf63a90eb12dbd22bdb6b789d"
-"checksum colored 1.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "c1d4a2a8e207306352a8b08263af6c83c0be745b21cd2eedfe03a5f49ec8cd93"
-"checksum conv 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "78ff10625fd0ac447827aa30ea8b861fead473bb60aeb73af6c1c58caf0d1299"
+"checksum colored 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b0aa3473e85a3161b59845d6096b289bb577874cafeaf75ea1b1beaa6572c7fc"
 "checksum crossbeam 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)" = "0c5ea215664ca264da8a9d9c3be80d2eaf30923c259d03e870388eb927508f97"
-"checksum custom_derive 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "ef8ae57c4978a2acd8b869ce6b9ca1dfe817bff704c220209fdef2c0b75a01b9"
 "checksum dbghelp-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "97590ba53bcb8ac28279161ca943a924d1fd4a8fb3fa63302591647c4fc5b850"
 "checksum derive_builder 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "03600ae366b6eb2314e54d62adc833d9866da03798acc61c61789654ceaa227a"
 "checksum derive_builder_core 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "eed37eae64daa5511467b1a55cebdf472deeaef108d22f62f25e8bbcaffd56ac"
 "checksum difference 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b3304d19798a8e067e48d8e69b2c37f0b5e9b4e462504ad9e27e9f3fce02bba8"
 "checksum dtoa 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "09c3753c3db574d215cba4ea76018483895d7bff25a31b49ba45db21c48e50ab"
-"checksum either 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "cbee135e9245416869bf52bd6ccc9b59e2482651510784e089b874272f02a252"
-"checksum encoding_rs 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6f0a39f0e2f497d3c2e6a5529a0ec4fc640084fa401493c640421673471f8b72"
+"checksum either 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e311a7479512fbdf858fb54d91ec59f3b9f85bc0113659f46bba12b199d273ce"
+"checksum encoding_rs 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f5215aabf22b83153be3ee44dfe3f940214541b2ce13d419c55e7a115c8c51a9"
 "checksum env_logger 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3ddf21e73e016298f5cb37d6ef8e8da8e39f91f9ec8b0df44b7deb16a9f8cd5b"
+"checksum environment 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "1f4b14e20978669064c33b4c1e0fb4083412e40fe56cbea2eae80fd7591503ee"
 "checksum error-chain 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d9435d864e017c3c6afeac1654189b06cdb491cf2ff73dbf0d73b0f292f42ff8"
 "checksum error-chain 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ff511d5dc435d703f4971bc399647c9bc38e20cb41452e3b9feb4765419ed3f3"
-"checksum filetime 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)" = "6ab199bf38537c6f38792669e081e0bb278b9b7405bba2642e4e5d15bf732c0e"
+"checksum filetime 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)" = "aa75ec8f7927063335a9583e7fa87b0110bb888cf766dc01b54c0ff70d760c8e"
 "checksum flate2 0.2.20 (registry+https://github.com/rust-lang/crates.io-index)" = "e6234dd4468ae5d1e2dbb06fe2b058696fdc50a339c68a393aefbf00bc81e423"
 "checksum fnv 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "6cc484842f1e2884faf56f529f960cc12ad8c71ce96cc7abba0a067c98fee344"
-"checksum fsevent 0.2.16 (registry+https://github.com/rust-lang/crates.io-index)" = "dfe593ebcfc76884138b25426999890b10da8e6a46d01b499d7c54c604672c38"
+"checksum fsevent 0.2.17 (registry+https://github.com/rust-lang/crates.io-index)" = "c4bbbf71584aeed076100b5665ac14e3d85eeb31fdbb45fbd41ef9a682b5ec05"
 "checksum fsevent-sys 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "1a772d36c338d07a032d5375a36f15f9a7043bf0cb8ce7cee658e037c6032874"
+"checksum fuchsia-zircon 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f6c0581a4e363262e52b87f59ee2afe3415361c6ec35e665924eb08afe8ff159"
+"checksum fuchsia-zircon-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "43f3795b4bae048dc6123a6b972cadde2e676f9ded08aef6bb77f5f157684a82"
 "checksum gcc 0.3.54 (registry+https://github.com/rust-lang/crates.io-index)" = "5e33ec290da0d127825013597dbdfc28bee4964690c7ce1166cbc2a7bd08b1bb"
 "checksum getopts 0.2.15 (registry+https://github.com/rust-lang/crates.io-index)" = "65922871abd2f101a2eb0eaebadc66668e54a87ad9c3dd82520b5f86ede5eff9"
 "checksum ghp 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "2381a505873cc9b3bc814214150a0da3193db84cdaf3c9eb2145c7a369d337f0"
 "checksum glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "8be18de09a56b60ed0edf84bc9df007e30040691af7acd1c41874faac5895bfb"
-"checksum globset 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "feeb1b6840809ef5efcf7a4a990bc4e1b7ee3df8cf9e2379a75aeb2ba42ac9c3"
+"checksum globset 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "464627f948c3190ae3d04b1bc6d7dca2f785bda0ac01278e6db129ad383dbeb6"
 "checksum httparse 1.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "af2f2dd97457e8fb1ae7c5a420db346af389926e36f43768b96f101546b04a07"
 "checksum hyper 0.10.13 (registry+https://github.com/rust-lang/crates.io-index)" = "368cb56b2740ebf4230520e2b90ebb0461e69034d85d1945febd9b3971426db2"
 "checksum idna 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "014b298351066f1512874135335d62a789ffe78a9974f94b43ed5621951eaf7d"
+"checksum if_chain 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "61bb90bdd39e3af69b0172dfc6130f6cd6332bf040fbb9bdd4401d37adbd48b8"
 "checksum ignore 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "b3fcaf2365eb14b28ec7603c98c06cc531f19de9eb283d89a3dff8417c8c99f5"
 "checksum inotify 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "887fcc180136e77a85e6a6128579a719027b1bab9b1c38ea4444244fe262c20c"
 "checksum itertools 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)" = "d3f2be4da1690a039e9ae5fd575f706a63ad5a2120f161b1d653c9da3930dd21"
@@ -1394,24 +1412,23 @@ dependencies = [
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
 "checksum language-tags 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a91d884b6667cd606bb5a69aa0c99ba811a115fc68915e7056ec08a46e93199a"
 "checksum lazy_static 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)" = "c9e5e58fa1a4c3b915a561a78a22ee0cac6ab97dca2504428bc1cb074375f8d5"
-"checksum libc 0.2.31 (registry+https://github.com/rust-lang/crates.io-index)" = "d1419b2939a0bc44b77feb34661583c7546b532b192feab36249ab584b86856c"
+"checksum libc 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)" = "5ba3df4dcb460b9dfbd070d41c94c19209620c191b0340b929ce748a2bcd42d2"
 "checksum libloading 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "3f92926a9a4ba7aeeb01f5fba3f0d577147243b6e7fa8261c219cd1d6fbe3b1c"
 "checksum linked-hash-map 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6d262045c5b87c0861b3f004610afd0e2c851e2908d08b6c870cbb9d5f494ecd"
 "checksum linked-hash-map 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7860ec297f7008ff7a1e3382d7f7e1dcd69efc94751a2284bafc3d013c2aa939"
 "checksum liquid 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2bd0db04ca9b57c71fd20638b6290eaed9a3ba1aa9af2ee43f163a8bd98dac43"
 "checksum log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)" = "880f77541efa6e5cc74e76910c9884d9859683118839d6a1dc3b11e63512565b"
-"checksum magenta 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4bf0336886480e671965f794bc9b6fce88503563013d1bfb7a502c81fe3ac527"
-"checksum magenta-sys 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "40d014c7011ac470ae28e2f76a02bfea4a8480f73e701353b49ad7a8d75f4699"
 "checksum matches 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "100aabe6b8ff4e4a7e32c1c13523379802df0772b82466207ac25b013f193376"
-"checksum memchr 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "1dbccc0e46f1ea47b9f17e6d67c5a96bd27030519c519c9c91327e31275a47b4"
+"checksum memchr 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "148fab2e51b4f1cfc66da2a7c32981d1d3c083a803978268bb11fe4b86925e7a"
+"checksum memchr 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e01e64d9017d18e7fc09d8e4fe0e28ff6931019e979fb8019319db7ca827f8a6"
 "checksum mime 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "ba626b8a6de5da682e1caa06bdb42a335aee5a84db8e5046a3e8ab17ba0a3ae0"
 "checksum miniz-sys 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "609ce024854aeb19a0ef7567d348aaa5a746b32fb72e336df7fcc16869d7e2b4"
 "checksum mio 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a637d1ca14eacae06296a008fa7ad955347e34efcb5891cfd8ba05491a37907e"
 "checksum miow 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "3e690c5df6b2f60acd45d56378981e827ff8295562fc8d34f573deb267a59cd1"
 "checksum net2 0.2.31 (registry+https://github.com/rust-lang/crates.io-index)" = "3a80f842784ef6c9a958b68b7516bc7e35883c614004dd94959a4dca1b716c09"
 "checksum nix 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "bfb3ddedaa14746434a02041940495bf11325c22f6d36125d3bdd56090d50a79"
-"checksum nom 3.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "06989cbd367e06f787a451f3bc67d8c3e0eaa10b461cc01152ffab24261a31b1"
-"checksum notify 4.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "298d4401ff2c6cebb7f8944c90288647c89ce59029d43b439444cf1067df55e1"
+"checksum nom 3.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "05aec50c70fd288702bcd93284a8444607f3292dbdf2a30de5ea5dcdbe72287b"
+"checksum notify 4.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "745bdfd0d0764c71525e880c6d7662b721cb5658ddb2feaa71c3193ec359aef8"
 "checksum num 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)" = "a311b77ebdc5dd4cf6449d81e4135d9f0e3b153839ac90e648a8ef538f923525"
 "checksum num-integer 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)" = "d1452e8b06e448a07f0e6ebb0bb1d92b8890eea63288c0b627331d53514d0fba"
 "checksum num-iter 0.1.34 (registry+https://github.com/rust-lang/crates.io-index)" = "7485fcc84f85b4ecd0ea527b14189281cf27d60e583ae65ebc9c088b13dffe01"
@@ -1430,7 +1447,7 @@ dependencies = [
 "checksum quick-xml 0.9.4 (registry+https://github.com/rust-lang/crates.io-index)" = "19a3a610544419c527d5f51ae1a6ae3db533e25c117d3eed8fce6434f70c5e95"
 "checksum quine-mc_cluskey 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "07589615d719a60c8dd8a4622e7946465dfef20d1a428f969e3443e7386d5f45"
 "checksum quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6e920b65c65f10b2ae65c831a81a073a89edd28c7cce89475bff467ab4167a"
-"checksum rand 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)" = "eb250fd207a4729c976794d03db689c9be1d634ab5a1c9da9492a13d8fecbcdf"
+"checksum rand 0.3.17 (registry+https://github.com/rust-lang/crates.io-index)" = "61efcbcd9fa8d8fbb07c84e34a8af18a1ff177b449689ad38a6e9457ecc7b2ae"
 "checksum redox_syscall 0.1.31 (registry+https://github.com/rust-lang/crates.io-index)" = "8dde11f18c108289bef24469638a04dce49da56084f2d50618b226e47eb04509"
 "checksum redox_termios 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7e891cfe48e9100a70a3b6eb652fef28920c117d366339687bd5576160db0f76"
 "checksum regex 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1731164734096285ec2a5ec7fea5248ae2f5485b3feeb0115af4fda2183b2d1b"
@@ -1443,13 +1460,14 @@ dependencies = [
 "checksum sass-rs 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "22498eeceeef42b0bfbf44c27bf49bc37043beddc7eac73ae9f4d17e08967e2e"
 "checksum sass-sys 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "49e6025ff142eb235157aea8d6ee8085d9f5b80e280cb54b911f6b778e64075a"
 "checksum semver 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7a3186ec9e65071a2095434b1f5bb24838d4e8e130f584c790f6033c79943537"
+"checksum semver 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bee2bc909ab2d8d60dab26e8cad85b25d795b14603a0dcb627b78b9d30b6454b"
 "checksum semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
-"checksum serde 1.0.15 (registry+https://github.com/rust-lang/crates.io-index)" = "6a7046c9d4c6c522d10b2d098f9bebe2bef227e0e74044d8c1bfcf6b476af799"
-"checksum serde_derive 1.0.15 (registry+https://github.com/rust-lang/crates.io-index)" = "1afcaae083fd1c46952a315062326bc9957f182358eb7da03b57ef1c688f7aa9"
+"checksum serde 1.0.18 (registry+https://github.com/rust-lang/crates.io-index)" = "395993cac4e3599c7c1b70a6a92d3b3f55f4443df9f0b5294e362285ad7c9ecb"
+"checksum serde_derive 1.0.18 (registry+https://github.com/rust-lang/crates.io-index)" = "7fa060f679fe2d5a9f7374dd4553dc907eba4f9acf183e4c7baf69eae02e6ca8"
 "checksum serde_derive_internals 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bd381f6d01a6616cdba8530492d453b7761b456ba974e98768a18cad2cd76f58"
-"checksum serde_json 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "d243424e06f9f9c39e3cd36147470fd340db785825e367625f79298a6ac6b7ac"
+"checksum serde_json 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "ae1e67ce320daa7e494c578e34d4b00689f23bb94512fe0ca0dfaf02ea53fb67"
 "checksum serde_yaml 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "49d983aa39d2884a4b422bb11bb38f4f48fa05186e17469bc31e47d01e381111"
-"checksum skeptic 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1f31525315eba9ea57e24df3a92f981fb50bdfc811f4879bdc897d84cf8baec5"
+"checksum skeptic 0.13.2 (registry+https://github.com/rust-lang/crates.io-index)" = "c8431f8fca168e2db4be547bd8329eac70d095dff1444fee4b0fa0fabc7df75a"
 "checksum slab 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "d807fd58c4181bbabed77cb3b891ba9748241a552bcc5be698faaebefc54f46e"
 "checksum strsim 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b4d15c810519a91cf877e7e36e63fe068815c678181439f2f29e2562147c3694"
 "checksum syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)" = "d3b891b9015c88c576343b9b3e41c2c11a51c219ef067b264bd9c8aa9b441dad"
@@ -1461,9 +1479,8 @@ dependencies = [
 "checksum syntex_syntax 0.58.1 (registry+https://github.com/rust-lang/crates.io-index)" = "6e0e4dbae163dd98989464c23dd503161b338790640e11537686f2ef0f25c791"
 "checksum tempdir 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "87974a6f5c1dfb344d733055601650059a3363de2a6104819293baff662132d6"
 "checksum term 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "fa63644f74ce96fbeb9b794f66aff2a52d601cbd5e80f4b97123e3899f4570f1"
-"checksum term_size 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e2b6b55df3198cc93372e85dd2ed817f0e38ce8cc0f22eb32391bfad9c4bf209"
 "checksum termion 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "689a3bdfaab439fd92bc87df5c4c78417d3cbe537487274e9b0b2dce76e92096"
-"checksum textwrap 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "df8e08afc40ae3459e4838f303e465aa50d823df8d7f83ca88108f6d3afe7edd"
+"checksum textwrap 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c0b59b6b4b44d867f1370ef1bd91bfb262bf07bf0ae65c202ea2fbc16153b693"
 "checksum thread_local 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "1697c4b57aeeb7a536b647165a2825faddffb1d3bad386d507709bd51a90bb14"
 "checksum time 0.1.38 (registry+https://github.com/rust-lang/crates.io-index)" = "d5d788d3aa77bc0ef3e9621256885555368b47bd495c13dd2e7413c89f845520"
 "checksum toml 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)" = "a7540f4ffc193e0d3c94121edb19b055670d369f77d5804db11ae053a45b6e7e"
@@ -1476,7 +1493,7 @@ dependencies = [
 "checksum unicode-width 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "bf3a113775714a22dcb774d8ea3655c53a32debae63a063acc00a91cc586245f"
 "checksum unicode-xid 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "8c1f860d7d29cf02cb2f3f359fd35991af3d30bac52c57d265a3c461074cb4dc"
 "checksum unreachable 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "382810877fe448991dfc7f0dd6e3ae5d58088fd0ea5e35189655f84e6814fa56"
-"checksum url 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "eeb819346883532a271eb626deb43c4a1bb4c4dd47c519bd78137c3e72a4fe27"
+"checksum url 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fa35e768d4daf1d85733418a49fb42e10d7f633e394fccab4ab7aba897053fe2"
 "checksum utf8-ranges 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "662fab6525a98beff2921d7f61a39e7d59e0b425ebc7d0d9e66d316e55124122"
 "checksum vec_map 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "887b5b631c2ad01628bbbaa7dd4c869f80d3186688f8d0b6f58774fbe324988c"
 "checksum version_check 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "6b772017e347561807c1aa192438c5fd74242a670a6cffacc40f2defd1dc069d"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ log = "0.3"
 env_logger = "0.4"
 rss = "1.1"
 jsonfeed = "0.2"
-pulldown-cmark = "0.1"
+pulldown-cmark = {version="0.1", default-features = false}
 notify = "4.0"
 ghp = "0.1"
 regex = "0.2"

--- a/src/cobalt.rs
+++ b/src/cobalt.rs
@@ -150,7 +150,8 @@ pub fn build(config: &Config) -> Result<()> {
             files::create_document_file(content, dest.join(file_path))?;
         }
 
-        let mut context = post.get_render_context(&simple_posts_data);
+        let mut context = post.get_render_context();
+        context.set_val("posts", liquid::Value::Array(simple_posts_data.clone()));
         context.set_val("site",
                         liquid::Value::Object(config.site.attributes.clone()));
 
@@ -200,7 +201,8 @@ pub fn build(config: &Config) -> Result<()> {
             files::create_document_file(content, dest.join(file_path))?;
         }
 
-        let mut context = doc.get_render_context(&posts_data);
+        let mut context = doc.get_render_context();
+        context.set_val("posts", liquid::Value::Array(posts_data.clone()));
         context.set_val("site",
                         liquid::Value::Object(config.site.attributes.clone()));
 

--- a/src/cobalt.rs
+++ b/src/cobalt.rs
@@ -227,7 +227,7 @@ pub fn build(config: &Config) -> Result<()> {
             !template_extensions.contains(&p.extension().unwrap_or_else(|| OsStr::new("")))
         }) {
             if file_path.extension() == Some(OsStr::new("scss")) {
-                sass::compile_sass(&config.sass, source, dest, file_path)?;
+                sass::compile_sass(&config.assets.sass, source, dest, file_path)?;
             } else {
                 let rel_src = file_path
                     .strip_prefix(source)

--- a/src/cobalt.rs
+++ b/src/cobalt.rs
@@ -151,6 +151,7 @@ pub fn build(config: &Config) -> Result<()> {
         }
 
         let mut context = post.get_render_context();
+        // TODO(epage): Switch `posts` to `parent` which is an object see #323
         context.set_val("posts", liquid::Value::Array(simple_posts_data.clone()));
         context.set_val("site",
                         liquid::Value::Object(config.site.attributes.clone()));
@@ -202,6 +203,7 @@ pub fn build(config: &Config) -> Result<()> {
         }
 
         let mut context = doc.get_render_context();
+        // TODO(epage): Switch `posts` to an object see #323
         context.set_val("posts", liquid::Value::Array(posts_data.clone()));
         context.set_val("site",
                         liquid::Value::Object(config.site.attributes.clone()));

--- a/src/config.rs
+++ b/src/config.rs
@@ -131,7 +131,7 @@ impl Default for ConfigBuilder {
         ConfigBuilder {
             root: path::PathBuf::new(),
             source: "./".to_owned(),
-            destination: "./".to_owned(),
+            destination: "./_site".to_owned(),
             abs_dest: None,
             include_drafts: false,
             default: frontmatter::FrontmatterBuilder::new()

--- a/src/config.rs
+++ b/src/config.rs
@@ -91,6 +91,13 @@ impl Default for PostBuilder {
     }
 }
 
+#[derive(Debug, PartialEq, Default)]
+#[derive(Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct AssetsBuilder {
+    pub sass: sass::SassOptions,
+}
+
 const LAYOUTS_DIR: &'static str = "_layouts";
 
 #[derive(Debug, PartialEq)]
@@ -113,7 +120,7 @@ pub struct ConfigBuilder {
     pub ignore: Vec<String>,
     pub syntax_highlight: SyntaxHighlight,
     pub layouts_dir: &'static str,
-    pub sass: sass::SassOptions,
+    pub assets: AssetsBuilder,
     // This is a debug-only field and should be transient rather than persistently set.
     #[serde(skip)]
     pub dump: Vec<Dump>,
@@ -138,7 +145,7 @@ impl Default for ConfigBuilder {
             ignore: vec![],
             syntax_highlight: SyntaxHighlight::default(),
             layouts_dir: LAYOUTS_DIR,
-            sass: sass::SassOptions::default(),
+            assets: AssetsBuilder::default(),
             dump: vec![],
         }
     }
@@ -200,7 +207,7 @@ impl ConfigBuilder {
             ignore,
             syntax_highlight,
             layouts_dir,
-            sass,
+            assets,
             dump,
         } = self;
 
@@ -261,7 +268,7 @@ impl ConfigBuilder {
             template_extensions,
             syntax_highlight,
             layouts_dir,
-            sass,
+            assets,
             dump,
         };
 
@@ -283,7 +290,7 @@ pub struct Config {
     pub ignore: Vec<String>,
     pub syntax_highlight: SyntaxHighlight,
     pub layouts_dir: &'static str,
-    pub sass: sass::SassOptions,
+    pub assets: AssetsBuilder,
     pub dump: Vec<Dump>,
 }
 

--- a/src/document.rs
+++ b/src/document.rs
@@ -230,7 +230,7 @@ impl Document {
 
         let perma_attributes = permalink_attributes(&front, rel_path);
         let (file_path, url_path) = {
-            let permalink = front.path.as_ref();
+            let permalink = front.permalink.as_ref();
             let url_path = explode_permalink(permalink, perma_attributes);
             let file_path = format_url_as_file(&url_path);
             (file_path, url_path)

--- a/src/document.rs
+++ b/src/document.rs
@@ -67,9 +67,6 @@ fn format_path_variable(source_file: &Path) -> String {
 fn permalink_attributes(front: &frontmatter::Frontmatter,
                         dest_file: &Path)
                         -> HashMap<String, String> {
-    // TODO replace "date", "pretty", "ordinal" and "none"
-    // for Jekyl compatibility
-
     let mut attributes = HashMap::new();
 
     attributes.insert(":path".to_owned(), format_path_variable(dest_file));
@@ -79,8 +76,12 @@ fn permalink_attributes(front: &frontmatter::Frontmatter,
         attributes.insert(":filename".to_owned(), filename.to_owned());
     }
 
+    // TODO(epage): Add `collection` (the collection's slug), see #257
+    // or `parent.slug`, see #323
+
     attributes.insert(":slug".to_owned(), front.slug.clone());
 
+    // TODO(epage): slugify categories?  See #257
     attributes.insert(":categories".to_owned(),
                       itertools::join(front.categories.iter(), "/"));
 
@@ -98,6 +99,7 @@ fn permalink_attributes(front: &frontmatter::Frontmatter,
     }
 
     // Allow customizing any of the above with custom frontmatter attributes
+    // TODO(epage): Place in a `custom` variable.  See #257
     for (key, val) in &front.custom {
         let key = format!(":{}", key);
         // HACK: We really should support nested types
@@ -113,6 +115,7 @@ fn explode_permalink<S: Into<String>>(permalink: S, attributes: HashMap<String, 
 }
 
 fn explode_permalink_string(permalink: String, attributes: HashMap<String, String>) -> String {
+    // TODO(epage): Switch to liquid templating
     let mut p = permalink;
 
     for (key, val) in attributes {
@@ -160,6 +163,7 @@ fn document_attributes(front: &frontmatter::Frontmatter,
     let mut attributes = liquid::Object::new();
 
     attributes.insert("path".to_owned(), liquid::Value::str(url_path));
+    // TODO(epage): Remove?  See #257
     attributes.insert("source".to_owned(), liquid::Value::str(source_file));
     attributes.insert("title".to_owned(), liquid::Value::str(&front.title));
     if let Some(ref description) = front.description {
@@ -172,12 +176,16 @@ fn document_attributes(front: &frontmatter::Frontmatter,
                                                .map(|c| liquid::Value::str(c))
                                                .collect()));
     if let Some(ref published_date) = front.published_date {
+        // TODO(epage): Rename to published_date. See #257
         attributes.insert("date".to_owned(),
                           liquid::Value::Str(published_date.format()));
     }
+    // TODO(epage): Rename to `is_draft`. See #257
     attributes.insert("draft".to_owned(), liquid::Value::Bool(front.is_draft));
+    // TODO(epage): Remove? See #257
     attributes.insert("is_post".to_owned(), liquid::Value::Bool(front.is_post));
 
+    // TODO(epage): Place in a `custom` variable.  See #257
     for (key, val) in &front.custom {
         attributes.insert(key.clone(), val.clone());
     }

--- a/src/document.rs
+++ b/src/document.rs
@@ -294,10 +294,8 @@ impl Document {
 
 
     /// Prepares liquid context for further rendering.
-    pub fn get_render_context(&self, posts: &[Value]) -> Context {
-        let mut context = Context::with_values(self.attributes.clone());
-        context.set_val("posts", Value::Array(posts.to_vec()));
-        context
+    pub fn get_render_context(&self) -> Context {
+        Context::with_values(self.attributes.clone())
     }
 
     /// Renders liquid templates into HTML in the context of current document.

--- a/src/frontmatter.rs
+++ b/src/frontmatter.rs
@@ -23,7 +23,7 @@ impl Default for SourceFormat {
 #[derive(Serialize, Deserialize)]
 #[serde(deny_unknown_fields, default)]
 pub struct FrontmatterBuilder {
-    pub path: Option<String>,
+    pub permalink: Option<String>,
     pub slug: Option<String>,
     pub title: Option<String>,
     pub description: Option<String>,
@@ -41,49 +41,47 @@ pub struct FrontmatterBuilder {
 }
 
 impl FrontmatterBuilder {
-    pub fn new() -> FrontmatterBuilder {
-        FrontmatterBuilder::default()
+    pub fn new() -> Self {
+        Self::default()
     }
 
-    pub fn set_permalink<S: Into<Option<String>>>(self, permalink: S) -> FrontmatterBuilder {
-        FrontmatterBuilder {
-            path: permalink.into(),
+    pub fn set_permalink<S: Into<Option<String>>>(self, permalink: S) -> Self {
+        Self {
+            permalink: permalink.into(),
             ..self
         }
     }
 
-    pub fn set_slug<S: Into<Option<String>>>(self, slug: S) -> FrontmatterBuilder {
-        FrontmatterBuilder {
+    pub fn set_slug<S: Into<Option<String>>>(self, slug: S) -> Self {
+        Self {
             slug: slug.into(),
             ..self
         }
     }
 
-    pub fn set_title<S: Into<Option<String>>>(self, title: S) -> FrontmatterBuilder {
-        FrontmatterBuilder {
+    pub fn set_title<S: Into<Option<String>>>(self, title: S) -> Self {
+        Self {
             title: title.into(),
             ..self
         }
     }
 
-    pub fn set_description<S: Into<Option<String>>>(self, description: S) -> FrontmatterBuilder {
-        FrontmatterBuilder {
+    pub fn set_description<S: Into<Option<String>>>(self, description: S) -> Self {
+        Self {
             description: description.into(),
             ..self
         }
     }
 
-    pub fn set_categories<S: Into<Option<Vec<String>>>>(self, categories: S) -> FrontmatterBuilder {
-        FrontmatterBuilder {
+    pub fn set_categories<S: Into<Option<Vec<String>>>>(self, categories: S) -> Self {
+        Self {
             categories: categories.into(),
             ..self
         }
     }
 
-    pub fn set_excerpt_separator<S: Into<Option<String>>>(self,
-                                                          excerpt_separator: S)
-                                                          -> FrontmatterBuilder {
-        FrontmatterBuilder {
+    pub fn set_excerpt_separator<S: Into<Option<String>>>(self, excerpt_separator: S) -> Self {
+        Self {
             excerpt_separator: excerpt_separator.into(),
             ..self
         }
@@ -91,97 +89,93 @@ impl FrontmatterBuilder {
 
     pub fn set_published_date<D: Into<Option<datetime::DateTime>>>(self,
                                                                    published_date: D)
-                                                                   -> FrontmatterBuilder {
-        FrontmatterBuilder {
+                                                                   -> Self {
+        Self {
             published_date: published_date.into(),
             ..self
         }
     }
 
     #[cfg(test)]
-    pub fn set_format<S: Into<Option<SourceFormat>>>(self, format: S) -> FrontmatterBuilder {
-        FrontmatterBuilder {
+    pub fn set_format<S: Into<Option<SourceFormat>>>(self, format: S) -> Self {
+        Self {
             format: format.into(),
             ..self
         }
     }
 
-    pub fn set_layout<S: Into<Option<String>>>(self, layout: S) -> FrontmatterBuilder {
-        FrontmatterBuilder {
+    pub fn set_layout<S: Into<Option<String>>>(self, layout: S) -> Self {
+        Self {
             layout: layout.into(),
             ..self
         }
     }
 
-    pub fn set_draft<B: Into<Option<bool>>>(self, is_draft: B) -> FrontmatterBuilder {
-        FrontmatterBuilder {
+    pub fn set_draft<B: Into<Option<bool>>>(self, is_draft: B) -> Self {
+        Self {
             is_draft: is_draft.into(),
             ..self
         }
     }
 
-    pub fn set_post<B: Into<Option<bool>>>(self, is_post: B) -> FrontmatterBuilder {
-        FrontmatterBuilder {
+    pub fn set_post<B: Into<Option<bool>>>(self, is_post: B) -> Self {
+        Self {
             is_post: is_post.into(),
             ..self
         }
     }
 
-    pub fn merge_permalink<S: Into<Option<String>>>(self, permalink: S) -> FrontmatterBuilder {
-        self.merge(FrontmatterBuilder::new().set_permalink(permalink.into()))
+    pub fn merge_permalink<S: Into<Option<String>>>(self, permalink: S) -> Self {
+        self.merge(Self::new().set_permalink(permalink.into()))
     }
 
-    pub fn merge_slug<S: Into<Option<String>>>(self, slug: S) -> FrontmatterBuilder {
-        self.merge(FrontmatterBuilder::new().set_slug(slug.into()))
+    pub fn merge_slug<S: Into<Option<String>>>(self, slug: S) -> Self {
+        self.merge(Self::new().set_slug(slug.into()))
     }
 
-    pub fn merge_title<S: Into<Option<String>>>(self, title: S) -> FrontmatterBuilder {
-        self.merge(FrontmatterBuilder::new().set_title(title.into()))
+    pub fn merge_title<S: Into<Option<String>>>(self, title: S) -> Self {
+        self.merge(Self::new().set_title(title.into()))
     }
 
-    pub fn merge_description<S: Into<Option<String>>>(self, description: S) -> FrontmatterBuilder {
-        self.merge(FrontmatterBuilder::new().set_description(description.into()))
+    pub fn merge_description<S: Into<Option<String>>>(self, description: S) -> Self {
+        self.merge(Self::new().set_description(description.into()))
     }
 
-    pub fn merge_categories<S: Into<Option<Vec<String>>>>(self,
-                                                          categories: S)
-                                                          -> FrontmatterBuilder {
-        self.merge(FrontmatterBuilder::new().set_categories(categories.into()))
+    pub fn merge_categories<S: Into<Option<Vec<String>>>>(self, categories: S) -> Self {
+        self.merge(Self::new().set_categories(categories.into()))
     }
 
-    pub fn merge_excerpt_separator<S: Into<Option<String>>>(self,
-                                                            excerpt_separator: S)
-                                                            -> FrontmatterBuilder {
-        self.merge(FrontmatterBuilder::new().set_excerpt_separator(excerpt_separator.into()))
+    pub fn merge_excerpt_separator<S: Into<Option<String>>>(self, excerpt_separator: S) -> Self {
+        self.merge(Self::new().set_excerpt_separator(excerpt_separator.into()))
     }
 
     pub fn merge_published_date<D: Into<Option<datetime::DateTime>>>(self,
                                                                      published_date: D)
-                                                                     -> FrontmatterBuilder {
-        self.merge(FrontmatterBuilder::new().set_published_date(published_date.into()))
+                                                                     -> Self {
+        self.merge(Self::new().set_published_date(published_date.into()))
     }
 
     #[cfg(test)]
-    pub fn merge_format<S: Into<Option<SourceFormat>>>(self, format: S) -> FrontmatterBuilder {
-        self.merge(FrontmatterBuilder::new().set_format(format.into()))
+    pub fn merge_format<S: Into<Option<SourceFormat>>>(self, format: S) -> Self {
+        self.merge(Self::new().set_format(format.into()))
     }
 
-    pub fn merge_layout<S: Into<Option<String>>>(self, layout: S) -> FrontmatterBuilder {
-        self.merge(FrontmatterBuilder::new().set_layout(layout.into()))
+    pub fn merge_layout<S: Into<Option<String>>>(self, layout: S) -> Self {
+        self.merge(Self::new().set_layout(layout.into()))
     }
 
-    pub fn merge_draft<B: Into<Option<bool>>>(self, draft: B) -> FrontmatterBuilder {
-        self.merge(FrontmatterBuilder::new().set_draft(draft.into()))
+    pub fn merge_draft<B: Into<Option<bool>>>(self, draft: B) -> Self {
+        self.merge(Self::new().set_draft(draft.into()))
     }
 
     #[cfg(test)]
-    pub fn merge_post<B: Into<Option<bool>>>(self, post: B) -> FrontmatterBuilder {
-        self.merge(FrontmatterBuilder::new().set_post(post.into()))
+    pub fn merge_post<B: Into<Option<bool>>>(self, post: B) -> Self {
+        self.merge(Self::new().set_post(post.into()))
     }
 
-    pub fn merge_custom(self, other_custom: liquid::Object) -> FrontmatterBuilder {
-        let FrontmatterBuilder {
-            path,
+    pub fn merge_custom(self, other_custom: liquid::Object) -> Self {
+        let Self {
+            permalink,
             slug,
             title,
             description,
@@ -194,8 +188,8 @@ impl FrontmatterBuilder {
             is_post,
             custom,
         } = self;
-        FrontmatterBuilder {
-            path: path,
+        Self {
+            permalink: permalink,
             slug: slug,
             title: title,
             description: description,
@@ -210,9 +204,9 @@ impl FrontmatterBuilder {
         }
     }
 
-    pub fn merge(self, other: FrontmatterBuilder) -> FrontmatterBuilder {
-        let FrontmatterBuilder {
-            path,
+    pub fn merge(self, other: Self) -> Self {
+        let Self {
+            permalink,
             slug,
             title,
             description,
@@ -225,8 +219,8 @@ impl FrontmatterBuilder {
             is_post,
             custom,
         } = self;
-        let FrontmatterBuilder {
-            path: other_path,
+        let Self {
+            permalink: other_permalink,
             slug: other_slug,
             title: other_title,
             description: other_description,
@@ -239,8 +233,8 @@ impl FrontmatterBuilder {
             is_post: other_is_post,
             custom: other_custom,
         } = other;
-        FrontmatterBuilder {
-            path: path.or_else(|| other_path),
+        Self {
+            permalink: permalink.or_else(|| other_permalink),
             slug: slug.or_else(|| other_slug),
             title: title.or_else(|| other_title),
             description: description.or_else(|| other_description),
@@ -255,11 +249,11 @@ impl FrontmatterBuilder {
         }
     }
 
-    pub fn merge_path<P: AsRef<path::Path>>(self, relpath: P) -> FrontmatterBuilder {
+    pub fn merge_path<P: AsRef<path::Path>>(self, relpath: P) -> Self {
         self.merge_path_ref(relpath.as_ref())
     }
 
-    fn merge_path_ref(self, relpath: &path::Path) -> FrontmatterBuilder {
+    fn merge_path_ref(self, relpath: &path::Path) -> Self {
         let mut fm = self;
 
         if fm.format.is_none() {
@@ -289,8 +283,8 @@ impl FrontmatterBuilder {
     }
 
     pub fn build(self) -> Result<Frontmatter> {
-        let FrontmatterBuilder {
-            path,
+        let Self {
+            permalink,
             slug,
             title,
             description,
@@ -306,14 +300,14 @@ impl FrontmatterBuilder {
 
         let is_post = is_post.unwrap_or(false);
 
-        let path = path.unwrap_or_else(|| {
-                                           let default_path = "/:path/:filename:output_ext";
+        let permalink = permalink.unwrap_or_else(|| {
+            let default_permalink = "/:path/:filename:output_ext";
 
-                                           default_path.to_owned()
-                                       });
+            default_permalink.to_owned()
+        });
 
         let fm = Frontmatter {
-            path: path,
+            permalink: permalink,
             slug: slug.ok_or_else(|| "No slug")?,
             title: title.ok_or_else(|| "No title")?,
             description: description,
@@ -335,7 +329,7 @@ impl FrontmatterBuilder {
 #[derive(Serialize, Deserialize)]
 #[serde(deny_unknown_fields, default)]
 pub struct Frontmatter {
-    pub path: String,
+    pub permalink: String,
     pub slug: String,
     pub title: String,
     pub description: Option<String>,
@@ -424,7 +418,7 @@ mod test {
     fn frontmatter_global_merge() {
         let empty = FrontmatterBuilder::new();
         let a = FrontmatterBuilder {
-            path: Some("path a".to_owned()),
+            permalink: Some("permalink a".to_owned()),
             slug: Some("slug a".to_owned()),
             title: Some("title a".to_owned()),
             description: Some("description a".to_owned()),
@@ -438,7 +432,7 @@ mod test {
             custom: liquid::Object::new(),
         };
         let b = FrontmatterBuilder {
-            path: Some("path b".to_owned()),
+            permalink: Some("permalink b".to_owned()),
             slug: Some("slug b".to_owned()),
             title: Some("title b".to_owned()),
             description: Some("description b".to_owned()),
@@ -465,7 +459,7 @@ mod test {
     #[test]
     fn frontmatter_local_merge() {
         let a = FrontmatterBuilder {
-            path: Some("path a".to_owned()),
+            permalink: Some("permalink a".to_owned()),
             slug: Some("slug a".to_owned()),
             title: Some("title a".to_owned()),
             description: Some("description a".to_owned()),
@@ -480,7 +474,7 @@ mod test {
         };
 
         let merge_b_into_a = a.clone()
-            .merge_permalink("path b".to_owned())
+            .merge_permalink("permalink b".to_owned())
             .merge_slug("slug b".to_owned())
             .merge_title("title b".to_owned())
             .merge_description("description b".to_owned())
@@ -506,7 +500,7 @@ mod test {
         assert_eq!(merge_empty_into_a, a);
 
         let merge_a_into_empty = FrontmatterBuilder::new()
-            .merge_permalink("path a".to_owned())
+            .merge_permalink("permalink a".to_owned())
             .merge_slug("slug a".to_owned())
             .merge_title("title a".to_owned())
             .merge_description("description a".to_owned())

--- a/src/frontmatter.rs
+++ b/src/frontmatter.rs
@@ -262,33 +262,31 @@ impl FrontmatterBuilder {
         self.merge_path_ref(relpath.as_ref())
     }
 
-    fn merge_path_ref(self, relpath: &path::Path) -> Self {
-        let mut fm = self;
-
-        if fm.format.is_none() {
+    fn merge_path_ref(mut self, relpath: &path::Path) -> Self {
+        if self.format.is_none() {
             let ext = relpath.extension().and_then(|os| os.to_str()).unwrap_or("");
             let format = match ext {
                 "md" => SourceFormat::Markdown,
                 _ => SourceFormat::Raw,
             };
-            fm.format = Some(format);
+            self.format = Some(format);
         }
 
-        if fm.slug.is_none() {
+        if self.slug.is_none() {
             let file_stem = file_stem(relpath);
             let slug = slug::slugify(file_stem);
-            fm.slug = Some(slug);
+            self.slug = Some(slug);
         }
 
-        if fm.title.is_none() {
-            let slug = fm.slug
+        if self.title.is_none() {
+            let slug = self.slug
                 .as_ref()
                 .expect("slug has been unconditionally initialized");
             let title = slug::titleize_slug(slug);
-            fm.title = Some(title);
+            self.title = Some(title);
         }
 
-        fm
+        self
     }
 
     pub fn build(self) -> Result<Frontmatter> {
@@ -359,8 +357,7 @@ pub struct Frontmatter {
 }
 
 /// Shallow merge of `liquid::Object`'s
-fn merge_objects(primary: liquid::Object, secondary: liquid::Object) -> liquid::Object {
-    let mut primary = primary;
+fn merge_objects(mut primary: liquid::Object, secondary: liquid::Object) -> liquid::Object {
     for (key, value) in secondary {
         primary
             .entry(key.to_owned())

--- a/src/legacy/wildwest.rs
+++ b/src/legacy/wildwest.rs
@@ -273,7 +273,7 @@ impl From<GlobalConfig> for config::ConfigBuilder {
             template_extensions: template_extensions,
             ignore: ignore,
             syntax_highlight: syntax_highlight,
-            sass: sass,
+            assets: config::AssetsBuilder { sass },
             dump: vec![],
             ..Default::default()
         }

--- a/src/legacy/wildwest.rs
+++ b/src/legacy/wildwest.rs
@@ -44,7 +44,7 @@ impl From<FrontmatterBuilder> for frontmatter::FrontmatterBuilder {
                             .and_then(|v| v.as_str().map(|s| s.to_owned())))
             .merge_permalink(custom_attributes
                                  .remove("path")
-                                 .and_then(|v| v.as_str().map(|s| s.to_owned())))
+                                 .and_then(|v| v.as_str().map(|s| convert_permalink(s.to_owned()))))
             .merge_draft(custom_attributes.remove("draft").and_then(|v| v.as_bool()))
             .merge_excerpt_separator(custom_attributes
                                          .remove("excerpt_separator")
@@ -240,7 +240,7 @@ impl From<GlobalConfig> for config::ConfigBuilder {
             rss: rss,
             jsonfeed: jsonfeed,
             default: frontmatter::FrontmatterBuilder::new()
-                .set_permalink(post_path)
+                .set_permalink(post_path.map(convert_permalink))
                 .set_post(true),
         };
 
@@ -277,5 +277,34 @@ impl From<GlobalConfig> for config::ConfigBuilder {
             dump: vec![],
             ..Default::default()
         }
+    }
+}
+
+fn convert_permalink(mut perma: String) -> String {
+    if perma.starts_with('/') {
+        perma
+    } else {
+        perma.insert(0, '/');
+        perma
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn convert_permalink_empty() {
+        assert_eq!(convert_permalink("".into()), "/");
+    }
+
+    #[test]
+    fn convert_permalink_abs() {
+        assert_eq!(convert_permalink("/root".into()), "/root");
+    }
+
+    #[test]
+    fn convert_permalink_rel() {
+        assert_eq!(convert_permalink("rel".into()), "/rel");
     }
 }

--- a/src/legacy/wildwest.rs
+++ b/src/legacy/wildwest.rs
@@ -64,7 +64,7 @@ impl From<frontmatter::FrontmatterBuilder> for FrontmatterBuilder {
         let mut legacy = liquid::Object::new();
 
         let frontmatter::FrontmatterBuilder {
-            path,
+            permalink,
             slug,
             title,
             description,
@@ -77,7 +77,7 @@ impl From<frontmatter::FrontmatterBuilder> for FrontmatterBuilder {
             is_post: _is_post,
             custom,
         } = internal;
-        if let Some(path) = path {
+        if let Some(path) = permalink {
             legacy.insert("path".to_owned(), liquid::Value::Str(path));
         }
         if let Some(slug) = slug {

--- a/src/legacy/wildwest.rs
+++ b/src/legacy/wildwest.rs
@@ -233,6 +233,7 @@ impl From<GlobalConfig> for config::ConfigBuilder {
             .set_post(false);
         let posts = config::PostBuilder {
             name: None,
+            slug: None,
             description: None,
             dir: posts,
             drafts_dir: Some(drafts),

--- a/tests/fixtures/copy_files/posts/2014-08-24-my-first-blogpost.md
+++ b/tests/fixtures/copy_files/posts/2014-08-24-my-first-blogpost.md
@@ -1,7 +1,7 @@
 extends: posts.liquid
 
 title:   My first Blogpost
-date:    24/08/2014 at 15:36
+date:    24 Aug 2014 15:36:20 +0100
 ---
 # {{ title }}
 

--- a/tests/fixtures/custom_paths/no-post.md
+++ b/tests/fixtures/custom_paths/no-post.md
@@ -1,7 +1,7 @@
 extends: posts.liquid
 
 title:  Custom paths are available to non-posts
-date:   22/08/2014 at 15:36
+date:   22 Aug 2014 15:36:20 +0100
 path:  test/hello.html
 ---
 # {{ title }}

--- a/tests/fixtures/custom_posts_folder/blog/2014-08-24-my-first-blogpost.md
+++ b/tests/fixtures/custom_posts_folder/blog/2014-08-24-my-first-blogpost.md
@@ -1,7 +1,7 @@
 extends: posts.liquid
 
 title:   My first Blogpost
-date:    24/08/2014 at 15:36
+date:    24 Aug 2014 09:05:20 +0100
 ---
 # {{ title }}
 

--- a/tests/fixtures/custom_template_extensions/posts/2014-08-24-my-first-blogpost.md
+++ b/tests/fixtures/custom_template_extensions/posts/2014-08-24-my-first-blogpost.md
@@ -1,7 +1,7 @@
 extends: posts.exe
 
 title:   My first Blogpost
-date:    24/08/2014 at 15:36
+date:    24 Aug 2014 15:36:20 +0100
 ---
 # {{ title }}
 

--- a/tests/fixtures/dotfiles/posts/2014-08-24-my-first-blogpost.md
+++ b/tests/fixtures/dotfiles/posts/2014-08-24-my-first-blogpost.md
@@ -1,7 +1,7 @@
 extends: posts.liquid
 
 title:   My first Blogpost
-date:    24/08/2014 at 15:36
+date:    24 Aug 2014 15:36:20 +0100
 ---
 # {{ title }}
 

--- a/tests/fixtures/drafts/posts/2014-08-24-my-first-blogpost.md
+++ b/tests/fixtures/drafts/posts/2014-08-24-my-first-blogpost.md
@@ -1,7 +1,7 @@
 extends: posts.liquid
 
 title:   My first Blogpost
-date:    24/08/2014 at 15:36
+date:    24 Aug 2014 15:36:20 +0100
 ---
 # {{ title }}
 

--- a/tests/fixtures/drafts_not_shown_by_default/posts/2014-08-24-my-first-blogpost.md
+++ b/tests/fixtures/drafts_not_shown_by_default/posts/2014-08-24-my-first-blogpost.md
@@ -1,7 +1,7 @@
 extends: posts.liquid
 
 title:   My first Blogpost
-date:    24/08/2014 at 15:36
+date:    24 Aug 2014 15:36:20 +0100
 ---
 # {{ title }}
 

--- a/tests/fixtures/example/posts/2014-08-24-my-first-blogpost.md
+++ b/tests/fixtures/example/posts/2014-08-24-my-first-blogpost.md
@@ -1,7 +1,7 @@
 extends: posts.liquid
 
 title:   My first Blogpost
-date:    24/08/2014 at 15:36
+date:    24 Aug 2014 15:36:20 +0100
 ---
 # {{ title }}
 

--- a/tests/fixtures/hidden_posts_folder/_blog/2014-08-24-my-first-blogpost.md
+++ b/tests/fixtures/hidden_posts_folder/_blog/2014-08-24-my-first-blogpost.md
@@ -1,7 +1,7 @@
 extends: posts.liquid
 
 title:   My first Blogpost
-date:    24/08/2014 at 15:36
+date:    24 Aug 2014 15:36:20 +0100
 ---
 # {{ title }}
 

--- a/tests/fixtures/ignore_files/posts/2014-08-24-my-first-blogpost.md
+++ b/tests/fixtures/ignore_files/posts/2014-08-24-my-first-blogpost.md
@@ -1,7 +1,7 @@
 extends: posts.liquid
 
 title:   My first Blogpost
-date:    24/08/2014 at 15:36
+date:    24 Aug 2014 15:36:20 +0100
 ---
 # {{ title }}
 

--- a/tests/fixtures/liquid_error/_posts/2014-08-24-my-first-blogpost.md
+++ b/tests/fixtures/liquid_error/_posts/2014-08-24-my-first-blogpost.md
@@ -1,7 +1,7 @@
 extends: posts.liquid
 
 title:   My first Blogpost
-date:    24/08/2014 at 15:36
+date:    24 Aug 2014 15:36:20 +0100
 ---
 # {{ title }}
 

--- a/tests/fixtures/no_extends_error/posts/2014-08-24-my-first-blogpost.md
+++ b/tests/fixtures/no_extends_error/posts/2014-08-24-my-first-blogpost.md
@@ -1,5 +1,5 @@
 title:   My first Blogpost
-date:    24/08/2014 at 15:36
+date:    24 Aug 2014 15:36:20 +0100
 ---
 # {{ title }}
 

--- a/tests/fixtures/previous_next/posts/2014-08-24-my-first-blogpost.md
+++ b/tests/fixtures/previous_next/posts/2014-08-24-my-first-blogpost.md
@@ -1,7 +1,7 @@
 extends: posts.liquid
 
 title:   My first Blogpost
-date:    24/08/2014 at 15:36
+date:    24 Aug 2014 15:36:20 +0100
 ---
 # {{ title }}
 

--- a/tests/fixtures/previous_next/posts/2014-08-25-my-second-blogpost.md
+++ b/tests/fixtures/previous_next/posts/2014-08-25-my-second-blogpost.md
@@ -1,7 +1,7 @@
 extends: posts.liquid
 
 title:   My second Blogpost
-date:    25/08/2014 at 15:36
+date:    25 Aug 2014 15:36:20 +0100
 ---
 # {{ title }}
 

--- a/tests/fixtures/previous_next/posts/2014-08-26-my-third-blogpost.md
+++ b/tests/fixtures/previous_next/posts/2014-08-26-my-third-blogpost.md
@@ -1,7 +1,7 @@
 extends: posts.liquid
 
 title:   My third Blogpost
-date:    26/08/2014 at 15:36
+date:    26 Aug 2014 15:36:20 +0100
 ---
 # {{ title }}
 

--- a/tests/fixtures/yaml_error/_posts/2014-08-24-my-first-blogpost.md
+++ b/tests/fixtures/yaml_error/_posts/2014-08-24-my-first-blogpost.md
@@ -1,7 +1,7 @@
 extends: posts.liquid
 
 title:   My first Blogpost
-date:    24/08/2014 at 15:36
+date:    24 Aug 2014 15:36:20 +0100
 ---
 # {{ title }}
 

--- a/tests/target/previous_next/index.html
+++ b/tests/target/previous_next/index.html
@@ -9,11 +9,11 @@
         This is my Index page!
 
 
- <a href="posts/2014-08-24-my-first-blogpost.html">My first Blogpost</a>
+ <a href="posts/2014-08-26-my-third-blogpost.html">My third Blogpost</a>
 
  <a href="posts/2014-08-25-my-second-blogpost.html">My second Blogpost</a>
 
- <a href="posts/2014-08-26-my-third-blogpost.html">My third Blogpost</a>
+ <a href="posts/2014-08-24-my-first-blogpost.html">My first Blogpost</a>
 
 
     </body>

--- a/tests/target/previous_next/posts/2014-08-24-my-first-blogpost.html
+++ b/tests/target/previous_next/posts/2014-08-24-my-first-blogpost.html
@@ -7,7 +7,7 @@
         <h1>My first Blogpost</h1>
 <p>Hey there this is my first blogpost and this is super awesome.</p>
 <p>My Blog is lorem ipsum like, yes it is..</p>
-<p><a class="prev" href="/posts/2014-08-25-my-second-blogpost.html">« My second Blogpost</a></p>
+<p><a class="next" href="/posts/2014-08-25-my-second-blogpost.html">My second Blogpost »</a></p>
 
     </body>
 </html>

--- a/tests/target/previous_next/posts/2014-08-25-my-second-blogpost.html
+++ b/tests/target/previous_next/posts/2014-08-25-my-second-blogpost.html
@@ -7,8 +7,8 @@
         <h1>My second Blogpost</h1>
 <p>Hey there this is my second blogpost and this is super awesome.</p>
 <p>My Blog is lorem ipsum like, yes it is..</p>
-<p><a class="prev" href="/posts/2014-08-26-my-third-blogpost.html">« My third Blogpost</a></p>
-<p><a class="next" href="/posts/2014-08-24-my-first-blogpost.html">My first Blogpost »</a></p>
+<p><a class="prev" href="/posts/2014-08-24-my-first-blogpost.html">« My first Blogpost</a></p>
+<p><a class="next" href="/posts/2014-08-26-my-third-blogpost.html">My third Blogpost »</a></p>
 
     </body>
 </html>

--- a/tests/target/previous_next/posts/2014-08-26-my-third-blogpost.html
+++ b/tests/target/previous_next/posts/2014-08-26-my-third-blogpost.html
@@ -7,7 +7,7 @@
         <h1>My third Blogpost</h1>
 <p>Hey there this is my third blogpost and this is super awesome.</p>
 <p>My Blog is lorem ipsum like, yes it is..</p>
-<p><a class="next" href="/posts/2014-08-25-my-second-blogpost.html">My second Blogpost »</a></p>
+<p><a class="prev" href="/posts/2014-08-25-my-second-blogpost.html">« My second Blogpost</a></p>
 
     </body>
 </html>


### PR DESCRIPTION
Changes made because they were minor
- Infer `published_date` from filename (`YYYY-MM-DD Title`)

Changes made because they are currently hidden from the user
- Rename `path` to `permalink`
- `path` permalink alias
- permalinks will need to be absolute paths to distinguish from a permalink alias
- (not finished) collection (like posts) slug in permalinks
- Sass configuration will be under an `assets` section in prep for #318 and #322 
- `destination` will be `./_site`

Otherwise, TODOs were inserted