### PR TITLE
chore: fix warnings on trait object without `dyn` keyword

### DIFF
--- a/src/cobalt_model/files.rs
+++ b/src/cobalt_model/files.rs
@@ -84,7 +84,7 @@ impl FilesBuilder {
 }
 
 pub struct FilesIterator<'a> {
-    inner: Box<Iterator<Item = path::PathBuf> + 'a>,
+    inner: Box<dyn Iterator<Item = path::PathBuf> + 'a>,
 }
 
 impl<'a> FilesIterator<'a> {

--- a/src/cobalt_model/template.rs
+++ b/src/cobalt_model/template.rs
@@ -46,7 +46,7 @@ impl LiquidBuilder {
         Ok(Liquid { parser })
     }
 
-    fn highlight(theme: String) -> Result<Box<liquid::compiler::ParseBlock>> {
+    fn highlight(theme: String) -> Result<Box<dyn liquid::compiler::ParseBlock>> {
         let result: Result<()> = match syntax_highlight::has_syntax_theme(&theme) {
             Ok(true) => Ok(()),
             Ok(false) => Err(failure::format_err!(

--- a/src/syntax_highlight/syntect.rs
+++ b/src/syntax_highlight/syntect.rs
@@ -70,7 +70,7 @@ struct CodeBlock {
 }
 
 impl Renderable for CodeBlock {
-    fn render_to(&self, writer: &mut Write, _context: &mut Context) -> Result<(), liquid::Error> {
+    fn render_to(&self, writer: &mut dyn Write, _context: &mut Context) -> Result<(), liquid::Error> {
         let syntax = match self.lang {
             Some(ref lang) => SETUP.syntax_set.find_syntax_by_token(lang),
             _ => None,
@@ -106,7 +106,7 @@ impl liquid::compiler::ParseBlock for CodeBlockParser {
         mut arguments: TagTokenIter,
         mut tokens: TagBlock,
         _options: &Language,
-    ) -> Result<Box<Renderable>, liquid::Error> {
+    ) -> Result<Box<dyn Renderable>, liquid::Error> {
         let lang = arguments
             .expect_next("Identifier or literal expected.")
             .ok()


### PR DESCRIPTION
Added `dyn` where the compiler told me to do so to get rid of the warnings that appeared in Rust 1.37