### PR TITLE
feat(liquid): Add page.slug

### DIFF
--- a/src/document.rs
+++ b/src/document.rs
@@ -166,6 +166,7 @@ fn document_attributes(
     let attributes = vec![
         ("permalink".to_owned(), liquid::Value::scalar(url_path)),
         ("title".to_owned(), liquid::Value::scalar(&front.title)),
+        ("slug".to_owned(), liquid::Value::scalar(&front.slug)),
         (
             "description".to_owned(),
             liquid::Value::scalar(front.description.as_ref().map(|s| s.as_str()).unwrap_or("")),


### PR DESCRIPTION
This was removed in #257 because it was deemed as not being needed but a
use case was found in #384.  I'm not fully convinced about that use case
but I feel there are probably others, like in having an identifier to
use in creating a table of contents.

Fixed #384