### PR TITLE
feat: Minify html,css,js

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -272,6 +272,7 @@ dependencies = [
  "exitfailure",
  "failure",
  "ghp",
+ "html-minifier",
  "ignore",
  "itertools",
  "jsonfeed",
@@ -299,6 +300,12 @@ dependencies = [
  "toml",
  "walkdir 2.3.2",
 ]
+
+[[package]]
+name = "cow-utils"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79bb3adfaf5f75d24b01aee375f7555907840fa2800e5ec8fa3b9e2031830173"
 
 [[package]]
 name = "crc32fast"
@@ -423,6 +430,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56899898ce76aaf4a0f24d914c97ea6ed976d42fec6ad33fcbb0a1103e07b2b0"
 
 [[package]]
+name = "educe"
+version = "0.4.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b6f648515c65974bcb893b286a5c4a35adfdcfbfd03c1bbf1108f40feec65d7"
+dependencies = [
+ "enum-ordinalize",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "either"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -435,6 +454,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "80df024fbc5ac80f87dfef0d9f5209a252f2a497f7f42944cff24d8253cac065"
 dependencies = [
  "cfg-if 1.0.0",
+]
+
+[[package]]
+name = "enum-ordinalize"
+version = "3.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b166c9e378360dd5a6666a9604bb4f54ae0cac39023ffbac425e917a2a04fef"
+dependencies = [
+ "num-bigint",
+ "num-traits",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -675,6 +707,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "html-escape"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "816ea801a95538fc5f53c836697b3f8b64a9d664c4f0b91efe1fe7c92e4dbcb7"
+dependencies = [
+ "utf8-width",
+]
+
+[[package]]
+name = "html-minifier"
+version = "3.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "108452631307790510cde91282fc706ae70076bd68200add8638773f06d5e122"
+dependencies = [
+ "cow-utils",
+ "educe",
+ "html-escape",
+ "minifier",
+]
+
+[[package]]
 name = "humantime"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -902,6 +955,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "macro-utils"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e72f7deb758fea9ea7d290aebfa788763d0bffae12caa6406a25baaf8fa68a8"
+
+[[package]]
 name = "maplit"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -933,6 +992,15 @@ checksum = "2684d4c2e97d99848d30b324b00c8fcc7e5c897b7cbb5819b09e7c90e8baf212"
 dependencies = [
  "mime",
  "unicase",
+]
+
+[[package]]
+name = "minifier"
+version = "0.0.39"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6cdf618de5c9c98d4a7b2e0d1f1e44f82a19196cfd94040bb203621c25d28d98"
+dependencies = [
+ "macro-utils",
 ]
 
 [[package]]
@@ -1021,6 +1089,17 @@ dependencies = [
  "mio-extras",
  "walkdir 2.3.2",
  "winapi 0.3.9",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e0d047c1062aa51e256408c560894e5251f08925980e53cf1aa5bd00eec6512"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
 ]
 
 [[package]]
@@ -1688,6 +1767,12 @@ dependencies = [
  "matches",
  "percent-encoding",
 ]
+
+[[package]]
+name = "utf8-width"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cf7d77f457ef8dfa11e4cd5933c5ddb5dc52a94664071951219a97710f0a32b"
 
 [[package]]
 name = "vec_map"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,6 +55,8 @@ mime_guess = { version = "2", optional = true }
 
 sass-rs = { version = "0.2", optional = true }
 
+html-minifier = {version="3.0", optional = true }
+
 [dependencies.syntect]
 version = "4.5.0"
 optional = true
@@ -68,7 +70,7 @@ predicates = "1.0"
 difference = "2.0"
 
 [features]
-default = ["syntax-highlight", "sass", "serve"]
+default = ["syntax-highlight", "sass", "serve", "html-minifier"]
 unstable = []
 
 serve = ["tiny_http", "notify", "mime_guess"]

--- a/src/cobalt.rs
+++ b/src/cobalt.rs
@@ -116,7 +116,9 @@ pub fn build(config: Config) -> Result<()> {
 
     // copy all remaining files in the source to the destination
     // compile SASS along the way
-    context.assets.populate(&context.destination)?;
+    context
+        .assets
+        .populate(&context.destination, context.minify)?;
 
     Ok(())
 }

--- a/src/cobalt.rs
+++ b/src/cobalt.rs
@@ -14,7 +14,7 @@ use crate::cobalt_model;
 use crate::cobalt_model::files;
 use crate::cobalt_model::permalink;
 use crate::cobalt_model::Collection;
-use crate::cobalt_model::{Config, SortOrder};
+use crate::cobalt_model::{Config, Minify, SortOrder};
 use crate::document::{Document, RenderContex};
 use crate::error::*;
 use crate::pagination;
@@ -30,7 +30,7 @@ struct Context {
     pub markdown: cobalt_model::Markdown,
     pub assets: cobalt_model::Assets,
     pub sitemap: Option<String>,
-    pub minify: bool,
+    pub minify: Minify,
 }
 
 impl Context {
@@ -118,7 +118,7 @@ pub fn build(config: Config) -> Result<()> {
     // compile SASS along the way
     context
         .assets
-        .populate(&context.destination, context.minify)?;
+        .populate(&context.destination, &context.minify)?;
 
     Ok(())
 }
@@ -169,7 +169,7 @@ fn generate_doc(
             parser: &context.liquid,
             markdown: &context.markdown,
             globals: &globals,
-            minify: context.minify,
+            minify: context.minify.clone(),
         };
 
         doc.render_excerpt(&render_context).with_context(|_| {
@@ -189,7 +189,7 @@ fn generate_doc(
         parser: &context.liquid,
         markdown: &context.markdown,
         globals: &globals,
-        minify: context.minify,
+        minify: context.minify.clone(),
     };
     let doc_html = doc
         .render(&render_context, &context.layouts)

--- a/src/cobalt_model/assets.rs
+++ b/src/cobalt_model/assets.rs
@@ -69,7 +69,7 @@ impl Assets {
             let dest_path = dest.join(rel_src);
             if sass::is_sass_file(file_path.as_path()) {
                 self.sass
-                    .compile_file(self.source(), dest, file_path.as_path())?;
+                    .compile_file(self.source(), dest, file_path.as_path(), minify)?;
             } else if file_path.extension() == Some(OsStr::new("js")) {
                 copy_and_minify_js(file_path.as_path(), dest_path.as_path(), minify.js)?;
             } else if file_path.extension() == Some(OsStr::new("css")) {
@@ -111,10 +111,6 @@ fn copy_and_minify_css(src_file: &path::Path, dest_file: &path::Path, minify: bo
 
 #[cfg(feature = "html-minifier")]
 fn copy_and_minify_js(src_file: &path::Path, dest_file: &path::Path, minify: bool) -> Result<()> {
-    debug!(
-        "pre Copying and minifying {:?} to {:?}",
-        src_file, dest_file
-    );
     if minify {
         use html_minifier::js::minify;
         // create target directories if any exist

--- a/src/cobalt_model/assets.rs
+++ b/src/cobalt_model/assets.rs
@@ -4,6 +4,8 @@ use super::files;
 use super::sass;
 
 use crate::error::*;
+use failure::ResultExt;
+use std::ffi::OsStr;
 
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 #[serde(deny_unknown_fields, default)]
@@ -55,22 +57,89 @@ impl Assets {
         &self.files
     }
 
-    pub fn populate<P: AsRef<path::Path>>(&self, dest: P) -> Result<()> {
-        self.populate_path(dest.as_ref())
+    pub fn populate<P: AsRef<path::Path>>(&self, dest: P, minify: bool) -> Result<()> {
+        self.populate_path(dest.as_ref(), minify)
     }
 
-    fn populate_path(&self, dest: &path::Path) -> Result<()> {
+    fn populate_path(&self, dest: &path::Path, minify: bool) -> Result<()> {
         for file_path in self.files() {
+            let rel_src = file_path
+                .strip_prefix(self.source())
+                .expect("file was found under the root");
+            let dest_path = dest.join(rel_src);
             if sass::is_sass_file(file_path.as_path()) {
-                self.sass.compile_file(self.source(), dest, file_path)?;
+                self.sass
+                    .compile_file(self.source(), dest, file_path.as_path())?;
+            } else if file_path.extension() == Some(OsStr::new("js")) {
+                copy_and_minify_js(file_path.as_path(), dest_path.as_path(), minify)?;
+            } else if file_path.extension() == Some(OsStr::new("css")) {
+                copy_and_minify_css(file_path.as_path(), dest_path.as_path(), minify)?;
             } else {
-                let rel_src = file_path
-                    .strip_prefix(self.source())
-                    .expect("file was found under the root");
-                files::copy_file(&file_path, dest.join(rel_src).as_path())?;
+                files::copy_file(&file_path, dest_path.as_path())?;
             }
         }
 
         Ok(())
     }
+}
+
+#[cfg(feature = "html-minifier")]
+fn copy_and_minify_css(src_file: &path::Path, dest_file: &path::Path, minify: bool) -> Result<()> {
+    if minify {
+        use html_minifier::css::minify;
+        // create target directories if any exist
+        if let Some(parent) = dest_file.parent() {
+            std::fs::create_dir_all(parent)
+                .with_context(|_| failure::format_err!("Could not create {}", parent.display()))?;
+        }
+
+        debug!("Copying and minifying {:?} to {:?}", src_file, dest_file);
+        let content = std::fs::read_to_string(src_file)?;
+        let minified = minify(&content).map_err(|e| {
+            failure::format_err!(
+                "Could not minify css file {} error {}",
+                src_file.to_string_lossy(),
+                e
+            )
+        })?;
+        std::fs::write(dest_file, minified)?;
+    } else {
+        files::copy_file(src_file, dest_file)?;
+    }
+    Ok(())
+}
+
+#[cfg(feature = "html-minifier")]
+fn copy_and_minify_js(src_file: &path::Path, dest_file: &path::Path, minify: bool) -> Result<()> {
+    debug!(
+        "pre Copying and minifying {:?} to {:?}",
+        src_file, dest_file
+    );
+    if minify {
+        use html_minifier::js::minify;
+        // create target directories if any exist
+        if let Some(parent) = dest_file.parent() {
+            std::fs::create_dir_all(parent)
+                .with_context(|_| failure::format_err!("Could not create {}", parent.display()))?;
+        }
+
+        debug!("Copying and minifying {:?} to {:?}", src_file, dest_file);
+        let content = std::fs::read_to_string(src_file)?;
+        std::fs::write(dest_file, minify(&content))?;
+    } else {
+        files::copy_file(src_file, dest_file)?;
+    }
+    Ok(())
+}
+
+#[cfg(not(feature = "html-minifier"))]
+fn copy_and_minify_css(src_file: &path::Path, dest_file: &path::Path, _minify: bool) -> Result<()> {
+    files::copy_file(src_file, dest_file)?;
+    Ok(())
+}
+
+#[cfg(not(feature = "html-minifier"))]
+fn copy_and_minify_js(src_file: &path::Path, dest_file: &path::Path, _minify: bool) -> Result<()> {
+    files::copy_file(src_file, dest_file)?;
+    Ok(())
 }

--- a/src/cobalt_model/assets.rs
+++ b/src/cobalt_model/assets.rs
@@ -1,7 +1,7 @@
 use std::path;
 
-use super::files;
 use super::sass;
+use super::{files, Minify};
 
 use crate::error::*;
 use failure::ResultExt;
@@ -57,11 +57,11 @@ impl Assets {
         &self.files
     }
 
-    pub fn populate<P: AsRef<path::Path>>(&self, dest: P, minify: bool) -> Result<()> {
+    pub fn populate<P: AsRef<path::Path>>(&self, dest: P, minify: &Minify) -> Result<()> {
         self.populate_path(dest.as_ref(), minify)
     }
 
-    fn populate_path(&self, dest: &path::Path, minify: bool) -> Result<()> {
+    fn populate_path(&self, dest: &path::Path, minify: &Minify) -> Result<()> {
         for file_path in self.files() {
             let rel_src = file_path
                 .strip_prefix(self.source())
@@ -71,9 +71,9 @@ impl Assets {
                 self.sass
                     .compile_file(self.source(), dest, file_path.as_path())?;
             } else if file_path.extension() == Some(OsStr::new("js")) {
-                copy_and_minify_js(file_path.as_path(), dest_path.as_path(), minify)?;
+                copy_and_minify_js(file_path.as_path(), dest_path.as_path(), minify.js)?;
             } else if file_path.extension() == Some(OsStr::new("css")) {
-                copy_and_minify_css(file_path.as_path(), dest_path.as_path(), minify)?;
+                copy_and_minify_css(file_path.as_path(), dest_path.as_path(), minify.css)?;
             } else {
                 files::copy_file(&file_path, dest_path.as_path())?;
             }

--- a/src/cobalt_model/config.rs
+++ b/src/cobalt_model/config.rs
@@ -265,6 +265,7 @@ pub struct ConfigBuilder {
     #[serde(skip)]
     pub includes_dir: &'static str,
     pub assets: AssetsConfig,
+    pub minify: bool,
 }
 
 impl Default for ConfigBuilder {
@@ -285,6 +286,7 @@ impl Default for ConfigBuilder {
             layouts_dir: "_layouts",
             includes_dir: "_includes",
             assets: AssetsConfig::default(),
+            minify: false,
         }
     }
 }
@@ -349,6 +351,7 @@ impl ConfigBuilder {
             layouts_dir,
             includes_dir,
             assets,
+            minify,
         } = self;
 
         if include_drafts {
@@ -419,6 +422,7 @@ impl ConfigBuilder {
             markdown,
             assets,
             sitemap,
+            minify,
         };
 
         Ok(config)
@@ -446,6 +450,7 @@ pub struct Config {
     pub markdown: mark::MarkdownBuilder,
     pub assets: assets::AssetsBuilder,
     pub sitemap: Option<String>,
+    pub minify: bool,
 }
 
 impl Default for Config {

--- a/src/cobalt_model/config.rs
+++ b/src/cobalt_model/config.rs
@@ -245,6 +245,24 @@ impl AssetsConfig {
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields, default)]
+pub struct Minify {
+    pub html: bool,
+    pub css: bool,
+    pub js: bool,
+}
+
+impl Default for Minify {
+    fn default() -> Self {
+        Minify {
+            html: false,
+            css: false,
+            js: false,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields, default)]
 pub struct ConfigBuilder {
     #[serde(skip)]
     pub root: path::PathBuf,
@@ -265,7 +283,7 @@ pub struct ConfigBuilder {
     #[serde(skip)]
     pub includes_dir: &'static str,
     pub assets: AssetsConfig,
-    pub minify: bool,
+    pub minify: Minify,
 }
 
 impl Default for ConfigBuilder {
@@ -286,7 +304,7 @@ impl Default for ConfigBuilder {
             layouts_dir: "_layouts",
             includes_dir: "_includes",
             assets: AssetsConfig::default(),
-            minify: false,
+            minify: Minify::default(),
         }
     }
 }
@@ -450,7 +468,7 @@ pub struct Config {
     pub markdown: mark::MarkdownBuilder,
     pub assets: assets::AssetsBuilder,
     pub sitemap: Option<String>,
-    pub minify: bool,
+    pub minify: Minify,
 }
 
 impl Default for Config {

--- a/src/cobalt_model/mod.rs
+++ b/src/cobalt_model/mod.rs
@@ -22,6 +22,7 @@ pub use self::collection::SortOrder;
 pub use self::config::AssetsConfig;
 pub use self::config::Config;
 pub use self::config::ConfigBuilder;
+pub use self::config::Minify;
 pub use self::config::PageConfig;
 pub use self::config::PostConfig;
 pub use self::config::SassConfig;

--- a/src/document.rs
+++ b/src/document.rs
@@ -18,13 +18,14 @@ use crate::cobalt_model;
 use crate::cobalt_model::files;
 use crate::cobalt_model::permalink;
 use crate::cobalt_model::slug;
+use crate::cobalt_model::Minify;
 use crate::error::*;
 
 pub struct RenderContex<'a> {
     pub parser: &'a cobalt_model::Liquid,
     pub markdown: &'a cobalt_model::Markdown,
     pub globals: &'a Object,
-    pub minify: bool,
+    pub minify: Minify,
 }
 
 #[cfg(not(feature = "html-minifier"))]
@@ -34,7 +35,7 @@ fn minify_if_enabled(html: String, _context: &RenderContex) -> Result<String> {
 
 #[cfg(feature = "html-minifier")]
 fn minify_if_enabled(html: String, context: &RenderContex) -> Result<String> {
-    if context.minify {
+    if context.minify.html {
         Ok(html_minifier::minify(html)?)
     } else {
         Ok(html)

--- a/src/document.rs
+++ b/src/document.rs
@@ -20,6 +20,27 @@ use crate::cobalt_model::permalink;
 use crate::cobalt_model::slug;
 use crate::error::*;
 
+pub struct RenderContex<'a> {
+    pub parser: &'a cobalt_model::Liquid,
+    pub markdown: &'a cobalt_model::Markdown,
+    pub globals: &'a Object,
+    pub minify: bool,
+}
+
+#[cfg(not(feature = "html-minifier"))]
+fn minify_if_enabled(html: String, _context: &RenderContex) -> Result<String> {
+    Ok(html)
+}
+
+#[cfg(feature = "html-minifier")]
+fn minify_if_enabled(html: String, context: &RenderContex) -> Result<String> {
+    if context.minify {
+        Ok(html_minifier::minify(html)?)
+    } else {
+        Ok(html)
+    }
+}
+
 /// Convert the source file's relative path into a format useful for generating permalinks that
 /// mirror the source directory hierarchy.
 fn format_path_variable(source_file: &Path) -> String {
@@ -298,20 +319,16 @@ impl Document {
     /// Takes `content` string and returns rendered HTML. This function doesn't
     /// take `"extends"` attribute into account. This function can be used for
     /// rendering content or excerpt.
-    fn render_html(
-        &self,
-        content: &str,
-        globals: &Object,
-        parser: &cobalt_model::Liquid,
-        markdown: &cobalt_model::Markdown,
-    ) -> Result<String> {
-        let template = parser.parse(content)?;
-        let html = template.render(globals)?;
+    fn render_html(&self, content: &str, context: &RenderContex) -> Result<String> {
+        let template = context.parser.parse(content)?;
+        let html = template.render(context.globals)?;
 
         let html = match self.front.format {
             cobalt_model::SourceFormat::Raw => html,
-            cobalt_model::SourceFormat::Markdown => markdown.parse(&html)?,
+            cobalt_model::SourceFormat::Markdown => context.markdown.parse(&html)?,
         };
+
+        let html = minify_if_enabled(html, context)?;
         Ok(html)
     }
 
@@ -321,14 +338,9 @@ impl Document {
     /// given, or extracted from the content, if `excerpt_separator` is not
     /// empty. When neither condition applies, the excerpt is set to the `Nil`
     /// value.
-    pub fn render_excerpt(
-        &mut self,
-        globals: &Object,
-        parser: &cobalt_model::Liquid,
-        markdown: &cobalt_model::Markdown,
-    ) -> Result<()> {
+    pub fn render_excerpt(&mut self, context: &RenderContex) -> Result<()> {
         let value = if let Some(excerpt_str) = self.front.excerpt.as_ref() {
-            let excerpt = self.render_html(excerpt_str, globals, parser, markdown)?;
+            let excerpt = self.render_html(excerpt_str, context)?;
             Value::scalar(excerpt)
         } else if self.front.excerpt_separator.is_empty() {
             Value::Nil
@@ -338,7 +350,7 @@ impl Document {
                 self.front.format,
                 &self.front.excerpt_separator,
             );
-            let excerpt = self.render_html(&excerpt, globals, parser, markdown)?;
+            let excerpt = self.render_html(&excerpt, context)?;
             Value::scalar(excerpt)
         };
 
@@ -349,13 +361,8 @@ impl Document {
     /// Renders the content and adds it to attributes of the document.
     ///
     /// When we say "content" we mean only this document without extended layout.
-    pub fn render_content(
-        &mut self,
-        globals: &Object,
-        parser: &cobalt_model::Liquid,
-        markdown: &cobalt_model::Markdown,
-    ) -> Result<()> {
-        let content_html = self.render_html(&self.content, globals, parser, markdown)?;
+    pub fn render_content(&mut self, context: &RenderContex) -> Result<()> {
+        let content_html = self.render_html(&self.content, context)?;
         self.attributes
             .insert("content".into(), Value::scalar(content_html));
         Ok(())
@@ -368,8 +375,7 @@ impl Document {
     /// * layout may be inserted to layouts cache
     pub fn render(
         &mut self,
-        globals: &Object,
-        parser: &cobalt_model::Liquid,
+        context: &RenderContex,
         layouts: &HashMap<String, String>,
     ) -> Result<String> {
         if let Some(ref layout) = self.front.layout {
@@ -381,23 +387,26 @@ impl Document {
                 )
             })?;
 
-            let template = parser
+            let template = context
+                .parser
                 .parse(layout_data_ref)
                 .with_context(|_| failure::format_err!("Failed to parse layout {:?}", layout))?;
             let content_html = template
-                .render(globals)
+                .render(context.globals)
                 .with_context(|_| failure::format_err!("Failed to render layout {:?}", layout))?;
+            let content_html = minify_if_enabled(content_html, context)?;
             Ok(content_html)
         } else {
             let path = &[
                 kstring::KStringCow::from_static("page").into(),
                 kstring::KStringCow::from_static("content").into(),
             ];
-            let content_html = liquid::model::try_find(globals, path)
+            let content_html = liquid::model::try_find(context.globals, path)
                 .ok_or_else(|| failure::err_msg("Internal error: page isn't in globals"))?
                 .render()
                 .to_string();
 
+            let content_html = minify_if_enabled(content_html, context)?;
             Ok(content_html)
         }
     }

--- a/tests/fixtures/example_minified/_cobalt.yml
+++ b/tests/fixtures/example_minified/_cobalt.yml
@@ -1,0 +1,1 @@
+minify: true

--- a/tests/fixtures/example_minified/_cobalt.yml
+++ b/tests/fixtures/example_minified/_cobalt.yml
@@ -1,1 +1,4 @@
-minify: true
+minify: 
+  html: true
+  css: true
+  js: true

--- a/tests/fixtures/example_minified/_layouts/default.liquid
+++ b/tests/fixtures/example_minified/_layouts/default.liquid
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>test</title>
+    </head>
+    <body>
+        <h1>{{ page.permalink }}</h1>
+
+        {{ page.content }}
+    </body>
+</html>
+

--- a/tests/fixtures/example_minified/_layouts/default.liquid
+++ b/tests/fixtures/example_minified/_layouts/default.liquid
@@ -2,6 +2,8 @@
 <html>
     <head>
         <title>test</title>
+        <link href="static/example.css" rel="stylesheed" />
+        <script src="static/example.js" type="javascript"></script>
     </head>
     <body>
         <h1>{{ page.permalink }}</h1>

--- a/tests/fixtures/example_minified/_layouts/posts.liquid
+++ b/tests/fixtures/example_minified/_layouts/posts.liquid
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>My blog - {{ page.title }}</title>
+    </head>
+    <body>
+        {{ page.content }}
+    </body>
+</html>
+

--- a/tests/fixtures/example_minified/index.liquid
+++ b/tests/fixtures/example_minified/index.liquid
@@ -1,0 +1,8 @@
+---
+layout: default.liquid
+---
+This is my Index page!
+
+{% for post in collections.posts.pages %}
+ <a href="{{post.permalink}}">{{ post.title }}</a>
+{% endfor %}

--- a/tests/fixtures/example_minified/posts/2014-08-24-my-first-blogpost.md
+++ b/tests/fixtures/example_minified/posts/2014-08-24-my-first-blogpost.md
@@ -1,0 +1,11 @@
+---
+layout: posts.liquid
+
+title:   My first Blogpost
+published_date:    2014-08-24 15:36:20 +0100
+---
+# {{ page.title }}
+
+Hey there this is my first blogpost and this is super awesome.
+
+My Blog is lorem ipsum like, yes it is..

--- a/tests/fixtures/example_minified/static/example.css
+++ b/tests/fixtures/example_minified/static/example.css
@@ -1,0 +1,5 @@
+
+.title {
+    color:blue;
+}
+

--- a/tests/fixtures/example_minified/static/example.js
+++ b/tests/fixtures/example_minified/static/example.js
@@ -1,0 +1,4 @@
+
+function simpleFunction() {
+    return 'text';
+}

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -146,6 +146,7 @@ pub fn example() {
     test_with_expected("example").expect("Build error");
 }
 
+#[cfg(feature = "html-minifier")]
 #[test]
 pub fn example_minified() {
     test_with_expected("example_minified").expect("Build error");

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -147,6 +147,11 @@ pub fn example() {
 }
 
 #[test]
+pub fn example_minified() {
+    test_with_expected("example_minified").expect("Build error");
+}
+
+#[test]
 pub fn hidden_posts_folder() {
     test_with_expected("hidden_posts_folder").expect("Build error");
 }

--- a/tests/target/example_minified/index.html
+++ b/tests/target/example_minified/index.html
@@ -2,6 +2,8 @@
 <html>
 <head>
 <title>test</title>
+<link href="static/example.css" rel="stylesheed"/>
+<script src="static/example.js" type="javascript"></script>
 </head>
 <body>
 <h1>index.html</h1>

--- a/tests/target/example_minified/index.html
+++ b/tests/target/example_minified/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>test</title>
+</head>
+<body>
+<h1>index.html</h1>
+This is my Index page!
+<a href="posts/2014-08-24-my-first-blogpost.html">My first Blogpost</a>
+</body>
+</html>

--- a/tests/target/example_minified/posts/2014-08-24-my-first-blogpost.html
+++ b/tests/target/example_minified/posts/2014-08-24-my-first-blogpost.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>My blog - My first Blogpost</title>
+</head>
+<body>
+<h1>My first Blogpost</h1>
+<p>Hey there this is my first blogpost and this is super awesome.</p>
+<p>My Blog is lorem ipsum like, yes it is..</p>
+</body>
+</html>

--- a/tests/target/example_minified/static/example.css
+++ b/tests/target/example_minified/static/example.css
@@ -1,0 +1,1 @@
+.title{color:blue;}

--- a/tests/target/example_minified/static/example.js
+++ b/tests/target/example_minified/static/example.js
@@ -1,0 +1,1 @@
+function simpleFunction(){return'text'}


### PR DESCRIPTION
- Minifies rendered documents
- Minifies js, and css assets

Minification is disabled by default, for backward and text compatibility.  This can be changed on an extension-by-extension basis.

This doesn't touch the unused config crate.