### PR TITLE
 fix(front): Ensure exceprt is rendered before used 

### DIFF
--- a/src/cobalt.rs
+++ b/src/cobalt.rs
@@ -157,9 +157,16 @@ pub fn build(config: &Config) -> Result<()> {
         context.set_val("posts", liquid::Value::Array(simple_posts_data.clone()));
         context.set_val("site",
                         liquid::Value::Object(config.site.attributes.clone()));
-
         post.render_excerpt(&mut context, &parser, &config.syntax_highlight.theme)
             .chain_err(|| format!("Failed to render excerpt for {:?}", post.file_path))?;
+
+        // Yes, this is terrible for performance but we need a new `get_render_context` to get an
+        // updated `excerpt`.  liquid#95 allow us to improve this.
+        let mut context = post.get_render_context();
+        // TODO(epage): Switch `posts` to `parent` which is an object see #323
+        context.set_val("posts", liquid::Value::Array(simple_posts_data.clone()));
+        context.set_val("site",
+                        liquid::Value::Object(config.site.attributes.clone()));
         let post_html = post.render(&mut context,
                                     &parser,
                                     &layouts,

--- a/src/cobalt_model/frontmatter.rs
+++ b/src/cobalt_model/frontmatter.rs
@@ -58,6 +58,7 @@ pub struct FrontmatterBuilder {
     pub slug: Option<String>,
     pub title: Option<String>,
     pub description: Option<String>,
+    pub excerpt: Option<String>,
     pub categories: Option<Vec<String>>,
     pub excerpt_separator: Option<String>,
     pub published_date: Option<datetime::DateTime>,
@@ -100,6 +101,13 @@ impl FrontmatterBuilder {
     pub fn set_description<S: Into<Option<String>>>(self, description: S) -> Self {
         Self {
             description: description.into(),
+            ..self
+        }
+    }
+
+    pub fn set_excerpt<S: Into<Option<String>>>(self, excerpt: S) -> Self {
+        Self {
+            excerpt: excerpt.into(),
             ..self
         }
     }
@@ -172,6 +180,10 @@ impl FrontmatterBuilder {
         self.merge(Self::new().set_description(description.into()))
     }
 
+    pub fn merge_excerpt<S: Into<Option<String>>>(self, excerpt: S) -> Self {
+        self.merge(Self::new().set_excerpt(excerpt.into()))
+    }
+
     pub fn merge_categories<S: Into<Option<Vec<String>>>>(self, categories: S) -> Self {
         self.merge(Self::new().set_categories(categories.into()))
     }
@@ -210,6 +222,7 @@ impl FrontmatterBuilder {
             slug,
             title,
             description,
+            excerpt,
             categories,
             excerpt_separator,
             published_date,
@@ -224,6 +237,7 @@ impl FrontmatterBuilder {
             slug: slug,
             title: title,
             description: description,
+            excerpt: excerpt,
             categories: categories,
             excerpt_separator: excerpt_separator,
             published_date: published_date,
@@ -241,6 +255,7 @@ impl FrontmatterBuilder {
             slug,
             title,
             description,
+            excerpt,
             categories,
             excerpt_separator,
             published_date,
@@ -255,6 +270,7 @@ impl FrontmatterBuilder {
             slug: other_slug,
             title: other_title,
             description: other_description,
+            excerpt: other_excerpt,
             categories: other_categories,
             excerpt_separator: other_excerpt_separator,
             published_date: other_published_date,
@@ -269,6 +285,7 @@ impl FrontmatterBuilder {
             slug: slug.or_else(|| other_slug),
             title: title.or_else(|| other_title),
             description: description.or_else(|| other_description),
+            excerpt: excerpt.or_else(|| other_excerpt),
             categories: categories.or_else(|| other_categories),
             excerpt_separator: excerpt_separator.or_else(|| other_excerpt_separator),
             published_date: published_date.or_else(|| other_published_date),
@@ -323,6 +340,7 @@ impl FrontmatterBuilder {
             slug,
             title,
             description,
+            excerpt,
             categories,
             excerpt_separator,
             published_date,
@@ -351,6 +369,7 @@ impl FrontmatterBuilder {
             slug: slug.ok_or_else(|| "No slug")?,
             title: title.ok_or_else(|| "No title")?,
             description: description,
+            excerpt: excerpt,
             categories: categories.unwrap_or_else(|| vec![]),
             excerpt_separator: excerpt_separator.unwrap_or_else(|| "\n\n".to_owned()),
             published_date: published_date,
@@ -382,6 +401,7 @@ pub struct Frontmatter {
     pub slug: String,
     pub title: String,
     pub description: Option<String>,
+    pub excerpt: Option<String>,
     pub categories: Vec<String>,
     pub excerpt_separator: String,
     pub published_date: Option<datetime::DateTime>,
@@ -592,6 +612,7 @@ mod test {
             slug: Some("slug a".to_owned()),
             title: Some("title a".to_owned()),
             description: Some("description a".to_owned()),
+            excerpt: Some("excerpt a".to_owned()),
             categories: Some(vec!["a".to_owned(), "b".to_owned()]),
             excerpt_separator: Some("excerpt_separator a".to_owned()),
             published_date: Some(datetime::DateTime::default()),
@@ -606,6 +627,7 @@ mod test {
             slug: Some("slug b".to_owned()),
             title: Some("title b".to_owned()),
             description: Some("description b".to_owned()),
+            excerpt: Some("excerpt b".to_owned()),
             categories: Some(vec!["b".to_owned(), "a".to_owned()]),
             excerpt_separator: Some("excerpt_separator b".to_owned()),
             published_date: Some(datetime::DateTime::default()),
@@ -633,6 +655,7 @@ mod test {
             slug: Some("slug a".to_owned()),
             title: Some("title a".to_owned()),
             description: Some("description a".to_owned()),
+            excerpt: Some("excerpt a".to_owned()),
             categories: Some(vec!["a".to_owned(), "b".to_owned()]),
             excerpt_separator: Some("excerpt_separator a".to_owned()),
             published_date: None,
@@ -648,6 +671,7 @@ mod test {
             .merge_slug("slug b".to_owned())
             .merge_title("title b".to_owned())
             .merge_description("description b".to_owned())
+            .merge_excerpt("excerpt b".to_owned())
             .merge_categories(vec!["a".to_owned(), "b".to_owned()])
             .merge_excerpt_separator("excerpt_separator b".to_owned())
             .merge_format(SourceFormat::Raw)
@@ -661,6 +685,7 @@ mod test {
             .merge_slug(None)
             .merge_title(None)
             .merge_description(None)
+            .merge_excerpt(None)
             .merge_categories(None)
             .merge_excerpt_separator(None)
             .merge_format(None)
@@ -674,6 +699,7 @@ mod test {
             .merge_slug("slug a".to_owned())
             .merge_title("title a".to_owned())
             .merge_description("description a".to_owned())
+            .merge_excerpt("excerpt a".to_owned())
             .merge_categories(vec!["a".to_owned(), "b".to_owned()])
             .merge_excerpt_separator("excerpt_separator a".to_owned())
             .merge_format(SourceFormat::Markdown)

--- a/src/document.rs
+++ b/src/document.rs
@@ -310,9 +310,7 @@ impl Document {
                           syntax_theme: &str)
                           -> Result<()> {
         let excerpt_html = {
-            let excerpt_attr = self.attributes
-                .get("excerpt")
-                .and_then(|attr| attr.as_str());
+            let excerpt_attr = self.front.excerpt.as_ref();
 
             let excerpt_separator = &self.front.excerpt_separator;
 

--- a/src/legacy_model/frontmatter.rs
+++ b/src/legacy_model/frontmatter.rs
@@ -39,6 +39,9 @@ impl From<FrontmatterBuilder> for cobalt_model::FrontmatterBuilder {
             .merge_description(unprocessed_attributes
                                    .remove("description")
                                    .and_then(|v| v.as_str().map(|s| s.to_owned())))
+            .merge_excerpt(unprocessed_attributes
+                               .remove("excerpt")
+                               .and_then(|v| v.as_str().map(|s| s.to_owned())))
             .merge_categories(unprocessed_attributes.remove("categories").and_then(|v| {
                 v.as_array()
                     .map(|v| v.iter().map(|v| v.to_string()).collect())
@@ -74,6 +77,7 @@ impl From<cobalt_model::FrontmatterBuilder> for FrontmatterBuilder {
             slug,
             title,
             description,
+            excerpt,
             categories,
             excerpt_separator,
             published_date,
@@ -94,6 +98,9 @@ impl From<cobalt_model::FrontmatterBuilder> for FrontmatterBuilder {
         }
         if let Some(description) = description {
             legacy.insert("description".to_owned(), liquid::Value::Str(description));
+        }
+        if let Some(excerpt) = excerpt {
+            legacy.insert("excerpt".to_owned(), liquid::Value::Str(excerpt));
         }
         if let Some(categories) = categories {
             legacy.insert("categories".to_owned(),


### PR DESCRIPTION
Original sequence of behavior
- front.excerpt was put in the page's attributes
- capture attributes
- render_excerpt renders using captured attribtes
- render_excerpt updates page's attributes
- render used the captured attributes which included the unredered
  excerpt

The previous change made things worse
- capture attributes
- render_excerpt renders using captured attribtes
- render_excerpt updates page's attributes
- render used the captured attributes which had no excerpt

Now
- capture attributes
- render_excerpt renders using captured attribtes
- render_excerpt updates page's attributes
- capture attributes
- render used the updated captured attributes, including support for
  excerpt