### PR TITLE
Document frontmatter can now be surrounded by ---

### DIFF
--- a/src/cobalt_model/document.rs
+++ b/src/cobalt_model/document.rs
@@ -46,14 +46,33 @@ impl<T: frontmatter::Front> fmt::Display for DocumentBuilder<T> {
 fn split_document(content: &str) -> Result<(Option<&str>, &str)> {
     lazy_static! {
         static ref FRONT_MATTER_DIVIDE: regex::Regex = regex::Regex::new(r"---\s*\r?\n").unwrap();
-        static ref FRONT_MATTER: regex::Regex = regex::Regex::new(r"\A---\s*\r?\n[\s\S]*---\s*\r?\n").unwrap();
+        static ref FRONT_MATTER: regex::Regex = regex::Regex::new(r"\A---\s*\r?\n([\s\S]*\n)?---\s*\r?\n").unwrap();
     }
 
-    // remove divide at beginning of file if exists
-    let content = if FRONT_MATTER.is_match(content) {
-        content.splitn(2, '\n').skip(1).next().unwrap()
-    } else { content };
+    if FRONT_MATTER.is_match(content) {
+        // skip first empty string
+        let mut splits = FRONT_MATTER_DIVIDE.splitn(content, 3).skip(1);
 
+        // split between dividers
+        let front_split = splits.next().unwrap_or("");
+
+        // split after second divider
+        let content_split = splits.next().unwrap_or("");
+
+        if front_split.is_empty() {
+            Ok((None, content_split))
+        } else {
+            Ok((Some(front_split), content_split))
+        }
+    } else {
+        deprecated_split_front_matter(content)
+    }
+}
+
+fn deprecated_split_front_matter(content: &str) -> Result<(Option<&str>, &str)> {
+    lazy_static! {
+        static ref FRONT_MATTER_DIVIDE: regex::Regex = regex::Regex::new(r"(\A|\n)---\s*\r?\n").unwrap();
+    }
     if FRONT_MATTER_DIVIDE.is_match(content) {
         let mut splits = FRONT_MATTER_DIVIDE.splitn(content, 2);
 
@@ -71,8 +90,8 @@ fn split_document(content: &str) -> Result<(Option<&str>, &str)> {
     } else {
         Ok((None, content))
     }
-
 }
+
 
 #[cfg(test)]
 mod test {
@@ -114,7 +133,7 @@ mod test {
     fn split_document_deprecated_empty_body() {
         let input = "cobalt_model\n---\n";
         let (cobalt_model, content) = split_document(input).unwrap();
-        assert_eq!(cobalt_model.unwrap(), "cobalt_model\n");
+        assert_eq!(cobalt_model.unwrap(), "cobalt_model");
         assert_eq!(content, "");
     }
 
@@ -132,6 +151,15 @@ mod test {
         let (cobalt_model, content) = split_document(input).unwrap();
         assert_eq!(cobalt_model.unwrap(), "cobalt_model\n");
         assert_eq!(content, "body");
+    }
+
+    #[test]
+    fn split_document_no_new_line_after_front_matter() {
+        let input = "invalid_front_matter---\nbody";
+        let (cobalt_model, content) = split_document(input).unwrap();
+        assert!(cobalt_model.is_none());
+        assert_eq!(content, input);
+
     }
 
     #[test]

--- a/src/cobalt_model/document.rs
+++ b/src/cobalt_model/document.rs
@@ -74,6 +74,8 @@ fn deprecated_split_front_matter(content: &str) -> Result<(Option<&str>, &str)> 
         static ref FRONT_MATTER_DIVIDE: regex::Regex = regex::Regex::new(r"(\A|\n)---\s*\r?\n").unwrap();
     }
     if FRONT_MATTER_DIVIDE.is_match(content) {
+        warn!("Front matter should have a separator above and below. Using just a trailing separator is deprecated.");
+
         let mut splits = FRONT_MATTER_DIVIDE.splitn(content, 2);
 
         // above the split are the attributes

--- a/src/cobalt_model/document.rs
+++ b/src/cobalt_model/document.rs
@@ -74,7 +74,7 @@ fn deprecated_split_front_matter(content: &str) -> Result<(Option<&str>, &str)> 
         static ref FRONT_MATTER_DIVIDE: regex::Regex = regex::Regex::new(r"(\A|\n)---\s*\r?\n").unwrap();
     }
     if FRONT_MATTER_DIVIDE.is_match(content) {
-        warn!("Front matter should have a separator above and below. Using just a trailing separator is deprecated.");
+        warn!("Trailing separators are deprecated. We recommend frontmatters be surrounded, above and below, with ---");
 
         let mut splits = FRONT_MATTER_DIVIDE.splitn(content, 2);
 

--- a/src/cobalt_model/document.rs
+++ b/src/cobalt_model/document.rs
@@ -46,7 +46,8 @@ impl<T: frontmatter::Front> fmt::Display for DocumentBuilder<T> {
 fn split_document(content: &str) -> Result<(Option<&str>, &str)> {
     lazy_static! {
         static ref FRONT_MATTER_DIVIDE: regex::Regex = regex::Regex::new(r"---\s*\r?\n").unwrap();
-        static ref FRONT_MATTER: regex::Regex = regex::Regex::new(r"\A---\s*\r?\n([\s\S]*\n)?---\s*\r?\n").unwrap();
+        static ref FRONT_MATTER: regex::Regex =
+            regex::Regex::new(r"\A---\s*\r?\n([\s\S]*\n)?---\s*\r?\n").unwrap();
     }
 
     if FRONT_MATTER.is_match(content) {
@@ -71,7 +72,8 @@ fn split_document(content: &str) -> Result<(Option<&str>, &str)> {
 
 fn deprecated_split_front_matter(content: &str) -> Result<(Option<&str>, &str)> {
     lazy_static! {
-        static ref FRONT_MATTER_DIVIDE: regex::Regex = regex::Regex::new(r"(\A|\n)---\s*\r?\n").unwrap();
+        static ref FRONT_MATTER_DIVIDE: regex::Regex =
+            regex::Regex::new(r"(\A|\n)---\s*\r?\n").unwrap();
     }
     if FRONT_MATTER_DIVIDE.is_match(content) {
         warn!("Trailing separators are deprecated. We recommend frontmatters be surrounded, above and below, with ---");

--- a/src/cobalt_model/document.rs
+++ b/src/cobalt_model/document.rs
@@ -96,7 +96,6 @@ fn deprecated_split_front_matter(content: &str) -> Result<(Option<&str>, &str)> 
     }
 }
 
-
 #[cfg(test)]
 mod test {
     use super::*;
@@ -163,7 +162,6 @@ mod test {
         let (cobalt_model, content) = split_document(input).unwrap();
         assert!(cobalt_model.is_none());
         assert_eq!(content, input);
-
     }
 
     #[test]


### PR DESCRIPTION
#431 
Documents can optionally start with a `---` now.  The code I added essentially checks if the document has front matter surrounded by `---` and if so, it removes the first line and then the logic for separating the front matter stays the same. I added a couple tests as well.

Questions and suggestions are welcome and encouraged! I tried a few ideas before settling on this.