### PR TITLE
fix(CI): Try to fix coverage reporting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ matrix:
 install:
   - curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain $TRAVIS_RUST_VERSION
   - source ~/.cargo/env || true
-  - which cargo-coveralls || travis_wait cargo install cargo-travis --force --vers $COVERALLS
+  - travis_wait cargo install cargo-travis --force --vers $COVERALLS
   - if [[ `cargo-when --version` != *$WHEN ]] ; then travis_wait cargo install cargo-when --force --vers $WHEN; fi
 
 script:


### PR DESCRIPTION
I think its because we are using an old cargo-travis that doesn't
understand new cargo features.

I had to disable the caching of cargo-travis to upgrade it because we
have no way to make the cache auto-invalidate.  We'll just have to wait
until we can assume its propogate to all travis caches.