### PR TITLE
Add support for Sass's indented syntax

### DIFF
--- a/src/cobalt_model/assets.rs
+++ b/src/cobalt_model/assets.rs
@@ -1,5 +1,4 @@
 use std::path;
-use std::ffi;
 
 use super::sass;
 use super::files;
@@ -62,7 +61,7 @@ impl Assets {
 
     fn populate_path(&self, dest: &path::Path) -> Result<()> {
         for file_path in self.files() {
-            if file_path.extension() == Some(ffi::OsStr::new("scss")) {
+            if sass::is_sass_file(&file_path.as_path()) {
                 self.sass.compile_file(self.source(), dest, file_path)?;
             } else {
                 let rel_src = file_path

--- a/src/cobalt_model/sass.rs
+++ b/src/cobalt_model/sass.rs
@@ -1,4 +1,5 @@
 use std::path;
+use std::ffi;
 
 #[cfg(feature = "sass")]
 use sass_rs;
@@ -100,4 +101,9 @@ impl SassCompiler {
         let dest_file = dest.join(rel_src);
         files::copy_file(file_path, &dest_file)
     }
+}
+
+pub fn is_sass_file(file_path: &path::Path) -> bool {
+    return file_path.extension() == Some(ffi::OsStr::new("scss"))
+        || file_path.extension() == Some(ffi::OsStr::new("sass"));
 }

--- a/tests/fixtures/sass/style/indented.sass
+++ b/tests/fixtures/sass/style/indented.sass
@@ -1,0 +1,2 @@
+body
+	font-family: Arial

--- a/tests/fixtures/sass_custom_config/style/indented.sass
+++ b/tests/fixtures/sass_custom_config/style/indented.sass
@@ -1,0 +1,2 @@
+body
+	font-family: Arial

--- a/tests/target/sass/style/indented.css
+++ b/tests/target/sass/style/indented.css
@@ -1,0 +1,2 @@
+body {
+  font-family: Arial; }

--- a/tests/target/sass_custom_config/style/indented.css
+++ b/tests/target/sass_custom_config/style/indented.css
@@ -1,0 +1,1 @@
+body{font-family:Arial}


### PR DESCRIPTION
I was wondering why Cobalt doesn't support [Sass's indented syntax](http://sass-lang.com/documentation/file.INDENTED_SYNTAX.html) (`.sass` files) since sass-rs and libsass seem to support it. I hope I didn't overlook anything in regard to that!

I'm also unsure about the `is_sass_file` function, so looking forward to your feedback :)