### PR TITLE
 feat(new): Load default files from disk 

### DIFF
--- a/src/bin/cobalt/main.rs
+++ b/src/bin/cobalt/main.rs
@@ -8,6 +8,9 @@ extern crate notify;
 extern crate serde_yaml;
 
 #[macro_use]
+extern crate lazy_static;
+
+#[macro_use]
 extern crate error_chain;
 
 #[macro_use]

--- a/src/bin/cobalt/new.rs
+++ b/src/bin/cobalt/new.rs
@@ -164,7 +164,7 @@ pub fn create_new_document(
     title: &str,
     file: path::PathBuf,
 ) -> Result<()> {
-    let file = if file.extension().is_none() {
+    let file = if file.extension().is_none() || file.is_dir() {
         let file_name = format!("{}.md", cobalt_model::slug::slugify(title));
         let mut file = file;
         file.push(path::Path::new(&file_name));

--- a/src/bin/cobalt/new.rs
+++ b/src/bin/cobalt/new.rs
@@ -147,7 +147,7 @@ const INDEX_MD: &str = "layout: default.liquid
 ";
 
 lazy_static! {
-    static ref DEFAULT: collections::HashMap<&'static str, &'static str> = [("pages", INDEX_MD), ("posts", POST_MD)].iter().map(|e| e.clone()).collect();
+    static ref DEFAULT: collections::HashMap<&'static str, &'static str> = [("pages", INDEX_MD), ("posts", POST_MD)].iter().cloned().collect();
 }
 
 pub fn create_new_project<P: AsRef<path::Path>>(dest: P) -> Result<()> {


### PR DESCRIPTION
`cobalt new` looks for a file that matches `_defaults/<collection>.<ext>` where:
- `collection` is the name of the collection (like `pages` or `posts`)
- `ext` is
  - from `--with-ext`
  - from `--file`
  - otherwise `md`

If the file is not found, a built in is used.

I dislike the name `_defaults` but couldn't come up with a better.  The
only alternative I had was `_new`.

`cobalt init` will also now create the `_defaults` folder to help guide
users to this new feature.

Fixes #355