### PR TITLE
feat(pagination): pagination on tags

### DIFF
--- a/src/cobalt_model/frontmatter.rs
+++ b/src/cobalt_model/frontmatter.rs
@@ -15,6 +15,7 @@ use super::pagination_config;
 use super::slug;
 
 const PATH_ALIAS: &str = "/{{parent}}/{{name}}{{ext}}";
+
 lazy_static! {
     static ref PERMALINK_ALIASES: HashMap<&'static str, &'static str> = [("path", PATH_ALIAS),]
         .iter()

--- a/src/cobalt_model/pagination_config.rs
+++ b/src/cobalt_model/pagination_config.rs
@@ -12,6 +12,7 @@ pub const DEFAULT_PER_PAGE: i32 = 10;
 pub enum Include {
     None,
     All,
+    Tags,
 }
 
 impl Into<&'static str> for Include {
@@ -19,6 +20,7 @@ impl Into<&'static str> for Include {
         match self {
             Include::None => "",
             Include::All => "all",
+            Include::Tags => "tags",
         }
     }
 }

--- a/tests/fixtures/pagination_tags/_layouts/default.liquid
+++ b/tests/fixtures/pagination_tags/_layouts/default.liquid
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>test</title>
+    </head>
+    <body>
+        <h1>{{ page.permalink }}</h1>
+
+        {{ page.content }}
+    </body>
+</html>
+

--- a/tests/fixtures/pagination_tags/_layouts/posts.liquid
+++ b/tests/fixtures/pagination_tags/_layouts/posts.liquid
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>My blog - {{ page.title }}</title>
+    </head>
+    <body>
+        {{ page.content }}
+    </body>
+</html>
+

--- a/tests/fixtures/pagination_tags/index.liquid
+++ b/tests/fixtures/pagination_tags/index.liquid
@@ -1,0 +1,30 @@
+---
+layout: default.liquid
+pagination:
+  include: Tags
+---
+{% if paginator.indexes %}
+<ul>
+  {% for ptag in paginator.indexes %}
+  <li><a href="/{{ ptag.index_permalink }}/">{{ ptag.index_title }} ({{ ptag.total_pages }})</a>
+    {% endfor %}
+</ul>
+{% else %}
+<ul>
+  {% for page in paginator.pages %}
+  <li><a href="/{{ page.permalink }}">{{ page.title }}</a>
+    {% endfor %}
+</ul>
+<div>
+  {% if paginator.previous_index %}
+    <a href="{{ paginator.previous_index_permalink }}"
+    class="left arrow">&#8592;</a>
+  {% endif %}
+  {% if paginator.next_index %}
+    <a href="{{ paginator.next_index_permalink }}"
+    class="right arrow">&#8594;</a>
+  {% endif %}
+
+  <span>{{ paginator.index }} / {{ paginator.total_indexes }}</span>
+</div>
+{% endif %}

--- a/tests/fixtures/pagination_tags/posts/my-first-blogpost.md
+++ b/tests/fixtures/pagination_tags/posts/my-first-blogpost.md
@@ -1,0 +1,12 @@
+---
+layout: posts.liquid
+
+title:   My first Blogpost
+published_date:    2016-01-01 21:00:00 +0100
+tags: [tag1]
+---
+# {{ page.title }}
+
+Hey there this is my first blogpost and this is super awesome.
+
+My Blog is lorem ipsum like, yes it is..

--- a/tests/fixtures/pagination_tags/posts/my-fith-blogpost.md
+++ b/tests/fixtures/pagination_tags/posts/my-fith-blogpost.md
@@ -1,0 +1,12 @@
+---
+layout: posts.liquid
+
+title:   My fith Blogpost
+published_date:    2016-06-01 21:00:00 +0100
+tags: [tag4, tag5]
+---
+# {{ page.title }}
+
+Hey there this is my first blogpost and this is super awesome.
+
+My Blog is lorem ipsum like, yes it is..

--- a/tests/fixtures/pagination_tags/posts/my-fourth-blogpost.md
+++ b/tests/fixtures/pagination_tags/posts/my-fourth-blogpost.md
@@ -1,0 +1,12 @@
+---
+layout: posts.liquid
+
+title:   My fourth Blogpost
+published_date:    2016-05-29 23:00:00 +0100
+tags: [tag4]
+---
+# {{ page.title }}
+
+Hey there this is my first blogpost and this is super awesome.
+
+My Blog is lorem ipsum like, yes it is..

--- a/tests/fixtures/pagination_tags/posts/my-second-blogpost.md
+++ b/tests/fixtures/pagination_tags/posts/my-second-blogpost.md
@@ -1,0 +1,12 @@
+---
+layout: posts.liquid
+
+title:   My second Blogpost
+published_date:    2016-01-02 10:00:00 +0100
+tags: [tag1, tag2]
+---
+# {{ page.title }}
+
+Hey there this is my first blogpost and this is super awesome.
+
+My Blog is lorem ipsum like, yes it is..

--- a/tests/fixtures/pagination_tags/posts/my-third-blogpost.md
+++ b/tests/fixtures/pagination_tags/posts/my-third-blogpost.md
@@ -1,0 +1,12 @@
+---
+layout: posts.liquid
+
+title:   My third Blogpost
+published_date:    2016-05-27 23:00:00 +0100
+tags: [tag1, tag2, tag3]
+---
+# {{ page.title }}
+
+Hey there this is my first blogpost and this is super awesome.
+
+My Blog is lorem ipsum like, yes it is..

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -299,3 +299,9 @@ pub fn pagination_less_per_page() {
 pub fn pagination_all_sort_by_title() {
     run_test("pagination_all_sort_by_title").expect("Build error");
 }
+
+#[cfg(feature = "pagination-unstable")]
+#[test]
+pub fn pagination_tags() {
+    run_test("pagination_tags").expect("Build error");
+}

--- a/tests/target/pagination_all/all/_p/2/index.html
+++ b/tests/target/pagination_all/all/_p/2/index.html
@@ -22,6 +22,7 @@
 
   <span>2 / 2</span>
 </div>
+
     </body>
 </html>
 

--- a/tests/target/pagination_all/index.html
+++ b/tests/target/pagination_all/index.html
@@ -40,6 +40,7 @@
 
   <span>1 / 2</span>
 </div>
+
     </body>
 </html>
 

--- a/tests/target/pagination_all_reverse_date/index.html
+++ b/tests/target/pagination_all_reverse_date/index.html
@@ -25,6 +25,7 @@
 
   <span>1 / 1</span>
 </div>
+
     </body>
 </html>
 

--- a/tests/target/pagination_all_sort_by_title/index.html
+++ b/tests/target/pagination_all_sort_by_title/index.html
@@ -25,6 +25,7 @@
 
   <span>1 / 1</span>
 </div>
+
     </body>
 </html>
 

--- a/tests/target/pagination_less_per_page/all/_p/2/index.html
+++ b/tests/target/pagination_less_per_page/all/_p/2/index.html
@@ -25,6 +25,7 @@
 
   <span>2 / 4</span>
 </div>
+
     </body>
 </html>
 

--- a/tests/target/pagination_less_per_page/all/_p/3/index.html
+++ b/tests/target/pagination_less_per_page/all/_p/3/index.html
@@ -25,6 +25,7 @@
 
   <span>3 / 4</span>
 </div>
+
     </body>
 </html>
 

--- a/tests/target/pagination_less_per_page/all/_p/4/index.html
+++ b/tests/target/pagination_less_per_page/all/_p/4/index.html
@@ -22,6 +22,7 @@
 
   <span>4 / 4</span>
 </div>
+
     </body>
 </html>
 

--- a/tests/target/pagination_less_per_page/index.html
+++ b/tests/target/pagination_less_per_page/index.html
@@ -22,6 +22,7 @@
 
   <span>1 / 4</span>
 </div>
+
     </body>
 </html>
 

--- a/tests/target/pagination_tags/index.html
+++ b/tests/target/pagination_tags/index.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>test</title>
+    </head>
+    <body>
+        <h1>index.html</h1>
+
+        
+<ul>
+  
+  <li><a href="/tags/tag1/">tag1 (3)</a>
+    
+  <li><a href="/tags/tag2/">tag2 (2)</a>
+    
+  <li><a href="/tags/tag3/">tag3 (1)</a>
+    
+  <li><a href="/tags/tag4/">tag4 (2)</a>
+    
+  <li><a href="/tags/tag5/">tag5 (1)</a>
+    
+</ul>
+
+
+    </body>
+</html>
+

--- a/tests/target/pagination_tags/posts/my-first-blogpost.html
+++ b/tests/target/pagination_tags/posts/my-first-blogpost.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>My blog - My first Blogpost</title>
+    </head>
+    <body>
+        <h1>My first Blogpost</h1>
+<p>Hey there this is my first blogpost and this is super awesome.</p>
+<p>My Blog is lorem ipsum like, yes it is..</p>
+
+    </body>
+</html>
+

--- a/tests/target/pagination_tags/posts/my-fith-blogpost.html
+++ b/tests/target/pagination_tags/posts/my-fith-blogpost.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>My blog - My fith Blogpost</title>
+    </head>
+    <body>
+        <h1>My fith Blogpost</h1>
+<p>Hey there this is my first blogpost and this is super awesome.</p>
+<p>My Blog is lorem ipsum like, yes it is..</p>
+
+    </body>
+</html>
+

--- a/tests/target/pagination_tags/posts/my-fourth-blogpost.html
+++ b/tests/target/pagination_tags/posts/my-fourth-blogpost.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>My blog - My fourth Blogpost</title>
+    </head>
+    <body>
+        <h1>My fourth Blogpost</h1>
+<p>Hey there this is my first blogpost and this is super awesome.</p>
+<p>My Blog is lorem ipsum like, yes it is..</p>
+
+    </body>
+</html>
+

--- a/tests/target/pagination_tags/posts/my-second-blogpost.html
+++ b/tests/target/pagination_tags/posts/my-second-blogpost.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>My blog - My second Blogpost</title>
+    </head>
+    <body>
+        <h1>My second Blogpost</h1>
+<p>Hey there this is my first blogpost and this is super awesome.</p>
+<p>My Blog is lorem ipsum like, yes it is..</p>
+
+    </body>
+</html>
+

--- a/tests/target/pagination_tags/posts/my-third-blogpost.html
+++ b/tests/target/pagination_tags/posts/my-third-blogpost.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>My blog - My third Blogpost</title>
+    </head>
+    <body>
+        <h1>My third Blogpost</h1>
+<p>Hey there this is my first blogpost and this is super awesome.</p>
+<p>My Blog is lorem ipsum like, yes it is..</p>
+
+    </body>
+</html>
+

--- a/tests/target/pagination_tags/tags/tag1/index.html
+++ b/tests/target/pagination_tags/tags/tag1/index.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>test</title>
+    </head>
+    <body>
+        <h1>index.html</h1>
+
+        
+<ul>
+  
+  <li><a href="/posts/my-third-blogpost.html">My third Blogpost</a>
+    
+  <li><a href="/posts/my-second-blogpost.html">My second Blogpost</a>
+    
+  <li><a href="/posts/my-first-blogpost.html">My first Blogpost</a>
+    
+</ul>
+<div>
+  
+  
+
+  <span>1 / 1</span>
+</div>
+
+
+    </body>
+</html>
+

--- a/tests/target/pagination_tags/tags/tag2/index.html
+++ b/tests/target/pagination_tags/tags/tag2/index.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>test</title>
+    </head>
+    <body>
+        <h1>index.html</h1>
+
+        
+<ul>
+  
+  <li><a href="/posts/my-third-blogpost.html">My third Blogpost</a>
+    
+  <li><a href="/posts/my-second-blogpost.html">My second Blogpost</a>
+    
+</ul>
+<div>
+  
+  
+
+  <span>1 / 1</span>
+</div>
+
+
+    </body>
+</html>
+

--- a/tests/target/pagination_tags/tags/tag3/index.html
+++ b/tests/target/pagination_tags/tags/tag3/index.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>test</title>
+    </head>
+    <body>
+        <h1>index.html</h1>
+
+        
+<ul>
+  
+  <li><a href="/posts/my-third-blogpost.html">My third Blogpost</a>
+    
+</ul>
+<div>
+  
+  
+
+  <span>1 / 1</span>
+</div>
+
+
+    </body>
+</html>
+

--- a/tests/target/pagination_tags/tags/tag4/index.html
+++ b/tests/target/pagination_tags/tags/tag4/index.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>test</title>
+    </head>
+    <body>
+        <h1>index.html</h1>
+
+        
+<ul>
+  
+  <li><a href="/posts/my-fith-blogpost.html">My fith Blogpost</a>
+    
+  <li><a href="/posts/my-fourth-blogpost.html">My fourth Blogpost</a>
+    
+</ul>
+<div>
+  
+  
+
+  <span>1 / 1</span>
+</div>
+
+
+    </body>
+</html>
+

--- a/tests/target/pagination_tags/tags/tag5/index.html
+++ b/tests/target/pagination_tags/tags/tag5/index.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>test</title>
+    </head>
+    <body>
+        <h1>index.html</h1>
+
+        
+<ul>
+  
+  <li><a href="/posts/my-fith-blogpost.html">My fith Blogpost</a>
+    
+</ul>
+<div>
+  
+  
+
+  <span>1 / 1</span>
+</div>
+
+
+    </body>
+</html>
+


### PR DESCRIPTION
Here is my implementation of pagination on tags (https://github.com/cobalt-org/cobalt.rs/issues/395). 

* `paginator.indexes` is populated with the 1st paginator of each tag.
* I support multiple pages per tag.
* I've added `index_title` in the paginator so we know which tag we are in.

I still need to write some tests, but I'd like to start the review process as we know it will take some time reach a stable code ;)