### PR TITLE
feat: `rename` subcommand

### DIFF
--- a/src/bin/cobalt/main.rs
+++ b/src/bin/cobalt/main.rs
@@ -43,6 +43,7 @@ fn run() -> Result<()> {
         .args(&args::get_logging_args())
         .subcommand(new::init_command_args())
         .subcommand(new::new_command_args())
+        .subcommand(new::rename_command_args())
         .subcommand(new::publish_command_args())
         .subcommand(build::build_command_args())
         .subcommand(build::clean_command_args())
@@ -64,6 +65,7 @@ fn run() -> Result<()> {
     match command {
         "init" => new::init_command(matches),
         "new" => new::new_command(matches),
+        "rename" => new::rename_command(matches),
         "publish" => new::publish_command(matches),
         "build" => build::build_command(matches),
         "clean" => build::clean_command(matches),


### PR DESCRIPTION
Cobalt now has supprot for:
`cobalt rename <src_path> <new_title> [--file <dest_path>]`
This will
- Update the `title` in the frontmatter
- Move the file to the `dest_path` (or cwd)

We have all the information we need to help the user set up a
redirection, so ideally we would.  Unfortunately, that will require:
1. Deciding on an approach (alias vs file)
2. Refactoring the code necesary to make either work.

This has now been split out into #403.

Fixes #393