### PR TITLE
 fix(import): import is self-contained

### DIFF
--- a/src/bin/cobalt/build.rs
+++ b/src/bin/cobalt/build.rs
@@ -76,15 +76,25 @@ pub fn clean_command(matches: &clap::ArgMatches) -> Result<()> {
     let config = args::get_config(matches)?;
     let config = config.build()?;
 
+    clean(config)
+}
+
+pub fn clean(config: cobalt::Config) -> Result<()> {
     let cwd = env::current_dir().unwrap_or_else(|_| path::PathBuf::new());
-    let destdir = config
-        .destination
-        .canonicalize()
-        .unwrap_or_else(|_| path::PathBuf::new());
+    let destdir = config.destination.canonicalize();
+    let destdir = match destdir {
+        Ok(destdir) => destdir,
+        Err(e) => {
+            debug!("directory \"{:?}\" doesn't exist", &config.destination);
+            debug!("{}", e);
+            return Ok(());
+        }
+    };
     if cwd.starts_with(&destdir) {
         bail!(
-            "Attempting to delete current directory, \
-             Cancelling the operation"
+            "Attempting to delete current directory ({:?}), \
+             Cancelling the operation",
+            destdir
         );
     }
 

--- a/src/bin/cobalt/build.rs
+++ b/src/bin/cobalt/build.rs
@@ -13,31 +13,6 @@ pub fn build_command_args() -> clap::App<'static, 'static> {
     clap::SubCommand::with_name("build")
         .about("build the cobalt project at the source dir")
         .args(&args::get_config_args())
-        .arg(
-            clap::Arg::with_name("import")
-                .short("i")
-                .long("import")
-                .help("Import after build to gh-pages branch")
-                .takes_value(false),
-        )
-        .arg(
-            clap::Arg::with_name("branch")
-                .short("b")
-                .long("branch")
-                .value_name("BRANCH")
-                .help("Branch that will be used to import the site to")
-                .default_value("gh-pages")
-                .takes_value(true),
-        )
-        .arg(
-            clap::Arg::with_name("message")
-                .short("m")
-                .long("message")
-                .value_name("COMMIT-MESSAGE")
-                .help("Commit message that will be used on import")
-                .default_value("cobalt site import")
-                .takes_value(true),
-        )
 }
 
 pub fn build_command(matches: &clap::ArgMatches) -> Result<()> {
@@ -46,12 +21,6 @@ pub fn build_command(matches: &clap::ArgMatches) -> Result<()> {
 
     build(config.clone())?;
     info!("Build successful");
-
-    if matches.is_present("import") {
-        let branch = matches.value_of("branch").unwrap().to_string();
-        let message = matches.value_of("message").unwrap().to_string();
-        import(&config, &branch, &message)?
-    }
 
     Ok(())
 }
@@ -68,7 +37,7 @@ pub fn build(config: cobalt::Config) -> Result<()> {
 
 pub fn clean_command_args() -> clap::App<'static, 'static> {
     clap::SubCommand::with_name("clean")
-        .about("cleans directory set as destination")
+        .about("cleans `destination` directory")
         .args(&args::get_config_args())
 }
 
@@ -76,16 +45,16 @@ pub fn clean_command(matches: &clap::ArgMatches) -> Result<()> {
     let config = args::get_config(matches)?;
     let config = config.build()?;
 
-    clean(config)
+    clean(&config)
 }
 
-pub fn clean(config: cobalt::Config) -> Result<()> {
+pub fn clean(config: &cobalt::Config) -> Result<()> {
     let cwd = env::current_dir().unwrap_or_else(|_| path::PathBuf::new());
     let destdir = config.destination.canonicalize();
     let destdir = match destdir {
         Ok(destdir) => destdir,
         Err(e) => {
-            debug!("directory \"{:?}\" doesn't exist", &config.destination);
+            debug!("No \"{:?}\" to clean", &config.destination);
             debug!("{}", e);
             return Ok(());
         }
@@ -132,6 +101,9 @@ pub fn import_command_args() -> clap::App<'static, 'static> {
 pub fn import_command(matches: &clap::ArgMatches) -> Result<()> {
     let config = args::get_config(matches)?;
     let config = config.build()?;
+
+    clean(&config)?;
+    build(config.clone())?;
 
     let branch = matches.value_of("branch").unwrap().to_string();
     let message = matches.value_of("message").unwrap().to_string();

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -161,17 +161,10 @@ pub fn clean() {
     assert_eq!(destdir.path().is_dir(), false);
 }
 
-#[cfg(not(windows))]
 #[test]
-pub fn clean_warning() {
+pub fn clean_empty() {
     assert_cli::Assert::command(&[&BIN, "clean"])
         .current_dir(CWD.join("tests/fixtures/example"))
-        .fails_with(1)
-        .stderr()
-        .contains(
-            "Attempting to delete current directory, Cancelling the \
-             operation",
-        )
         .unwrap();
 }
 


### PR DESCRIPTION
Recently, when I used `import`, I made several mistakes.  This was in
part out of assumptions of how I thought it worked.  This changes import
to work like how I at least expect.

Import does:
- `cobalt clean`
- `cobalt build`
- and imports `destination` into the specified branch

Because of this extra processing, `cobalt build -i` has been removed.

Fixes #394.

BREAKING CHANGE: `cobalt build -i` no longer works.  Instead use `cobalt
import`.