### PR TITLE
fix(files): sort by filename to have a reproducibly walking iterator

### DIFF
--- a/src/cobalt_model/files.rs
+++ b/src/cobalt_model/files.rs
@@ -91,6 +91,7 @@ impl<'a> FilesIterator<'a> {
         let walker = WalkDir::new(files.root_dir.as_path())
             .min_depth(1)
             .follow_links(false)
+            .sort_by(|a, b| a.file_name().cmp(b.file_name()))
             .into_iter()
             .filter_entry(move |e| files.includes_entry(e))
             .filter_map(|e| e.ok())


### PR DESCRIPTION
The underlaying structure's order is not fixed and may depend on
the filesystem implementation. Therefor the iterator needs to be
sorted by filename to guarantee a reproducible order of processing
input files.

One effect of this issue can be observed by having an unreproducible
order of posts that have the very same published_date (or none as
that falls back to default_date) purely depending on the order the
underlaying filesystem serves the files for consumption.

This fixes #457