### PR TITLE
feat(tags): Allow overriding default tag

### DIFF
--- a/src/cobalt_model/frontmatter.rs
+++ b/src/cobalt_model/frontmatter.rs
@@ -430,6 +430,11 @@ impl FrontmatterBuilder {
                 return Err("Empty strings are not allowed in tags".into());
             }
         }
+        let tags = if tags.as_ref().map(|t| t.len()).unwrap_or(0) == 0 {
+            None
+        } else {
+            tags
+        };
 
         let fm = Frontmatter {
             permalink,


### PR DESCRIPTION
Because "no tags" is `None` and "no preference" is `one`, we need to
allow `[]` to also represent `no tags` and convert it to `None`.

See #550 