### PR TITLE
perf(serve): Reduce duplicate rebuilds

### DIFF
--- a/src/cobalt.rs
+++ b/src/cobalt.rs
@@ -250,7 +250,7 @@ pub fn build(config: &Config) -> Result<()> {
     // copy all remaining files in the source to the destination
     // compile SASS along the way
     {
-        info!("Copying remaining assets");
+        debug!("Copying remaining assets");
 
         let mut asset_files = files::FilesBuilder::new(source)?;
         for line in &config.ignore {
@@ -277,7 +277,7 @@ pub fn build(config: &Config) -> Result<()> {
 // creates a new RSS file with the contents of the site blog
 fn create_rss(path: &str, dest: &Path, config: &Config, posts: &[Document]) -> Result<()> {
     let rss_path = dest.join(path);
-    info!("Creating RSS file at {}", rss_path.display());
+    debug!("Creating RSS file at {}", rss_path.display());
 
     let title = &config.posts.title;
     let description = config
@@ -323,7 +323,7 @@ fn create_rss(path: &str, dest: &Path, config: &Config, posts: &[Document]) -> R
 // creates a new jsonfeed file with the contents of the site blog
 fn create_jsonfeed(path: &str, dest: &Path, config: &Config, posts: &[Document]) -> Result<()> {
     let jsonfeed_path = dest.join(path);
-    info!("Creating jsonfeed file at {}", jsonfeed_path.display());
+    debug!("Creating jsonfeed file at {}", jsonfeed_path.display());
 
     let title = &config.posts.title;
     let description = config

--- a/src/cobalt_model/config.rs
+++ b/src/cobalt_model/config.rs
@@ -224,7 +224,7 @@ impl ConfigBuilder {
         let file_path = files::find_project_file(&cwd, "_cobalt.yml");
         let config = file_path
             .map(|p| {
-                     info!("Using config file {:?}", &p);
+                     debug!("Using config file {:?}", &p);
                      Self::from_file(&p).chain_err(|| format!("Error reading config file {:?}", p))
                  })
             .unwrap_or_else(|| {

--- a/src/cobalt_model/files.rs
+++ b/src/cobalt_model/files.rs
@@ -213,7 +213,7 @@ fn write_document_file_internal(content: &str, dest_file: &path::Path) -> Result
         .map_err(|e| format!("Could not create {:?}: {}", dest_file, e))?;
 
     file.write_all(content.as_bytes())?;
-    info!("Wrote {}", dest_file.display());
+    trace!("Wrote {}", dest_file.display());
     Ok(())
 }
 

--- a/src/cobalt_model/site.rs
+++ b/src/cobalt_model/site.rs
@@ -155,7 +155,7 @@ fn load_data(data_path: &path::Path) -> Result<liquid::Value> {
 }
 
 fn insert_data_dir(data: &mut liquid::Object, data_root: &path::Path) -> Result<()> {
-    info!("Loading data from {:?}", data_root);
+    debug!("Loading data from {:?}", data_root);
 
     let data_files_builder = files::FilesBuilder::new(data_root)?;
     let data_files = data_files_builder.build()?;


### PR DESCRIPTION
This mostly resolves #356.  vim will cause a `delete` and `create`
notification on save.  The problem is that debouncing is really a
per-application policy rather than something that is universal.  It'd be
ideal for these to be debounced for cobalt but that wouldn't work in
other cases.