### PR TITLE
fix(deprecation): remove `use std::ascii::AsciiExt` 

### DIFF
--- a/src/syntax_highlight/syntect.rs
+++ b/src/syntax_highlight/syntect.rs
@@ -1,6 +1,3 @@
-#[allow(unused_imports)]
-use std::ascii::AsciiExt;
-
 use itertools::Itertools;
 use std::borrow::Cow::Owned;
 


### PR DESCRIPTION
to get rid of deprecation warning