### PR TITLE
refactor(core): Pull out file walking 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -353,7 +353,13 @@ name = "cobalt-core"
 version = "0.16.0"
 dependencies = [
  "cobalt-config",
+ "ignore",
+ "liquid-core",
+ "log",
+ "once_cell",
+ "serde",
  "status",
+ "walkdir 2.3.2",
 ]
 
 [[package]]

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -16,4 +16,10 @@ preview_unstable = []
 
 [dependencies]
 cobalt-config = { version = "=0.16.0", path = "..//config", features = ["unstable"] }
+ignore = "0.4"
+walkdir = "2.2"
+liquid-core = "0.22"
+log = "0.4"
+serde = "1.0"
+once_cell = "1.2"
 status = { version = "0.0.10", features = ["send_sync"] }

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -1,2 +1,6 @@
-pub type Status = status::Status;
-pub type Result<T, E = Status> = std::result::Result<T, E>;
+mod source;
+
+pub use source::*;
+
+type Status = status::Status;
+type Result<T, E = Status> = std::result::Result<T, E>;

--- a/crates/core/src/source.rs
+++ b/crates/core/src/source.rs
@@ -94,6 +94,7 @@ impl Source {
 }
 
 #[cfg(test)]
+#[allow(clippy::bool_assert_comparison)]
 mod tests {
     use super::*;
 

--- a/crates/core/src/source.rs
+++ b/crates/core/src/source.rs
@@ -1,0 +1,169 @@
+use crate::Result;
+use crate::Status;
+
+#[derive(Debug, Clone)]
+pub struct Source {
+    root: std::path::PathBuf,
+    ignore: ignore::gitignore::Gitignore,
+}
+
+impl Source {
+    pub fn new<'i>(
+        root: &std::path::Path,
+        ignores: impl IntoIterator<Item = &'i str>,
+    ) -> Result<Self> {
+        let mut ignore = ignore::gitignore::GitignoreBuilder::new(root);
+        for line in ignores.into_iter() {
+            ignore
+                .add_line(None, line)
+                .map_err(|e| Status::new("Invalid ignore entry").with_source(e))?;
+        }
+        let ignore = ignore
+            .build()
+            .map_err(|e| Status::new("Invalid ignore entry").with_source(e))?;
+
+        let source = Self {
+            root: root.to_owned(),
+            ignore,
+        };
+        Ok(source)
+    }
+
+    pub fn root(&self) -> &std::path::Path {
+        &self.root
+    }
+
+    pub fn includes_file(&self, file: &std::path::Path) -> bool {
+        let is_dir = false;
+        self.includes_path(file, is_dir)
+    }
+
+    pub fn includes_dir(&self, dir: &std::path::Path) -> bool {
+        let is_dir = true;
+        self.includes_path(dir, is_dir)
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item = std::path::PathBuf> + '_ {
+        walkdir::WalkDir::new(&self.root)
+            .min_depth(1)
+            .follow_links(false)
+            .sort_by_file_name()
+            .into_iter()
+            .filter_entry(move |e| self.includes_entry(e))
+            .filter_map(|e| e.ok())
+            .filter(|e| e.file_type().is_file())
+            .map(move |e| e.path().to_path_buf())
+    }
+
+    fn includes_path(&self, path: &std::path::Path, is_dir: bool) -> bool {
+        if path == self.root {
+            return true;
+        }
+
+        let parent = path.parent();
+        if let Some(parent) = parent {
+            if parent.starts_with(&self.root) && !self.includes_path(parent, parent.is_dir()) {
+                return false;
+            }
+        }
+
+        self.includes_path_leaf(path, is_dir)
+    }
+
+    fn includes_path_leaf(&self, path: &std::path::Path, is_dir: bool) -> bool {
+        match self.ignore.matched(path, is_dir) {
+            ignore::Match::None => true,
+            ignore::Match::Ignore(glob) => {
+                log::trace!("{:?}: ignored {:?}", path, glob.original());
+                false
+            }
+            ignore::Match::Whitelist(glob) => {
+                log::trace!("{:?}: allowed {:?}", path, glob.original());
+                true
+            }
+        }
+    }
+
+    fn includes_entry(&self, entry: &walkdir::DirEntry) -> bool {
+        let file = entry.path();
+
+        // Assumption: The parent paths will have been checked before we even get to this point.
+        let is_dir = entry.file_type().is_dir();
+        self.includes_path_leaf(file, is_dir)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    macro_rules! assert_includes_dir {
+        ($root:expr, $ignores:expr, $test:expr, $included:expr) => {
+            let root = $root;
+            let ignores = $ignores.clone();
+            let files = Source::new(std::path::Path::new(root), ignores).unwrap();
+            assert_eq!(files.includes_dir(std::path::Path::new($test)), $included);
+        };
+    }
+    macro_rules! assert_includes_file {
+        ($root:expr, $ignores:expr, $test:expr, $included:expr) => {
+            let root = $root;
+            let ignores = $ignores.clone();
+            let files = Source::new(std::path::Path::new(root), ignores).unwrap();
+            assert_eq!(files.includes_file(std::path::Path::new($test)), $included);
+        };
+    }
+
+    #[test]
+    fn files_includes_root_dir() {
+        assert_includes_dir!("/usr/cobalt/site", &[], "/usr/cobalt/site", true);
+
+        assert_includes_dir!("./", &[], "./", true);
+    }
+
+    #[test]
+    fn files_includes_child_dir() {
+        assert_includes_dir!("/usr/cobalt/site", &[], "/usr/cobalt/site/child", true);
+
+        assert_includes_dir!("./", &[], "./child", true);
+    }
+
+    #[test]
+    fn files_includes_file() {
+        assert_includes_file!("/usr/cobalt/site", &[], "/usr/cobalt/site/child.txt", true);
+
+        assert_includes_file!("./", &[], "./child.txt", true);
+    }
+
+    #[test]
+    fn files_ignore_hidden() {
+        assert_includes_file!(
+            "/usr/cobalt/site",
+            &[".*"],
+            "/usr/cobalt/site/.child.txt",
+            false
+        );
+    }
+
+    #[test]
+    fn files_not_ignored_by_parent() {
+        assert_includes_file!(
+            "/tmp/.foo/cobalt/site",
+            &[".*"],
+            "/tmp/.foo/cobalt/site/child.txt",
+            true
+        );
+    }
+
+    #[test]
+    fn files_includes_child_dir_file() {
+        assert_includes_file!(
+            "/usr/cobalt/site",
+            &[],
+            "/usr/cobalt/site/child/child.txt",
+            true
+        );
+
+        assert_includes_file!("./", &[], "./child/child.txt", true);
+    }
+}

--- a/src/bin/cobalt/args.rs
+++ b/src/bin/cobalt/args.rs
@@ -2,8 +2,6 @@ use std::env;
 use std::io::Write;
 use std::path;
 
-use clap;
-use env_logger;
 use failure::ResultExt;
 
 use crate::error::*;

--- a/src/bin/cobalt/build.rs
+++ b/src/bin/cobalt/build.rs
@@ -2,10 +2,6 @@ use std::env;
 use std::fs;
 use std::path;
 
-use clap;
-use cobalt;
-use ghp;
-
 use crate::args;
 use crate::error::*;
 

--- a/src/bin/cobalt/debug.rs
+++ b/src/bin/cobalt/debug.rs
@@ -52,35 +52,22 @@ pub fn debug_command(matches: &clap::ArgMatches) -> Result<()> {
             let collection = matches.value_of("COLLECTION");
             match collection {
                 Some("assets") => {
-                    let assets = config.assets.build()?;
-                    for file_path in assets.files() {
-                        println!("{:?}", file_path);
-                    }
+                    failure::bail!("TODO Re-implement");
                 }
                 Some("pages") => {
-                    let pages = config.pages.build()?;
-                    for file_path in pages.pages.files() {
-                        println!("{:?}", file_path);
-                    }
-                    if let Some(ref drafts) = pages.drafts {
-                        for file_path in drafts.files() {
-                            println!("{:?}", file_path);
-                        }
-                    }
+                    failure::bail!("TODO Re-implement");
                 }
                 Some("posts") => {
-                    let posts = config.posts.build()?;
-                    for file_path in posts.pages.files() {
-                        println!("{:?}", file_path);
-                    }
-                    if let Some(ref drafts) = posts.drafts {
-                        for file_path in drafts.files() {
-                            println!("{:?}", file_path);
-                        }
-                    }
+                    failure::bail!("TODO Re-implement");
                 }
                 None => {
-                    failure::bail!("Must specify collection");
+                    let source_files = cobalt_core::Source::new(
+                        &config.source,
+                        config.ignore.iter().map(|s| s.as_str()),
+                    )?;
+                    for path in source_files.iter() {
+                        println!("{}", path.display());
+                    }
                 }
                 _ => {
                     failure::bail!("Collection is not yet supported");

--- a/src/bin/cobalt/debug.rs
+++ b/src/bin/cobalt/debug.rs
@@ -1,6 +1,3 @@
-use clap;
-use cobalt;
-
 use crate::args;
 use crate::error::*;
 

--- a/src/bin/cobalt/new.rs
+++ b/src/bin/cobalt/new.rs
@@ -5,7 +5,6 @@ use std::fs;
 use std::io::Write;
 use std::path;
 
-use clap;
 use cobalt::cobalt_model;
 use failure::ResultExt;
 

--- a/src/bin/cobalt/serve.rs
+++ b/src/bin/cobalt/serve.rs
@@ -6,12 +6,9 @@ use std::sync::mpsc::channel;
 use std::thread;
 use std::time;
 
-use clap;
 use cobalt::cobalt_model;
 use failure::ResultExt;
-use notify;
 use notify::Watcher;
-use open;
 use tiny_http::{Request, Response, Server};
 
 use crate::args;

--- a/src/cobalt.rs
+++ b/src/cobalt.rs
@@ -22,6 +22,9 @@ use crate::pagination;
 struct Context {
     pub source: path::PathBuf,
     pub destination: path::PathBuf,
+    pub source_files: cobalt_core::Source,
+    pub page_extensions: Vec<String>,
+    pub include_drafts: bool,
     pub pages: cobalt_model::Collection,
     pub posts: cobalt_model::Collection,
     pub site: cobalt_model::Site,
@@ -39,6 +42,9 @@ impl Context {
         let Config {
             source,
             destination,
+            ignore,
+            page_extensions,
+            include_drafts,
             pages,
             posts,
             site,
@@ -50,8 +56,7 @@ impl Context {
             minify,
         } = config;
 
-        let pages = pages.build()?;
-        let posts = posts.build()?;
+        let source_files = cobalt_core::Source::new(&source, ignore.iter().map(|s| s.as_str()))?;
         let site_attributes = site.load(&source)?;
         let liquid = liquid.build()?;
         let markdown = markdown.build();
@@ -64,6 +69,9 @@ impl Context {
         let context = Context {
             source,
             destination,
+            source_files,
+            page_extensions,
+            include_drafts,
             pages,
             posts,
             site,
@@ -83,35 +91,81 @@ impl Context {
 pub fn build(config: Config) -> Result<()> {
     let context = Context::with_config(config)?;
 
-    let post_files = &context.posts.pages;
-    let mut posts = parse_pages(post_files, &context.posts, &context.source)?;
-    if let Some(ref drafts) = context.posts.drafts {
-        let drafts_root = drafts.subtree();
-        parse_drafts(drafts_root, drafts, &mut posts, &context.posts)?;
+    let mut post_paths = Vec::new();
+    let mut post_draft_paths = Vec::new();
+    let mut page_paths = Vec::new();
+    let mut asset_paths = Vec::new();
+    for path in context.source_files.iter() {
+        match classify_path(
+            &path,
+            &context.source_files,
+            &context.pages,
+            &context.posts,
+            &context.page_extensions,
+        ) {
+            Some((slug, false)) if slug == context.pages.slug => page_paths.push(path),
+            Some((slug, true)) if slug == context.pages.slug => {
+                unreachable!("We don't support draft pages")
+            }
+            Some((slug, false)) if slug == context.posts.slug => post_paths.push(path),
+            Some((slug, true)) if slug == context.posts.slug => post_draft_paths.push(path),
+            Some((slug, _)) => unreachable!("Unknown collection: {}", slug),
+            None => asset_paths.push(path),
+        }
     }
 
-    let page_files = &context.pages.pages;
-    let documents = parse_pages(page_files, &context.pages, &context.source)?;
+    let mut posts = parse_pages(
+        &post_paths,
+        &context.posts,
+        &context.source,
+        context.include_drafts,
+    )?;
+    if !post_draft_paths.is_empty() {
+        parse_drafts(
+            &post_draft_paths,
+            &mut posts,
+            &context.posts,
+            &context.source,
+        )?;
+    }
+
+    let documents = parse_pages(
+        &page_paths,
+        &context.pages,
+        &context.source,
+        context.include_drafts,
+    )?;
 
     sort_pages(&mut posts, &context.posts)?;
     generate_posts(&mut posts, &context)?;
 
     // check if we should create an RSS file and create it!
     if let Some(ref path) = context.posts.rss {
-        create_rss(path, &context.destination, &context.posts, &posts)?;
+        create_rss(
+            path,
+            &context.destination,
+            &context.posts,
+            &posts,
+            context.site.base_url.as_deref(),
+        )?;
     }
     // check if we should create an jsonfeed file and create it!
     if let Some(ref path) = context.posts.jsonfeed {
-        create_jsonfeed(path, &context.destination, &context.posts, &posts)?;
+        create_jsonfeed(
+            path,
+            &context.destination,
+            &context.posts,
+            &posts,
+            context.site.base_url.as_deref(),
+        )?;
     }
     if let Some(ref path) = context.site.sitemap {
         let sitemap_path = &context.destination.join(path);
         create_sitemap(
             &sitemap_path,
-            &context.posts,
             &posts,
-            &context.pages,
             &documents,
+            context.site.base_url.as_deref(),
         )?;
     }
 
@@ -119,9 +173,11 @@ pub fn build(config: Config) -> Result<()> {
 
     // copy all remaining files in the source to the destination
     // compile SASS along the way
-    context
-        .assets
-        .populate(&context.destination, &context.minify)?;
+    for asset_path in asset_paths {
+        context
+            .assets
+            .process(&asset_path, &context.destination, &context.minify)?;
+    }
 
     Ok(())
 }
@@ -130,7 +186,7 @@ fn generate_collections_var(
     posts_data: &[liquid::model::Value],
     context: &Context,
 ) -> (kstring::KString, liquid::model::Value) {
-    let mut posts_variable = context.posts.attributes.clone();
+    let mut posts_variable = context.posts.attributes();
     posts_variable.insert(
         "pages".into(),
         liquid::model::Value::Array(posts_data.to_vec()),
@@ -313,22 +369,25 @@ fn sort_pages(posts: &mut Vec<Document>, collection: &Collection) -> Result<()> 
 }
 
 fn parse_drafts(
-    drafts_root: &path::Path,
-    draft_files: &files::Files,
+    page_paths: &[std::path::PathBuf],
     documents: &mut Vec<Document>,
     collection: &Collection,
+    source: &path::Path,
 ) -> Result<()> {
-    let rel_real = collection
-        .pages
-        .subtree()
-        .strip_prefix(collection.pages.root())
-        .expect("subtree is under root");
-    for file_path in draft_files.files() {
+    let dir = std::path::Path::new(&collection.dir);
+    let drafts_dir = std::path::Path::new(
+        collection
+            .drafts_dir
+            .as_deref()
+            .expect("Caller checked first"),
+    );
+    let drafts_root = source.join(drafts_dir);
+    for file_path in page_paths {
         // Provide a fake path as if it was not a draft
         let rel_src = file_path
             .strip_prefix(&drafts_root)
             .expect("file was found under the root");
-        let new_path = rel_real.join(rel_src);
+        let new_path = dir.join(rel_src);
 
         let default_front = cobalt_config::Frontmatter {
             is_draft: Some(true),
@@ -344,12 +403,13 @@ fn parse_drafts(
 }
 
 fn parse_pages(
-    page_files: &files::Files,
+    page_paths: &[std::path::PathBuf],
     collection: &Collection,
     source: &path::Path,
+    include_drafts: bool,
 ) -> Result<Vec<Document>> {
     let mut documents = vec![];
-    for file_path in page_files.files() {
+    for file_path in page_paths {
         let rel_src = file_path
             .strip_prefix(source)
             .expect("file was found under the root");
@@ -358,8 +418,10 @@ fn parse_pages(
 
         let doc = Document::parse(&file_path, rel_src, default_front)
             .with_context(|_| failure::format_err!("Failed to parse {}", rel_src.display()))?;
-        if !doc.front.is_draft || collection.include_drafts {
+        if !doc.front.is_draft || include_drafts {
             documents.push(doc);
+        } else {
+            log::trace!("Skipping draft {}", file_path.display());
         }
     }
     Ok(documents)
@@ -410,14 +472,14 @@ fn create_rss(
     dest: &path::Path,
     collection: &Collection,
     documents: &[Document],
+    base_url: Option<&str>,
 ) -> Result<()> {
     let rss_path = dest.join(path);
     debug!("Creating RSS file at {}", rss_path.display());
 
     let title = &collection.title;
     let description = collection.description.as_deref().unwrap_or("");
-    let link = collection
-        .base_url
+    let link = base_url
         .as_ref()
         .ok_or_else(|| failure::err_msg("`base_url` is required for RSS support"))?;
 
@@ -454,14 +516,14 @@ fn create_jsonfeed(
     dest: &path::Path,
     collection: &Collection,
     documents: &[Document],
+    base_url: Option<&str>,
 ) -> Result<()> {
     let jsonfeed_path = dest.join(path);
     debug!("Creating jsonfeed file at {}", jsonfeed_path.display());
 
     let title = &collection.title;
     let description = collection.description.as_deref().unwrap_or("");
-    let link = collection
-        .base_url
+    let link = base_url
         .as_ref()
         .ok_or_else(|| failure::err_msg("`base_url` is required for jsonfeed support"))?;
 
@@ -480,18 +542,17 @@ fn create_jsonfeed(
 
     Ok(())
 }
+
 fn create_sitemap(
     sitemap_path: &path::Path,
-    collection: &Collection,
     documents: &[Document],
-    collection_pages: &Collection,
     documents_pages: &[Document],
+    base_url: Option<&str>,
 ) -> Result<()> {
     debug!("Creating sitemap file at {}", sitemap_path.display());
     let mut buff = Vec::new();
     let writer = SiteMapWriter::new(&mut buff);
-    let link = collection
-        .base_url
+    let link = base_url
         .as_ref()
         .ok_or_else(|| failure::err_msg("`base_url` is required for sitemap support"))?;
     let mut urls = writer.start_urlset()?;
@@ -499,8 +560,7 @@ fn create_sitemap(
         doc.to_sitemap(link, &mut urls)?;
     }
 
-    let link = collection_pages
-        .base_url
+    let link = base_url
         .as_ref()
         .ok_or_else(|| failure::err_msg("`base_url` is required for sitemap support"))?;
     for doc in documents_pages {
@@ -511,4 +571,41 @@ fn create_sitemap(
     files::write_document_file(String::from_utf8(buff)?, sitemap_path)?;
 
     Ok(())
+}
+
+pub fn classify_path<'s>(
+    path: &std::path::Path,
+    source: &cobalt_core::Source,
+    pages: &'s cobalt_model::Collection,
+    posts: &'s cobalt_model::Collection,
+    page_extensions: &[String],
+) -> Option<(&'s str, bool)> {
+    if ext_contains(&page_extensions, &path) {
+        let relpath = path.strip_prefix(source.root()).unwrap();
+        loop {
+            if relpath.starts_with(std::path::Path::new(&posts.dir)) {
+                return Some((posts.slug.as_str(), false));
+            }
+
+            if let Some(drafts_dir) = posts.drafts_dir.as_ref() {
+                if relpath.starts_with(std::path::Path::new(drafts_dir)) {
+                    return Some((posts.slug.as_str(), true));
+                }
+            }
+
+            return Some((pages.slug.as_str(), false));
+        }
+    } else {
+        return None;
+    }
+}
+
+fn ext_contains(extensions: &[String], file: &path::Path) -> bool {
+    if extensions.is_empty() {
+        return true;
+    }
+
+    file.extension()
+        .map(|ext| extensions.iter().any(|e| std::ffi::OsStr::new(e) == ext))
+        .unwrap_or(false)
 }

--- a/src/cobalt.rs
+++ b/src/cobalt.rs
@@ -4,10 +4,7 @@ use std::io::Write;
 use std::path;
 
 use failure::ResultExt;
-use jsonfeed;
 use jsonfeed::Feed;
-use liquid;
-use rss;
 use sitemap::writer::SiteMapWriter;
 
 use crate::cobalt_model;
@@ -582,21 +579,19 @@ pub fn classify_path<'s>(
 ) -> Option<(&'s str, bool)> {
     if ext_contains(&page_extensions, &path) {
         let relpath = path.strip_prefix(source.root()).unwrap();
-        loop {
-            if relpath.starts_with(std::path::Path::new(&posts.dir)) {
-                return Some((posts.slug.as_str(), false));
-            }
-
-            if let Some(drafts_dir) = posts.drafts_dir.as_ref() {
-                if relpath.starts_with(std::path::Path::new(drafts_dir)) {
-                    return Some((posts.slug.as_str(), true));
-                }
-            }
-
-            return Some((pages.slug.as_str(), false));
+        if relpath.starts_with(std::path::Path::new(&posts.dir)) {
+            return Some((posts.slug.as_str(), false));
         }
+
+        if let Some(drafts_dir) = posts.drafts_dir.as_ref() {
+            if relpath.starts_with(std::path::Path::new(drafts_dir)) {
+                return Some((posts.slug.as_str(), true));
+            }
+        }
+
+        Some((pages.slug.as_str(), false))
     } else {
-        return None;
+        None
     }
 }
 

--- a/src/cobalt_model/collection.rs
+++ b/src/cobalt_model/collection.rs
@@ -91,8 +91,8 @@ impl Collection {
             order,
             rss,
             jsonfeed,
-            default,
             publish_date_in_filename,
+            default,
         };
         Ok(new)
     }

--- a/src/cobalt_model/collection.rs
+++ b/src/cobalt_model/collection.rs
@@ -1,73 +1,42 @@
-use std::path;
-
 use cobalt_config::Frontmatter;
 use cobalt_config::SortOrder;
 use liquid;
 
-use super::files;
-use super::slug;
 use crate::error::*;
 
-#[derive(Clone, Default, Debug, PartialEq, Serialize, Deserialize)]
-#[serde(deny_unknown_fields, default)]
-pub struct CollectionBuilder {
-    pub title: Option<String>,
-    pub slug: Option<String>,
+#[derive(Clone, Debug, PartialEq, Eq, serde::Serialize)]
+pub struct Collection {
+    pub title: String,
+    pub slug: String,
     pub description: Option<String>,
-    pub source: Option<path::PathBuf>,
-    pub dir: Option<String>,
+    pub dir: String,
     pub drafts_dir: Option<String>,
-    pub include_drafts: bool,
-    pub template_extensions: Vec<String>,
-    pub ignore: Vec<String>,
     pub order: SortOrder,
     pub rss: Option<String>,
     pub jsonfeed: Option<String>,
-    pub base_url: Option<String>,
     pub publish_date_in_filename: bool,
     pub default: Frontmatter,
 }
 
-impl CollectionBuilder {
+impl Collection {
     pub fn from_page_config(
         config: cobalt_config::PageCollection,
-        source: &path::Path,
         site: &cobalt_config::Site,
-        posts: &cobalt_config::PostCollection,
         common_default: &cobalt_config::Frontmatter,
-        ignore: &[String],
-        template_extensions: &[String],
-    ) -> Self {
-        let mut ignore = ignore.to_vec();
-        ignore.push(format!("/{}", posts.dir));
-        if let Some(ref drafts_dir) = posts.drafts_dir {
-            ignore.push(format!("/{}", drafts_dir));
-        }
+    ) -> Result<Self> {
         let mut config: cobalt_config::Collection = config.into();
         // Use `site` because the pages are effectively the site
         config.title = Some(site.title.clone().unwrap_or_else(|| "".to_owned()));
         config.description = site.description.clone();
-        Self::from_config(
-            config,
-            "pages",
-            false,
-            source,
-            site,
-            common_default,
-            ignore,
-            template_extensions,
-        )
+        Self::from_config(config, "pages", false, common_default)
     }
 
     pub fn from_post_config(
         config: cobalt_config::PostCollection,
-        source: &path::Path,
         site: &cobalt_config::Site,
         include_drafts: bool,
         common_default: &cobalt_config::Frontmatter,
-        ignore: &[String],
-        template_extensions: &[String],
-    ) -> Self {
+    ) -> Result<Self> {
         let mut config: cobalt_config::Collection = config.into();
         // Default with `site` for people quickly bootstrapping a blog, the blog and site are
         // effectively equivalent.
@@ -77,28 +46,15 @@ impl CollectionBuilder {
         if config.description.is_none() {
             config.description = site.description.clone();
         }
-        Self::from_config(
-            config,
-            "posts",
-            include_drafts,
-            source,
-            site,
-            common_default,
-            ignore.to_vec(),
-            template_extensions,
-        )
+        Self::from_config(config, "posts", include_drafts, common_default)
     }
 
     fn from_config(
         config: cobalt_config::Collection,
         slug: &str,
         include_drafts: bool,
-        source: &path::Path,
-        site: &cobalt_config::Site,
         common_default: &cobalt_config::Frontmatter,
-        ignore: Vec<String>,
-        template_extensions: &[String],
-    ) -> Self {
+    ) -> Result<Self> {
         let cobalt_config::Collection {
             title,
             description,
@@ -107,86 +63,21 @@ impl CollectionBuilder {
             order,
             rss,
             jsonfeed,
-            publish_date_in_filename,
             default,
+            publish_date_in_filename,
         } = config;
-        Self {
-            title: title,
-            slug: Some(slug.to_owned()),
-            description: description,
-            source: Some(source.to_owned()),
-            dir: dir.map(|p| p.to_string()),
-            drafts_dir: drafts_dir.map(|p| p.to_string()),
-            include_drafts,
-            template_extensions: template_extensions.to_vec(),
-            ignore,
-            order,
-            rss,
-            jsonfeed,
-            base_url: site.base_url.clone(),
-            publish_date_in_filename,
-            default: default.merge(&common_default),
-        }
-    }
-
-    pub fn merge_frontmatter(mut self, secondary: &Frontmatter) -> Self {
-        self.default = self.default.merge(secondary);
-        self
-    }
-
-    pub fn build(self) -> Result<Collection> {
-        let CollectionBuilder {
-            title,
-            slug,
-            description,
-            source,
-            dir,
-            drafts_dir,
-            include_drafts,
-            template_extensions,
-            ignore,
-            order,
-            rss,
-            jsonfeed,
-            base_url,
-            default,
-            ..
-        } = self;
 
         let title = title.ok_or_else(|| failure::err_msg("Collection is missing a `title`"))?;
-        let slug = slug.unwrap_or_else(|| slug::slugify(&title));
+        let slug = slug.to_owned();
 
-        let source = source.ok_or_else(|| failure::err_msg("No asset source provided"))?;
+        let dir = dir.map(|p| p.to_string()).unwrap_or_else(|| slug.clone());
+        let drafts_dir = if include_drafts {
+            drafts_dir.map(|p| p.to_string())
+        } else {
+            None
+        };
 
-        let dir = dir.unwrap_or_else(|| slug.clone());
-        let pages = Self::build_files(&source, &dir, &template_extensions, &ignore)?;
-
-        let drafts_dir = if include_drafts { drafts_dir } else { None };
-        let drafts = drafts_dir
-            .map(|dir| Self::build_files(&source, &dir, &template_extensions, &ignore))
-            .map_or(Ok(None), |r| r.map(Some))?;
-
-        let mut attributes: liquid::Object = vec![
-            ("title".into(), liquid::model::Value::scalar(title.clone())),
-            ("slug".into(), liquid::model::Value::scalar(slug.clone())),
-            (
-                "description".into(),
-                liquid::model::Value::scalar(description.clone().unwrap_or_else(|| "".to_owned())),
-            ),
-        ]
-        .into_iter()
-        .collect();
-        if let Some(ref rss) = rss {
-            attributes.insert("rss".into(), liquid::model::Value::scalar(rss.to_owned()));
-        }
-        if let Some(ref jsonfeed) = jsonfeed {
-            attributes.insert(
-                "jsonfeed".into(),
-                liquid::model::Value::scalar(jsonfeed.to_owned()),
-            );
-        }
-
-        let default = default.merge(&Frontmatter {
+        let default = default.merge(common_default).merge(&Frontmatter {
             collection: Some(slug.clone()),
             ..Default::default()
         });
@@ -195,111 +86,45 @@ impl CollectionBuilder {
             title,
             slug,
             description,
-            pages,
-            drafts,
-            include_drafts,
+            dir,
+            drafts_dir,
             order,
             rss,
             jsonfeed,
-            base_url,
             default,
-            attributes,
+            publish_date_in_filename,
         };
         Ok(new)
     }
 
-    fn build_files(
-        source: &path::Path,
-        dir: &str,
-        template_extensions: &[String],
-        ignore: &[String],
-    ) -> Result<files::Files> {
-        if dir.starts_with('/') {
-            failure::bail!("Collection dir {} must be a relative path", dir)
+    pub fn attributes(&self) -> liquid::Object {
+        let mut attributes: liquid::Object = vec![
+            (
+                "title".into(),
+                liquid::model::Value::scalar(self.title.clone()),
+            ),
+            (
+                "slug".into(),
+                liquid::model::Value::scalar(self.slug.clone()),
+            ),
+            (
+                "description".into(),
+                liquid::model::Value::scalar(
+                    self.description.clone().unwrap_or_else(|| "".to_owned()),
+                ),
+            ),
+        ]
+        .into_iter()
+        .collect();
+        if let Some(rss) = self.rss.as_ref() {
+            attributes.insert("rss".into(), liquid::model::Value::scalar(rss.to_owned()));
         }
-        let dir = files::cleanup_path(dir);
-        let mut pages = files::FilesBuilder::new(source)?;
-        if !dir.is_empty() {
-            // In-case `dir` starts with `_`
-            pages
-                .add_ignore(&format!("!/{}", dir))?
-                .add_ignore(&format!("!/{}/**", dir))?
-                .add_ignore(&format!("/{}/**/_*", dir))?
-                .add_ignore(&format!("/{}/**/_*/**", dir))?;
-            pages.limit(path::PathBuf::from(dir))?;
+        if let Some(jsonfeed) = self.jsonfeed.as_ref() {
+            attributes.insert(
+                "jsonfeed".into(),
+                liquid::model::Value::scalar(jsonfeed.to_owned()),
+            );
         }
-        for line in ignore {
-            pages.add_ignore(line.as_str())?;
-        }
-        for ext in template_extensions {
-            pages.add_extension(ext)?;
-        }
-        pages.build()
-    }
-}
-
-#[derive(Clone, Debug)]
-pub struct Collection {
-    pub title: String,
-    pub slug: String,
-    pub description: Option<String>,
-    pub pages: files::Files,
-    pub drafts: Option<files::Files>,
-    pub include_drafts: bool,
-    pub order: SortOrder,
-    pub rss: Option<String>,
-    pub jsonfeed: Option<String>,
-    pub base_url: Option<String>,
-    pub default: Frontmatter,
-    pub attributes: liquid::Object,
-}
-
-#[cfg(test)]
-mod test {
-    use super::*;
-
-    #[test]
-    fn test_build_dir_rel() {
-        let mut collection = CollectionBuilder::default();
-        collection.source = Some(path::PathBuf::from("/"));
-        collection.title = Some("title".to_owned());
-        collection.dir = Some("rel".to_owned());
-        let collection = collection.build().unwrap();
-        assert_eq!(collection.pages.subtree(), path::Path::new("/rel"));
-    }
-
-    #[test]
-    fn test_build_dir_abs() {
-        let mut collection = CollectionBuilder::default();
-        collection.source = Some(path::PathBuf::from("/"));
-        collection.title = Some("title".to_owned());
-        collection.dir = Some("/root".to_owned());
-        let collection = collection.build();
-        assert!(collection.is_err());
-    }
-
-    #[test]
-    fn test_build_drafts_rel() {
-        let mut collection = CollectionBuilder::default();
-        collection.source = Some(path::PathBuf::from("/"));
-        collection.title = Some("title".to_owned());
-        collection.drafts_dir = Some("rel".to_owned());
-        collection.include_drafts = true;
-        let collection = collection.build().unwrap();
-        assert_eq!(
-            collection.drafts.unwrap().subtree(),
-            path::Path::new("/rel")
-        );
-    }
-
-    #[test]
-    fn test_build_drafts_abs() {
-        let mut collection = CollectionBuilder::default();
-        collection.source = Some(path::PathBuf::from("/"));
-        collection.title = Some("title".to_owned());
-        collection.drafts_dir = Some("/root".to_owned());
-        collection.include_drafts = true;
-        let collection = collection.build();
-        assert!(collection.is_err());
+        attributes
     }
 }

--- a/src/cobalt_model/config.rs
+++ b/src/cobalt_model/config.rs
@@ -83,7 +83,7 @@ impl Config {
         }
         ignore.push(format!("/{}", includes_dir));
         ignore.push(format!("/{}", layouts_dir));
-        ignore.push(format!("/_defaults"));
+        ignore.push("/_defaults".to_owned());
         ignore.push(format!("/{}", assets.sass.import_dir));
         assert_eq!(pages.dir, "");
         assert_eq!(pages.drafts_dir, None);

--- a/src/cobalt_model/files.rs
+++ b/src/cobalt_model/files.rs
@@ -2,7 +2,6 @@ use std::ffi;
 use std::fs;
 use std::io::Read;
 use std::io::Write;
-use std::iter::FromIterator;
 use std::path;
 
 use crate::error::Result;
@@ -263,7 +262,7 @@ pub fn read_file<P: AsRef<path::Path>>(path: P) -> Result<String> {
     let mut file = fs::File::open(path.as_ref())?;
     let mut text = String::new();
     file.read_to_string(&mut text)?;
-    let text = String::from_iter(normalized(text.chars()));
+    let text: String = normalized(text.chars()).collect();
     Ok(text)
 }
 

--- a/src/cobalt_model/frontmatter.rs
+++ b/src/cobalt_model/frontmatter.rs
@@ -73,7 +73,7 @@ impl Frontmatter {
             title: title.ok_or_else(|| failure::err_msg("No title"))?,
             description,
             excerpt,
-            categories: categories.unwrap_or_else(|| vec![]),
+            categories: categories.unwrap_or_else(Vec::new),
             tags,
             excerpt_separator: excerpt_separator.unwrap_or_else(|| "\n\n".to_owned()),
             published_date,

--- a/src/cobalt_model/mod.rs
+++ b/src/cobalt_model/mod.rs
@@ -24,7 +24,6 @@ pub use cobalt_config::SourceFormat;
 pub use self::assets::Assets;
 pub use self::assets::AssetsBuilder;
 pub use self::collection::Collection;
-pub use self::collection::CollectionBuilder;
 pub use self::config::Config;
 pub use self::frontmatter::Frontmatter;
 pub use self::mark::Markdown;

--- a/src/cobalt_model/pagination.rs
+++ b/src/cobalt_model/pagination.rs
@@ -54,8 +54,8 @@ impl PaginationConfig {
 }
 
 // TODO to be replaced by a call to `is_sorted()` once it's stabilized
-pub fn is_date_index_sorted(v: &Vec<DateIndex>) -> bool {
-    let mut copy = v.clone();
+pub fn is_date_index_sorted(v: &[DateIndex]) -> bool {
+    let mut copy = v.to_owned();
     copy.sort_unstable();
     copy.eq(v)
 }

--- a/src/cobalt_model/sass.rs
+++ b/src/cobalt_model/sass.rs
@@ -59,13 +59,15 @@ impl SassCompiler {
         file_path: &path::Path,
         minify: &Minify,
     ) -> Result<()> {
-        let mut sass_opts = sass_rs::Options::default();
-        sass_opts.include_paths = self.import_dir.iter().cloned().collect();
-        sass_opts.output_style = match self.style {
-            SassOutputStyle::Nested => sass_rs::OutputStyle::Nested,
-            SassOutputStyle::Expanded => sass_rs::OutputStyle::Expanded,
-            SassOutputStyle::Compact => sass_rs::OutputStyle::Compact,
-            SassOutputStyle::Compressed => sass_rs::OutputStyle::Compressed,
+        let sass_opts = sass_rs::Options {
+            include_paths: self.import_dir.iter().cloned().collect(),
+            output_style: match self.style {
+                SassOutputStyle::Nested => sass_rs::OutputStyle::Nested,
+                SassOutputStyle::Expanded => sass_rs::OutputStyle::Expanded,
+                SassOutputStyle::Compact => sass_rs::OutputStyle::Compact,
+                SassOutputStyle::Compressed => sass_rs::OutputStyle::Compressed,
+            },
+            ..Default::default()
         };
         let content = sass_rs::compile_file(file_path, sass_opts).map_err(failure::err_msg)?;
 

--- a/src/cobalt_model/sass.rs
+++ b/src/cobalt_model/sass.rs
@@ -40,12 +40,6 @@ pub struct SassCompiler {
     style: SassOutputStyle,
 }
 
-impl Default for SassCompiler {
-    fn default() -> Self {
-        SassBuilder::default().build()
-    }
-}
-
 impl SassCompiler {
     pub fn compile_file<S: AsRef<path::Path>, D: AsRef<path::Path>, F: AsRef<path::Path>>(
         &self,
@@ -111,6 +105,12 @@ impl SassCompiler {
             .expect("file was found under the root");
         let dest_file = dest.join(rel_src);
         files::copy_file(file_path, &dest_file)
+    }
+}
+
+impl Default for SassCompiler {
+    fn default() -> Self {
+        SassBuilder::default().build()
     }
 }
 

--- a/src/document.rs
+++ b/src/document.rs
@@ -5,14 +5,10 @@ use std::path::{Path, PathBuf};
 
 use chrono::{Datelike, Timelike};
 use failure::ResultExt;
-use itertools;
-use jsonfeed;
-use liquid;
 use liquid::model::Value;
 use liquid::Object;
 use liquid::ValueView;
 use regex::Regex;
-use rss;
 
 use crate::cobalt_model;
 use crate::cobalt_model::files;
@@ -36,7 +32,7 @@ fn minify_if_enabled(html: String, _context: &RenderContex, _file_path: &Path) -
 
 #[cfg(feature = "html-minifier")]
 fn minify_if_enabled(html: String, context: &RenderContex, file_path: &Path) -> Result<String> {
-    let extension = file_path.extension().unwrap_or_else(|| Default::default());
+    let extension = file_path.extension().unwrap_or_else(Default::default);
     if context.minify.html && (extension == "html" || extension == "htm") {
         Ok(html_minifier::minify(html)?)
     } else {
@@ -174,10 +170,7 @@ fn document_attributes(
     }
 
     if let Some(ref published_date) = front.published_date {
-        attributes.insert(
-            "published_date".into(),
-            Value::scalar(liquid::model::DateTime::from(*published_date)),
-        );
+        attributes.insert("published_date".into(), Value::scalar(*published_date));
     }
 
     attributes

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,7 @@ extern crate lazy_static;
 extern crate serde;
 
 pub use crate::cobalt::build;
+pub use crate::cobalt::classify_path;
 pub use crate::cobalt_model::Config;
 pub use crate::error::Error;
 

--- a/src/pagination/categories.rs
+++ b/src/pagination/categories.rs
@@ -73,7 +73,7 @@ fn parse_categories_list<'a, 'b>(
         let mut cur_cat = if let Ok(idx) = parent.sub_cats.binary_search_by(|c| {
             compare_category_path(
                 c.cat_path.iter().map(|v| v.as_view()),
-                cat_full_path.iter().map(|v| *v),
+                cat_full_path.iter().copied(),
             )
         }) {
             &mut parent.sub_cats[idx]
@@ -138,8 +138,10 @@ fn walk_categories<'a, 'b>(
         if !cur_cat_paginators.is_empty() {
             cur_cat_paginators_holder.extend(cur_cat_paginators.into_iter());
         } else {
-            let mut p = Paginator::default();
-            p.index_title = Some(liquid::model::Value::array(category.cat_path.clone()));
+            let p = Paginator {
+                index_title: Some(liquid::model::Value::array(category.cat_path.clone())),
+                ..Default::default()
+            };
             cur_cat_paginators_holder.push(p);
         }
     } else {

--- a/src/pagination/dates.rs
+++ b/src/pagination/dates.rs
@@ -29,7 +29,7 @@ impl<'a> DateIndexHolder<'a> {
     }
 }
 
-fn extract_published_date<'a>(value: &'a dyn liquid::ValueView) -> Option<DateTime> {
+fn extract_published_date(value: &'_ dyn liquid::ValueView) -> Option<DateTime> {
     let published_date = extract_scalar(value, "published_date")?;
     published_date.to_date_time()
 }
@@ -79,8 +79,10 @@ fn walk_dates(
         if !cur_date_paginators.is_empty() {
             cur_date_holder_paginators.extend(cur_date_paginators.into_iter());
         } else {
-            let mut p = Paginator::default();
-            p.index_title = Some(index_title);
+            let p = Paginator {
+                index_title: Some(index_title),
+                ..Default::default()
+            };
             cur_date_holder_paginators.push(p);
         }
     } else {

--- a/src/pagination/paginator.rs
+++ b/src/pagination/paginator.rs
@@ -109,6 +109,7 @@ pub fn create_paginator(
     Ok(paginator)
 }
 
+#[allow(clippy::from_over_into)]
 impl Into<liquid::Object> for Paginator {
     fn into(self) -> liquid::Object {
         let mut object = liquid::Object::new();


### PR DESCRIPTION
This doesn't just pull out file walking logic but switches us from
walking per type of file to walking once and categorizing as we go,
which simplifies our walking logic and is easier to integrate into
whatever processing system we adopt.

This also includes all of the refactors, additional tests, etc to prepare for this refactor.