### PR TITLE
Fix EOL issue with tests

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,5 @@
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# force LF on checkout to avoid rustfmt messing up the EOL
+* text eol=lf

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -230,6 +230,7 @@ dependencies = [
  "lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "liquid 0.13.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "normalize-line-endings 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "notify 4.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "pulldown-cmark 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -657,6 +658,11 @@ dependencies = [
  "bitflags 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.35 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "normalize-line-endings"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "notify"
@@ -1317,6 +1323,7 @@ dependencies = [
 "checksum miow 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "3e690c5df6b2f60acd45d56378981e827ff8295562fc8d34f573deb267a59cd1"
 "checksum net2 0.2.31 (registry+https://github.com/rust-lang/crates.io-index)" = "3a80f842784ef6c9a958b68b7516bc7e35883c614004dd94959a4dca1b716c09"
 "checksum nix 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "bfb3ddedaa14746434a02041940495bf11325c22f6d36125d3bdd56090d50a79"
+"checksum normalize-line-endings 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "2e0a1a39eab95caf4f5556da9289b9e68f0aafac901b2ce80daaf020d3b733a8"
 "checksum notify 4.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "5c3812da3098f210a0bb440f9c008471a031aa4c1de07a264fdd75456c95a4eb"
 "checksum num 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)" = "cc4083e14b542ea3eb9b5f33ff48bd373a92d78687e74f4cc0a30caeb754f0ca"
 "checksum num-integer 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)" = "d1452e8b06e448a07f0e6ebb0bb1d92b8890eea63288c0b627331d53514d0fba"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,7 @@ serde = "1.0"
 serde_yaml = "0.7"
 serde_json = "1.0"
 toml = "0.4.0"
+normalize-line-endings = "0.2.2"
 
 [dependencies.sass-rs]
 version = "0.2"

--- a/src/cobalt_model/files.rs
+++ b/src/cobalt_model/files.rs
@@ -2,11 +2,12 @@ use std::fs;
 use std::io::Read;
 use std::io::Write;
 use std::path;
+use std::iter::FromIterator;
 
 use ignore::Match;
 use ignore::gitignore::{Gitignore, GitignoreBuilder};
 use walkdir::{WalkDir, DirEntry};
-
+use normalize_line_endings::normalized;
 use error::Result;
 
 pub struct FilesBuilder {
@@ -189,6 +190,7 @@ pub fn read_file<P: AsRef<path::Path>>(path: P) -> Result<String> {
     let mut file = fs::File::open(path.as_ref())?;
     let mut text = String::new();
     file.read_to_string(&mut text)?;
+    let text = String::from_iter(normalized(text.chars()));
     Ok(text)
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -85,6 +85,8 @@ extern crate lazy_static;
 #[macro_use]
 extern crate serde;
 
+extern crate normalize_line_endings;
+
 pub use cobalt::build;
 pub use error::Error;
 pub use cobalt_model::Config;

--- a/src/template.rs
+++ b/src/template.rs
@@ -3,7 +3,6 @@ use std::path;
 use std::result;
 
 use liquid;
-
 use error::*;
 use cobalt_model;
 use cobalt_model::files;

--- a/tests/fixtures/excerpts_CRLF/.editorconfig
+++ b/tests/fixtures/excerpts_CRLF/.editorconfig
@@ -1,0 +1,3 @@
+[*]
+end_of_line = crlf
+insert_final_newline = true

--- a/tests/fixtures/excerpts_CRLF/.gitattributes
+++ b/tests/fixtures/excerpts_CRLF/.gitattributes
@@ -1,0 +1,2 @@
+# force tests to keep their Windows EOL
+* text eol=crlf

--- a/tests/fixtures/excerpts_CRLF/_cobalt.yml
+++ b/tests/fixtures/excerpts_CRLF/_cobalt.yml
@@ -1,0 +1,3 @@
+source: "."
+site:
+  title: cobalt blog

--- a/tests/fixtures/excerpts_CRLF/_includes/post.liquid
+++ b/tests/fixtures/excerpts_CRLF/_includes/post.liquid
@@ -1,0 +1,6 @@
+<div>
+  <h2>{{ page.title }}</h2>
+  <p>
+    {{ page.content }}
+  </p>
+</div>

--- a/tests/fixtures/excerpts_CRLF/_layouts/default.liquid
+++ b/tests/fixtures/excerpts_CRLF/_layouts/default.liquid
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>{{ page.title }}</title>
+    </head>
+    <body>
+    <div>
+      {% if page.collection == "posts" %}
+        {% include 'post.liquid' %}
+      {% else %}
+        {{ page.content }}
+      {% endif %}
+    </div>
+  </body>
+</html>

--- a/tests/fixtures/excerpts_CRLF/index.liquid
+++ b/tests/fixtures/excerpts_CRLF/index.liquid
@@ -1,0 +1,15 @@
+layout: default.liquid
+---
+<div >
+  <h2>Blog!</h2>
+  <!--<br />-->
+  <div>
+    {% for post in collections.posts.pages %}
+      <div>
+        <h4>{{post.title}}</h4>
+        <h4><a href="{{post.permalink}}">{{ post.title }}</a></h4>
+        {{ post.excerpt }}
+      </div>
+    {% endfor %}
+  </div>
+</div>

--- a/tests/fixtures/excerpts_CRLF/posts/post-1.md
+++ b/tests/fixtures/excerpts_CRLF/posts/post-1.md
@@ -1,0 +1,9 @@
+layout: default.liquid
+
+title: First block is an excerpt
+published_date: 2016-01-14 21:00:30 -0500
+---
+
+# This is our first Post!
+
+Welcome to the first post ever on cobalt.rs!

--- a/tests/fixtures/excerpts_CRLF/posts/post-10.md
+++ b/tests/fixtures/excerpts_CRLF/posts/post-10.md
@@ -1,0 +1,12 @@
+layout: default.liquid
+
+title: Reference-style links immediately above first block
+published_date: 2017-02-11 04:50:21 -0000
+---
+
+[20]: /0
+ [21]: /1
+  [22]: /2
+   [23]: /3
+References are placed immediately above the first paragraph:
+[20][] [21][] [22][] [23][]

--- a/tests/fixtures/excerpts_CRLF/posts/post-11.md
+++ b/tests/fixtures/excerpts_CRLF/posts/post-11.md
@@ -1,0 +1,16 @@
+layout: default.liquid
+
+title: Reference-style links immediately below first block do not resolve
+published_date: 2017-02-11 04:51:34 -0000
+---
+
+References are placed immediately below the first paragraph:
+[30][] [31][] [32][] [33][]
+[30]: /0
+ [31]: /1
+  [32]: /2
+   [33]: /3
+
+Note that this is at it should be, as the markdown implementations I've tried
+(including CommonMark) do not render the above links (when the post is rendered
+individually).

--- a/tests/fixtures/excerpts_CRLF/posts/post-12.liquid
+++ b/tests/fixtures/excerpts_CRLF/posts/post-12.liquid
@@ -1,0 +1,14 @@
+layout: default.liquid
+
+title: Reference-style links in a non-markdown post do not resolve
+published_date: 2017-02-11 04:48:11 -0000
+---
+
+References are placed below the first paragraph, and are separated from the
+first paragraph by a single blank line:
+[40][] [41][] [42][] [43][]
+
+[40]: /0
+ [41]: /1
+  [42]: /2
+   [43]: /3

--- a/tests/fixtures/excerpts_CRLF/posts/post-2.md
+++ b/tests/fixtures/excerpts_CRLF/posts/post-2.md
@@ -1,0 +1,5 @@
+layout: default.liquid
+
+title: An empty post means an empty excerpt
+published_date: 2016-01-14 21:01:30 -0500
+---

--- a/tests/fixtures/excerpts_CRLF/posts/post-3.md
+++ b/tests/fixtures/excerpts_CRLF/posts/post-3.md
@@ -1,0 +1,10 @@
+layout: default.liquid
+
+title: Explicit `excerpt`
+published_date: 2016-01-14 21:02:30 -0500
+excerpt: Is in `markdown`
+---
+
+# This is our third Post!
+
+Welcome to the third post ever on cobalt.rs!

--- a/tests/fixtures/excerpts_CRLF/posts/post-4.md
+++ b/tests/fixtures/excerpts_CRLF/posts/post-4.md
@@ -1,0 +1,13 @@
+layout: default.liquid
+
+title: Custom excerpt separator
+published_date: 2016-01-14 21:03:30 -0500
+excerpt_separator: <!-- more -->
+---
+
+# Custom excerpt separator
+
+Welcome to the 4th post on cobalt.rs!
+<!-- more -->
+
+Something below the separator.

--- a/tests/fixtures/excerpts_CRLF/posts/post-5.md
+++ b/tests/fixtures/excerpts_CRLF/posts/post-5.md
@@ -1,0 +1,14 @@
+layout: default.liquid
+
+title: Both excerpt and excerpt separator are there
+published_date: 2016-01-14 21:04:30 -0500
+excerpt: "`excerpt` wins"
+excerpt_separator: <!-- more -->
+---
+
+# Both excerpt and excerpt separator are there
+
+Welcome to the 5th post on cobalt.rs!
+<!-- more -->
+
+Something below the separator.

--- a/tests/fixtures/excerpts_CRLF/posts/post-6.liquid
+++ b/tests/fixtures/excerpts_CRLF/posts/post-6.liquid
@@ -1,0 +1,13 @@
+layout: default.liquid
+
+title: Implicit excerpts work only in markdown
+published_date: 2016-01-14 21:05:30 -0500
+excerpt_separator: <!-- more -->
+---
+
+<h1>Custom excerpt separator</h1>
+
+<p>Welcome to the 6th post on cobalt.rs!</p>
+<!-- more -->
+
+<p>Something below the separator.</p>

--- a/tests/fixtures/excerpts_CRLF/posts/post-7.liquid
+++ b/tests/fixtures/excerpts_CRLF/posts/post-7.liquid
@@ -1,0 +1,14 @@
+layout: default.liquid
+
+title: Explicit excerpts work even in liquid
+published_date: 2016-01-14 21:06:30 -0500
+excerpt: <strong>explicit</strong> excerpt
+excerpt_separator: <!-- more -->
+---
+
+<h1>Custom excerpt separator</h1>
+
+<p>Welcome to the 7th post on cobalt.rs!</p>
+<!-- more -->
+
+<p>Something below the separator.</p>

--- a/tests/fixtures/excerpts_CRLF/posts/post-8.md
+++ b/tests/fixtures/excerpts_CRLF/posts/post-8.md
@@ -1,0 +1,14 @@
+layout: default.liquid
+
+title: Reference-style links above first block and separated by blank line resolve
+published_date: 2017-02-11 04:45:01 -0000
+---
+
+[00]: /0
+ [01]: /1
+  [02]: /2
+   [03]: /3
+
+References-style links are placed above the first paragraph, and are separated
+from the first paragraph by a single blank line:
+[00][] [01][] [02][] [03][]

--- a/tests/fixtures/excerpts_CRLF/posts/post-9.md
+++ b/tests/fixtures/excerpts_CRLF/posts/post-9.md
@@ -1,0 +1,14 @@
+layout: default.liquid
+
+title: Reference-style links below first block and separated by blank line resolve
+published_date: 2017-02-11 04:48:11 -0000
+---
+
+References are placed below the first paragraph, and are separated from the
+first paragraph by a single blank line:
+[10][] [11][] [12][] [13][]
+
+[10]: /0
+ [11]: /1
+  [12]: /2
+   [13]: /3

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -239,6 +239,11 @@ pub fn excerpts() {
 }
 
 #[test]
+pub fn excerpts_crlf() {
+    run_test("excerpts_CRLF").unwrap();
+}
+
+#[test]
 pub fn posts_in_subfolder() {
     run_test("posts_in_subfolder").unwrap();
 }

--- a/tests/target/excerpts_CRLF/index.html
+++ b/tests/target/excerpts_CRLF/index.html
@@ -1,0 +1,113 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>Index</title>
+    </head>
+    <body>
+    <div>
+      
+        <div >
+  <h2>Blog!</h2>
+  <!--<br />-->
+  <div>
+    
+      <div>
+        <h4>Reference-style links immediately below first block do not resolve</h4>
+        <h4><a href="posts/post-11.html">Reference-style links immediately below first block do not resolve</a></h4>
+        <p>References are placed immediately below the first paragraph:
+<a href="/0">30</a> <a href="/1">31</a> <a href="/2">32</a> <a href="/3">33</a>
+<a href="/0">30</a>: /0
+<a href="/1">31</a>: /1
+<a href="/2">32</a>: /2
+<a href="/3">33</a>: /3</p>
+
+      </div>
+    
+      <div>
+        <h4>Reference-style links immediately above first block</h4>
+        <h4><a href="posts/post-10.html">Reference-style links immediately above first block</a></h4>
+        <p>References are placed immediately above the first paragraph:
+<a href="/0">20</a> <a href="/1">21</a> <a href="/2">22</a> <a href="/3">23</a></p>
+
+      </div>
+    
+      <div>
+        <h4>Reference-style links in a non-markdown post do not resolve</h4>
+        <h4><a href="posts/post-12.html">Reference-style links in a non-markdown post do not resolve</a></h4>
+        References are placed below the first paragraph, and are separated from the
+first paragraph by a single blank line:
+[40][] [41][] [42][] [43][]
+      </div>
+    
+      <div>
+        <h4>Reference-style links below first block and separated by blank line resolve</h4>
+        <h4><a href="posts/post-9.html">Reference-style links below first block and separated by blank line resolve</a></h4>
+        <p>References are placed below the first paragraph, and are separated from the
+first paragraph by a single blank line:
+<a href="/0">10</a> <a href="/1">11</a> <a href="/2">12</a> <a href="/3">13</a></p>
+
+      </div>
+    
+      <div>
+        <h4>Reference-style links above first block and separated by blank line resolve</h4>
+        <h4><a href="posts/post-8.html">Reference-style links above first block and separated by blank line resolve</a></h4>
+        
+      </div>
+    
+      <div>
+        <h4>Explicit excerpts work even in liquid</h4>
+        <h4><a href="posts/post-7.html">Explicit excerpts work even in liquid</a></h4>
+        <strong>explicit</strong> excerpt
+      </div>
+    
+      <div>
+        <h4>Implicit excerpts work only in markdown</h4>
+        <h4><a href="posts/post-6.html">Implicit excerpts work only in markdown</a></h4>
+        <h1>Custom excerpt separator</h1>
+
+<p>Welcome to the 6th post on cobalt.rs!</p>
+
+      </div>
+    
+      <div>
+        <h4>Both excerpt and excerpt separator are there</h4>
+        <h4><a href="posts/post-5.html">Both excerpt and excerpt separator are there</a></h4>
+        <p><code>excerpt</code> wins</p>
+
+      </div>
+    
+      <div>
+        <h4>Custom excerpt separator</h4>
+        <h4><a href="posts/post-4.html">Custom excerpt separator</a></h4>
+        <h1>Custom excerpt separator</h1>
+<p>Welcome to the 4th post on cobalt.rs!</p>
+
+      </div>
+    
+      <div>
+        <h4>Explicit `excerpt`</h4>
+        <h4><a href="posts/post-3.html">Explicit `excerpt`</a></h4>
+        <p>Is in <code>markdown</code></p>
+
+      </div>
+    
+      <div>
+        <h4>An empty post means an empty excerpt</h4>
+        <h4><a href="posts/post-2.html">An empty post means an empty excerpt</a></h4>
+        
+      </div>
+    
+      <div>
+        <h4>First block is an excerpt</h4>
+        <h4><a href="posts/post-1.html">First block is an excerpt</a></h4>
+        <h1>This is our first Post!</h1>
+
+      </div>
+    
+  </div>
+</div>
+
+      
+    </div>
+  </body>
+</html>

--- a/tests/target/excerpts_CRLF/posts/post-1.html
+++ b/tests/target/excerpts_CRLF/posts/post-1.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>First block is an excerpt</title>
+    </head>
+    <body>
+    <div>
+      
+        <div>
+  <h2>First block is an excerpt</h2>
+  <p>
+    <h1>This is our first Post!</h1>
+<p>Welcome to the first post ever on cobalt.rs!</p>
+
+  </p>
+</div>
+
+      
+    </div>
+  </body>
+</html>

--- a/tests/target/excerpts_CRLF/posts/post-10.html
+++ b/tests/target/excerpts_CRLF/posts/post-10.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>Reference-style links immediately above first block</title>
+    </head>
+    <body>
+    <div>
+      
+        <div>
+  <h2>Reference-style links immediately above first block</h2>
+  <p>
+    <p>References are placed immediately above the first paragraph:
+<a href="/0">20</a> <a href="/1">21</a> <a href="/2">22</a> <a href="/3">23</a></p>
+
+  </p>
+</div>
+
+      
+    </div>
+  </body>
+</html>

--- a/tests/target/excerpts_CRLF/posts/post-11.html
+++ b/tests/target/excerpts_CRLF/posts/post-11.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>Reference-style links immediately below first block do not resolve</title>
+    </head>
+    <body>
+    <div>
+      
+        <div>
+  <h2>Reference-style links immediately below first block do not resolve</h2>
+  <p>
+    <p>References are placed immediately below the first paragraph:
+[30][] [31][] [32][] [33][]
+[30]: /0
+[31]: /1
+[32]: /2
+[33]: /3</p>
+<p>Note that this is at it should be, as the markdown implementations I've tried
+(including CommonMark) do not render the above links (when the post is rendered
+individually).</p>
+
+  </p>
+</div>
+
+      
+    </div>
+  </body>
+</html>

--- a/tests/target/excerpts_CRLF/posts/post-12.html
+++ b/tests/target/excerpts_CRLF/posts/post-12.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>Reference-style links in a non-markdown post do not resolve</title>
+    </head>
+    <body>
+    <div>
+      
+        <div>
+  <h2>Reference-style links in a non-markdown post do not resolve</h2>
+  <p>
+    References are placed below the first paragraph, and are separated from the
+first paragraph by a single blank line:
+[40][] [41][] [42][] [43][]
+
+[40]: /0
+ [41]: /1
+  [42]: /2
+   [43]: /3
+
+  </p>
+</div>
+
+      
+    </div>
+  </body>
+</html>

--- a/tests/target/excerpts_CRLF/posts/post-2.html
+++ b/tests/target/excerpts_CRLF/posts/post-2.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>An empty post means an empty excerpt</title>
+    </head>
+    <body>
+    <div>
+      
+        <div>
+  <h2>An empty post means an empty excerpt</h2>
+  <p>
+    
+  </p>
+</div>
+
+      
+    </div>
+  </body>
+</html>

--- a/tests/target/excerpts_CRLF/posts/post-3.html
+++ b/tests/target/excerpts_CRLF/posts/post-3.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>Explicit `excerpt`</title>
+    </head>
+    <body>
+    <div>
+      
+        <div>
+  <h2>Explicit `excerpt`</h2>
+  <p>
+    <h1>This is our third Post!</h1>
+<p>Welcome to the third post ever on cobalt.rs!</p>
+
+  </p>
+</div>
+
+      
+    </div>
+  </body>
+</html>

--- a/tests/target/excerpts_CRLF/posts/post-4.html
+++ b/tests/target/excerpts_CRLF/posts/post-4.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>Custom excerpt separator</title>
+    </head>
+    <body>
+    <div>
+      
+        <div>
+  <h2>Custom excerpt separator</h2>
+  <p>
+    <h1>Custom excerpt separator</h1>
+<p>Welcome to the 4th post on cobalt.rs!</p>
+<!-- more -->
+<p>Something below the separator.</p>
+
+  </p>
+</div>
+
+      
+    </div>
+  </body>
+</html>

--- a/tests/target/excerpts_CRLF/posts/post-5.html
+++ b/tests/target/excerpts_CRLF/posts/post-5.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>Both excerpt and excerpt separator are there</title>
+    </head>
+    <body>
+    <div>
+      
+        <div>
+  <h2>Both excerpt and excerpt separator are there</h2>
+  <p>
+    <h1>Both excerpt and excerpt separator are there</h1>
+<p>Welcome to the 5th post on cobalt.rs!</p>
+<!-- more -->
+<p>Something below the separator.</p>
+
+  </p>
+</div>
+
+      
+    </div>
+  </body>
+</html>

--- a/tests/target/excerpts_CRLF/posts/post-6.html
+++ b/tests/target/excerpts_CRLF/posts/post-6.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>Implicit excerpts work only in markdown</title>
+    </head>
+    <body>
+    <div>
+      
+        <div>
+  <h2>Implicit excerpts work only in markdown</h2>
+  <p>
+    <h1>Custom excerpt separator</h1>
+
+<p>Welcome to the 6th post on cobalt.rs!</p>
+<!-- more -->
+
+<p>Something below the separator.</p>
+
+  </p>
+</div>
+
+      
+    </div>
+  </body>
+</html>

--- a/tests/target/excerpts_CRLF/posts/post-7.html
+++ b/tests/target/excerpts_CRLF/posts/post-7.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>Explicit excerpts work even in liquid</title>
+    </head>
+    <body>
+    <div>
+      
+        <div>
+  <h2>Explicit excerpts work even in liquid</h2>
+  <p>
+    <h1>Custom excerpt separator</h1>
+
+<p>Welcome to the 7th post on cobalt.rs!</p>
+<!-- more -->
+
+<p>Something below the separator.</p>
+
+  </p>
+</div>
+
+      
+    </div>
+  </body>
+</html>

--- a/tests/target/excerpts_CRLF/posts/post-8.html
+++ b/tests/target/excerpts_CRLF/posts/post-8.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>Reference-style links above first block and separated by blank line resolve</title>
+    </head>
+    <body>
+    <div>
+      
+        <div>
+  <h2>Reference-style links above first block and separated by blank line resolve</h2>
+  <p>
+    <p>References-style links are placed above the first paragraph, and are separated
+from the first paragraph by a single blank line:
+<a href="/0">00</a> <a href="/1">01</a> <a href="/2">02</a> <a href="/3">03</a></p>
+
+  </p>
+</div>
+
+      
+    </div>
+  </body>
+</html>

--- a/tests/target/excerpts_CRLF/posts/post-9.html
+++ b/tests/target/excerpts_CRLF/posts/post-9.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>Reference-style links below first block and separated by blank line resolve</title>
+    </head>
+    <body>
+    <div>
+      
+        <div>
+  <h2>Reference-style links below first block and separated by blank line resolve</h2>
+  <p>
+    <p>References are placed below the first paragraph, and are separated from the
+first paragraph by a single blank line:
+<a href="/0">10</a> <a href="/1">11</a> <a href="/2">12</a> <a href="/3">13</a></p>
+
+  </p>
+</div>
+
+      
+    </div>
+  </body>
+</html>


### PR DESCRIPTION
Normalizing everything cobalt read to LF and and outputing LF as well. 
excerpts_CRLF test has fixtures as CRLF, and target as LF