### PR TITLE
cobalt_model - Add a `time` to Site

### DIFF
--- a/src/cobalt_model/site.rs
+++ b/src/cobalt_model/site.rs
@@ -53,7 +53,7 @@ impl Site {
             sitemap,
             data,
             data_dir,
-            time: DateTime::now()
+            time: DateTime::now(),
         }
     }
 
@@ -77,10 +77,7 @@ impl Site {
                 liquid::model::Value::scalar(kstring::KString::from_ref(base_url)),
             );
         }
-        attributes.insert(
-            "time".into(),
-            liquid::model::Value::scalar(self.time),
-        );
+        attributes.insert("time".into(), liquid::model::Value::scalar(self.time));
 
         let mut data = self.data.clone().unwrap_or_default();
         let data_path = source.join(&self.data_dir);

--- a/src/cobalt_model/site.rs
+++ b/src/cobalt_model/site.rs
@@ -79,7 +79,7 @@ impl Site {
         }
         attributes.insert(
             "time".into(),
-            liquid::model::Value::scalar(kstring::KString::from_ref(&self.time.to_string())),
+            liquid::model::Value::scalar(self.time),
         );
 
         let mut data = self.data.clone().unwrap_or_default();

--- a/src/cobalt_model/site.rs
+++ b/src/cobalt_model/site.rs
@@ -2,6 +2,7 @@ use std::ffi::OsStr;
 use std::fs;
 use std::path;
 
+use cobalt_config::DateTime;
 use failure::ResultExt;
 use liquid;
 use serde_json;
@@ -21,6 +22,8 @@ pub struct Site {
     pub sitemap: Option<cobalt_config::RelPath>,
     pub data: Option<liquid::Object>,
     pub data_dir: &'static str,
+    /// The time at which the `cobalt` binary built the site
+    pub time: DateTime,
 }
 
 impl Site {
@@ -50,6 +53,7 @@ impl Site {
             sitemap,
             data,
             data_dir,
+            time: DateTime::now()
         }
     }
 
@@ -73,6 +77,11 @@ impl Site {
                 liquid::model::Value::scalar(kstring::KString::from_ref(base_url)),
             );
         }
+        attributes.insert(
+            "time".into(),
+            liquid::model::Value::scalar(kstring::KString::from_ref(&self.time.to_string())),
+        );
+
         let mut data = self.data.clone().unwrap_or_default();
         let data_path = source.join(&self.data_dir);
         insert_data_dir(&mut data, &data_path)?;


### PR DESCRIPTION
This is the same option that is present in jekyll (as a global variable).

I'm rewriting the areweinspaceyet.org with rust and I want to keep it.
In a nutshell, it shows when was the last time the website was generated (updated).

https://github.com/AeroRust/are-we-in-space-yet/blob/933b45db16c2585f68d2ce0c9a03640ad6604366/_includes/footer.html#L19