### PR TITLE
feat: add runtime configuration to built in syntax highlighting

### DIFF
--- a/src/cobalt_model/config.rs
+++ b/src/cobalt_model/config.rs
@@ -19,12 +19,14 @@ use super::template;
 #[serde(deny_unknown_fields, default)]
 pub struct SyntaxHighlight {
     pub theme: String,
+    pub enabled: bool,
 }
 
 impl Default for SyntaxHighlight {
     fn default() -> Self {
         Self {
             theme: "base16-ocean.dark".to_owned(),
+            enabled: true,
         }
     }
 }
@@ -384,6 +386,7 @@ impl ConfigBuilder {
         };
         let markdown = mark::MarkdownBuilder {
             theme: syntax_highlight.theme,
+            syntax_highlight_enabled: syntax_highlight.enabled,
         };
 
         let config = Config {

--- a/src/cobalt_model/mark.rs
+++ b/src/cobalt_model/mark.rs
@@ -7,17 +7,22 @@ use error::*;
 #[serde(deny_unknown_fields)]
 pub struct MarkdownBuilder {
     pub theme: String,
+    pub syntax_highlight_enabled: bool,
 }
 
 impl MarkdownBuilder {
     pub fn build(self) -> Markdown {
-        Markdown { theme: self.theme }
+        Markdown {
+            theme: self.theme,
+            syntax_highlight_enabled: self.syntax_highlight_enabled,
+        }
     }
 }
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct Markdown {
     theme: String,
+    syntax_highlight_enabled: bool,
 }
 
 impl Markdown {
@@ -25,7 +30,11 @@ impl Markdown {
         let mut buf = String::new();
         let options = cmark::OPTION_ENABLE_FOOTNOTES | cmark::OPTION_ENABLE_TABLES;
         let parser = cmark::Parser::new_ext(content, options);
-        cmark::html::push_html(&mut buf, decorate_markdown(parser, &self.theme));
+        if self.syntax_highlight_enabled {
+            cmark::html::push_html(&mut buf, decorate_markdown(parser, &self.theme));
+        } else {
+            cmark::html::push_html(&mut buf, parser);
+        }
         Ok(buf)
     }
 }


### PR DESCRIPTION
Add an enabled option to the `syntax_highlight` category of `_cobalt.yml`. When set to `false`, cobalt will not perform syntax highlighting in Markdown files. The default is `true`, so this should be totally backwards compatible with the current functionality.

Do we also want to remove the compile time options for syntax-highlighting? If compiling with the feature adds extra dependencies, there are some potential benefits to keeping the compile time options in, however this could cause some confusion.

I'm not overly familiar with the architecture of this project, so feel free to let me know if there is a way you would rather me implement this or if there is some way to improve this PR.

Closes #343