### PR TITLE
Improve post-writing workflow

### DIFF
--- a/src/bin/cobalt/args.rs
+++ b/src/bin/cobalt/args.rs
@@ -19,7 +19,7 @@ pub fn get_config_args() -> Vec<clap::Arg<'static, 'static>> {
          .short("d")
          .long("destination")
          .value_name("DIR")
-         .help("Destination folder [default: ./]")
+         .help("Site destination folder [default: ./]")
          .takes_value(true),
      clap::Arg::with_name("drafts")
          .long("drafts")

--- a/src/bin/cobalt/main.rs
+++ b/src/bin/cobalt/main.rs
@@ -90,6 +90,7 @@ fn run() -> Result<()> {
         .args(&args::get_logging_args())
         .subcommand(new::init_command_args())
         .subcommand(new::new_command_args())
+        .subcommand(new::publish_command_args())
         .subcommand(build::build_command_args())
         .subcommand(build::clean_command_args())
         .subcommand(serve::serve_command_args())
@@ -125,6 +126,7 @@ fn run() -> Result<()> {
     match command {
         "init" => new::init_command(matches),
         "new" => new::new_command(matches),
+        "publish" => new::publish_command(matches),
         "build" => build::build_command(matches),
         "clean" => build::clean_command(matches),
         "serve" => serve::serve_command(matches),

--- a/src/bin/cobalt/new.rs
+++ b/src/bin/cobalt/new.rs
@@ -58,3 +58,24 @@ pub fn new_command(matches: &clap::ArgMatches) -> Result<()> {
 
     Ok(())
 }
+
+pub fn publish_command_args() -> clap::App<'static, 'static> {
+    clap::SubCommand::with_name("publish")
+        .about("Publish a document")
+        .arg(clap::Arg::with_name("FILENAME")
+                 .required(true)
+                 .help("Document path to publish")
+                 .takes_value(true))
+}
+
+pub fn publish_command(matches: &clap::ArgMatches) -> Result<()> {
+    let file = matches
+        .value_of("FILENAME")
+        .expect("required parameters are present");
+    let file = path::Path::new(file);
+
+    cobalt::publish_document(file)
+        .chain_err(|| format!("Could not publish `{:?}`", file))?;
+
+    Ok(())
+}

--- a/src/bin/cobalt/new.rs
+++ b/src/bin/cobalt/new.rs
@@ -1,3 +1,6 @@
+use std::env;
+use std::path;
+
 use clap;
 use cobalt;
 
@@ -25,16 +28,17 @@ pub fn init_command(matches: &clap::ArgMatches) -> Result<()> {
 
 pub fn new_command_args() -> clap::App<'static, 'static> {
     clap::SubCommand::with_name("new")
-        .about("Create a new post or page")
+        .about("Create a document")
         .args(&args::get_config_args())
-        .arg(clap::Arg::with_name("FILETYPE")
-                 .help("Type of file to create eg post or page")
-                 .default_value("post")
+        .arg(clap::Arg::with_name("TITLE")
+                 .required(true)
+                 .help("Title of the post")
                  .takes_value(true))
-        .arg(clap::Arg::with_name("FILENAME")
-                 .help("File to create")
-                 .default_value_if("FILETYPE", Some("page"), "new_page.md")
-                 .default_value("new_post.md")
+        .arg(clap::Arg::with_name("file")
+                 .short("f")
+                 .long("file")
+                 .value_name("DIR_OR_FILE")
+                 .help("New document's parent directory or file (default: `<CWD>/title.ext`)")
                  .takes_value(true))
 }
 
@@ -42,12 +46,15 @@ pub fn new_command(matches: &clap::ArgMatches) -> Result<()> {
     let config = args::get_config(matches)?;
     let config = config.build()?;
 
-    let filetype = matches.value_of("FILETYPE").unwrap();
-    let filename = matches.value_of("FILENAME").unwrap();
+    let title = matches.value_of("TITLE").unwrap();
 
-    cobalt::create_new_document(filetype, filename, &config)
-        .chain_err(|| format!("Could not create {}", filetype))?;
-    info!("Created new {} {}", filetype, filename);
+    let mut file = env::current_dir().expect("How does this fail?");
+    if let Some(rel_file) = matches.value_of("file") {
+        file.push(path::Path::new(rel_file))
+    }
+
+    cobalt::create_new_document(&config, title, file)
+        .chain_err(|| format!("Could not create `{}`", title))?;
 
     Ok(())
 }

--- a/src/cobalt.rs
+++ b/src/cobalt.rs
@@ -147,7 +147,7 @@ pub fn build(config: &Config) -> Result<()> {
             let file_name = format!("_{}.{}.{}", file_name, dump, ext);
             file_path.set_file_name(file_name);
             trace!("Generating {:?}", file_path);
-            files::create_document_file(content, dest.join(file_path))?;
+            files::write_document_file(content, dest.join(file_path))?;
         }
 
         let mut context = post.get_render_context();
@@ -164,7 +164,7 @@ pub fn build(config: &Config) -> Result<()> {
                                     &mut layouts_cache,
                                     &config.syntax_highlight.theme)
             .chain_err(|| format!("Failed to render for {:?}", post.file_path))?;
-        files::create_document_file(post_html, dest.join(&post.file_path))?;
+        files::write_document_file(post_html, dest.join(&post.file_path))?;
     }
 
     // check if we should create an RSS file and create it!
@@ -199,7 +199,7 @@ pub fn build(config: &Config) -> Result<()> {
             let file_name = format!("_{}.{}.{}", file_name, dump, ext);
             file_path.set_file_name(file_name);
             trace!("Generating {:?}", file_path);
-            files::create_document_file(content, dest.join(file_path))?;
+            files::write_document_file(content, dest.join(file_path))?;
         }
 
         let mut context = doc.get_render_context();
@@ -214,7 +214,7 @@ pub fn build(config: &Config) -> Result<()> {
                                   &mut layouts_cache,
                                   &config.syntax_highlight.theme)
             .chain_err(|| format!("Failed to render for {:?}", doc.file_path))?;
-        files::create_document_file(doc_html, dest.join(doc.file_path))?;
+        files::write_document_file(doc_html, dest.join(doc.file_path))?;
     }
 
     // copy all remaining files in the source to the destination

--- a/src/config.rs
+++ b/src/config.rs
@@ -182,16 +182,19 @@ impl ConfigBuilder {
 
     fn from_cwd_internal(cwd: path::PathBuf) -> Result<ConfigBuilder> {
         let file_path = files::find_project_file(&cwd, ".cobalt.yml");
-        let mut config = file_path
+        let config = file_path
             .map(|p| {
                      info!("Using config file {:?}", &p);
                      Self::from_file(&p).chain_err(|| format!("Error reading config file {:?}", p))
                  })
             .unwrap_or_else(|| {
                 warn!("No .cobalt.yml file found in current directory, using default config.");
-                Ok(ConfigBuilder::default())
+                let config = ConfigBuilder {
+                    root: cwd,
+                    ..Default::default()
+                };
+                Ok(config)
             })?;
-        config.root = cwd;
         Ok(config)
     }
 
@@ -370,7 +373,7 @@ fn test_from_file_not_found() {
 
 #[test]
 fn test_from_cwd_ok() {
-    let result = ConfigBuilder::from_cwd("tests/fixtures/config").unwrap();
+    let result = ConfigBuilder::from_cwd("tests/fixtures/config/child").unwrap();
     assert_eq!(result,
                ConfigBuilder {
                    root: path::Path::new("tests/fixtures/config").to_path_buf(),

--- a/src/datetime.rs
+++ b/src/datetime.rs
@@ -9,6 +9,11 @@ use serde;
 pub struct DateTime(chrono::DateTime<chrono::FixedOffset>);
 
 impl DateTime {
+    pub fn now() -> DateTime {
+        let d = chrono::Utc::now().with_timezone(&chrono::FixedOffset::east(0));
+        DateTime(d)
+    }
+
     pub fn parse<S: AsRef<str>>(d: S) -> Option<DateTime> {
         DateTime::parse_str(d.as_ref())
     }

--- a/src/datetime.rs
+++ b/src/datetime.rs
@@ -19,7 +19,7 @@ impl DateTime {
     }
 
     fn parse_str(d: &str) -> Option<DateTime> {
-        chrono::DateTime::parse_from_str(d.as_ref(), "%d %B %Y %H:%M:%S %z")
+        chrono::DateTime::parse_from_str(d, "%d %B %Y %H:%M:%S %z")
             .ok()
             .map(DateTime)
     }

--- a/src/document.rs
+++ b/src/document.rs
@@ -26,7 +26,7 @@ lazy_static!{
     static ref MARKDOWN_REF: Regex = Regex::new(r"(?m:^ {0,3}\[[^\]]+\]:.+$)").unwrap();
 }
 
-fn split_document(content: &str) -> Result<(Option<&str>, &str)> {
+pub fn split_document(content: &str) -> Result<(Option<&str>, &str)> {
     if FRONT_MATTER_DIVIDE.is_match(content) {
         let mut splits = FRONT_MATTER_DIVIDE.splitn(content, 2);
 

--- a/src/files.rs
+++ b/src/files.rs
@@ -192,13 +192,13 @@ pub fn copy_file(src_file: &path::Path, dest_file: &path::Path) -> Result<()> {
     Ok(())
 }
 
-pub fn create_document_file<S: AsRef<str>, P: AsRef<path::Path>>(content: S,
-                                                                 dest_file: P)
-                                                                 -> Result<()> {
-    create_document_file_internal(content.as_ref(), dest_file.as_ref())
+pub fn write_document_file<S: AsRef<str>, P: AsRef<path::Path>>(content: S,
+                                                                dest_file: P)
+                                                                -> Result<()> {
+    write_document_file_internal(content.as_ref(), dest_file.as_ref())
 }
 
-fn create_document_file_internal(content: &str, dest_file: &path::Path) -> Result<()> {
+fn write_document_file_internal(content: &str, dest_file: &path::Path) -> Result<()> {
     // create target directories if any exist
     if let Some(parent) = dest_file.parent() {
         fs::create_dir_all(parent)
@@ -209,7 +209,7 @@ fn create_document_file_internal(content: &str, dest_file: &path::Path) -> Resul
         .map_err(|e| format!("Could not create {:?}: {}", dest_file, e))?;
 
     file.write_all(content.as_bytes())?;
-    info!("Created {}", dest_file.display());
+    info!("Wrote {}", dest_file.display());
     Ok(())
 }
 

--- a/src/legacy/wildwest.rs
+++ b/src/legacy/wildwest.rs
@@ -1,6 +1,8 @@
 use std::default::Default;
+use std::fmt;
 
 use liquid;
+use serde_yaml;
 
 use super::super::config;
 use super::super::datetime;
@@ -13,8 +15,24 @@ use super::super::site;
 pub struct FrontmatterBuilder(liquid::Object);
 
 impl FrontmatterBuilder {
-    pub fn new() -> FrontmatterBuilder {
+    pub fn new() -> Self {
         FrontmatterBuilder(liquid::Object::new())
+    }
+
+    pub fn with_object(obj: liquid::Object) -> Self {
+        FrontmatterBuilder(obj)
+    }
+
+    pub fn object(self) -> liquid::Object {
+        self.0
+    }
+}
+
+impl fmt::Display for FrontmatterBuilder {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let mut converted = serde_yaml::to_string(self).map_err(|_| fmt::Error)?;
+        converted.drain(..4);
+        write!(f, "{}", converted)
     }
 }
 
@@ -114,6 +132,19 @@ impl From<frontmatter::FrontmatterBuilder> for FrontmatterBuilder {
         }
 
         FrontmatterBuilder(legacy)
+    }
+}
+
+#[derive(Debug, Eq, PartialEq, Default, Clone)]
+pub struct DocumentBuilder {
+    pub front: FrontmatterBuilder,
+    pub content: String,
+}
+
+impl fmt::Display for DocumentBuilder {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let front = self.front.to_string();
+        write!(f, "{}\n---\n{}", front, self.content)
     }
 }
 

--- a/src/legacy/wildwest.rs
+++ b/src/legacy/wildwest.rs
@@ -4,9 +4,11 @@ use std::fmt;
 use liquid;
 use serde_yaml;
 
+use super::super::error::*;
 use super::super::config;
 use super::super::datetime;
 use super::super::frontmatter;
+use super::super::document;
 use super::super::sass;
 use super::super::site;
 
@@ -139,6 +141,18 @@ impl From<frontmatter::FrontmatterBuilder> for FrontmatterBuilder {
 pub struct DocumentBuilder {
     pub front: FrontmatterBuilder,
     pub content: String,
+}
+
+impl DocumentBuilder {
+    pub fn parse(content: &str) -> Result<Self> {
+        let (front, content) = document::split_document(content)?;
+        let front: FrontmatterBuilder = front
+            .map(|s| serde_yaml::from_str(s))
+            .map_or(Ok(None), |r| r.map(Some))?
+            .unwrap_or_else(FrontmatterBuilder::new);
+        let content = content.to_owned();
+        Ok(Self { front, content })
+    }
 }
 
 impl fmt::Display for DocumentBuilder {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -90,7 +90,7 @@ pub use error::Error;
 pub use config::Config;
 pub use config::ConfigBuilder;
 pub use config::Dump;
-pub use new::{create_new_project, create_new_document};
+pub use new::{create_new_project, create_new_document, publish_document};
 
 pub mod error;
 pub mod files;

--- a/src/new.rs
+++ b/src/new.rs
@@ -6,10 +6,7 @@ use config::Config;
 
 const COBALT_YML: &'static [u8] = b"name: cobalt blog
 source: \".\"
-dest: \"build\"
-ignore:
-  - .git/*
-  - build/*
+dest: \"./_site\"
 ";
 
 const DEFAULT_LAYOUT: &'static [u8] = b"<!DOCTYPE html>

--- a/src/new.rs
+++ b/src/new.rs
@@ -42,7 +42,7 @@ const POST_LAYOUT: &'static [u8] = b"<div>
 const POST_MD: &'static [u8] = b"extends: default.liquid
 
 title: First Post
-date: 14 January 2016 21:00:30 -0500
+draft: true
 ---
 
 # This is our first Post!

--- a/src/new.rs
+++ b/src/new.rs
@@ -50,20 +50,15 @@ draft: true
 Welcome to the first post ever on cobalt.rs!
 ";
 
-const INDEX_LIQUID: &'static [u8] = b"extends: default.liquid
+const INDEX_MD: &'static [u8] = b"extends: default.liquid
 ---
-<div >
-  <h2>Blog!</h2>
-  <!--<br />-->
-  <div>
-    {% for post in posts %}
-      <div>
-        <h4>{{post.title}}</h4>
-        <h4><a href=\"{{post.path}}\">{{ post.title }}</a></h4>
-      </div>
-    {% endfor %}
-  </div>
-</div>
+## Blog!
+
+{% for post in posts %}
+#### {{post.title}}
+
+#### [{{ post.title }}]({{ post.path }})
+{% endfor %}
 ";
 
 pub fn create_new_project<P: AsRef<Path>>(dest: P) -> Result<()> {
@@ -74,7 +69,7 @@ pub fn create_new_project_for_path(dest: &Path) -> Result<()> {
     fs::create_dir_all(dest)?;
 
     create_file(&dest.join(".cobalt.yml"), COBALT_YML)?;
-    create_file(&dest.join("index.liquid"), INDEX_LIQUID)?;
+    create_file(&dest.join("index.md"), INDEX_MD)?;
 
     fs::create_dir_all(&dest.join("_layouts"))?;
     create_file(&dest.join("_layouts/default.liquid"), DEFAULT_LAYOUT)?;
@@ -91,7 +86,7 @@ pub fn create_new_document(doc_type: &str, name: &str, config: &Config) -> Resul
     let full_path = &path.join(&config.posts.dir).join(name);
 
     match doc_type {
-        "page" => create_file(name, INDEX_LIQUID)?,
+        "page" => create_file(name, INDEX_MD)?,
         "post" => create_file(full_path, POST_MD)?,
         _ => bail!("Unsupported document type {}", doc_type),
     }

--- a/src/sass.rs
+++ b/src/sass.rs
@@ -71,7 +71,7 @@ fn compile_sass_internal(config: &SassOptions,
     let mut dest_file = dest.join(rel_src);
     dest_file.set_extension("css");
 
-    files::create_document_file(content, dest_file)
+    files::write_document_file(content, dest_file)
 }
 
 #[cfg(not(feature = "sass"))]


### PR DESCRIPTION
`cobalt new` has improved semantics
- title is accepted (needs quotes for multi-word)
- filename is assumed to be the title's slug unless otherwise specified
- destination is assumed to be cwd unless otherwise specified
- page vs post is inferred from the destination

`cobalt publish` has been introduced
- Removes `draft` flag
- Sets `date` to now

To simplify this process
- `cobalt init` only generates `.md` files.
- new posts (`init` or `new`) start as drafts

Additionally, `cobalt init` has been made to align with more recently recommend practices.