### PR TITLE
Rust edition 2021 & docs build fix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,7 @@ jobs:
     - name: No-default features
       run: cargo test --workspace --no-default-features
   msrv:
-    name: "Check MSRV: 1.53.0"
+    name: "Check MSRV: 1.56.0"
     needs: smoke
     runs-on: ubuntu-latest
     steps:
@@ -74,7 +74,7 @@ jobs:
     - name: Install Rust
       uses: actions-rs/toolchain@v1
       with:
-        toolchain: 1.53.0  # MSRV
+        toolchain: 1.56.0  # MSRV
         profile: minimal
         override: true
     - uses: Swatinem/rust-cache@v1
@@ -127,7 +127,7 @@ jobs:
     - name: Install Rust
       uses: actions-rs/toolchain@v1
       with:
-        toolchain: 1.53.0  # MSRV
+        toolchain: 1.56.0  # MSRV
         profile: minimal
         override: true
         components: clippy

--- a/.github/workflows/rust-next.yml
+++ b/.github/workflows/rust-next.yml
@@ -57,7 +57,7 @@ jobs:
     strategy:
       matrix:
         rust:
-        - 1.53.0  # MSRV
+        - 1.56.0  # MSRV
         - stable
     continue-on-error: ${{ matrix.rust != '1.53.0' }}  # MSRV
     runs-on: ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ readme = "README.md"
 categories = ["command-line-utilities"]
 keywords = ["static", "site", "generator"]
 license = "MIT"
-edition = "2018"
+edition = "2021"
 exclude = [
     ".gitignore",
     "CHANGELOG.md",

--- a/README.md
+++ b/README.md
@@ -11,3 +11,7 @@ A straightforward static site generator written in [Rust](http://www.rust-lang.o
 - [API documentation](https://docs.rs/cobalt-bin)
 - [Contributing](https://github.com/cobalt-org/cobalt.rs/blob/master/CONTRIBUTING.md)
 - [LICENSE](https://github.com/cobalt-org/cobalt.rs/blob/master/LICENSE-MIT)
+
+
+# Minimum Supported Rust Version (MSRV)
+- Rust **1.56.0**

--- a/crates/config/Cargo.toml
+++ b/crates/config/Cargo.toml
@@ -8,7 +8,7 @@ readme = "../../README.md"
 keywords = ["static", "site", "generator"]
 categories = ["command-line-utilities"]
 license = "MIT OR Apache-2.0"
-edition = "2018"
+edition = "2021"
 
 [features]
 unstable = []

--- a/crates/config/src/document.rs
+++ b/crates/config/src/document.rs
@@ -20,7 +20,7 @@ impl Document {
         let front = front
             .map(parse_frontmatter)
             .map_or(Ok(None), |r| r.map(Some))?
-            .unwrap_or_else(Frontmatter::default);
+            .unwrap_or_default();
         let content = kstring::KString::from_ref(content);
         Ok(Self { front, content })
     }

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -8,7 +8,7 @@ readme = "../../README.md"
 keywords = ["static", "site", "generator"]
 categories = ["command-line-utilities"]
 license = "MIT OR Apache-2.0"
-edition = "2018"
+edition = "2021"
 
 [features]
 unstable = []

--- a/src/bin/cobalt/args.rs
+++ b/src/bin/cobalt/args.rs
@@ -33,7 +33,7 @@ pub fn get_config_args() -> Vec<clap::Arg<'static, 'static>> {
     .to_vec()
 }
 
-pub fn get_config(matches: &clap::ArgMatches) -> Result<cobalt_config::Config> {
+pub fn get_config(matches: &clap::ArgMatches<'_>) -> Result<cobalt_config::Config> {
     let config_path = matches.value_of("config");
 
     // Fetch config information if available
@@ -88,8 +88,8 @@ pub fn get_logging_args() -> Vec<clap::Arg<'static, 'static>> {
 }
 
 pub fn get_logging(
-    global_matches: &clap::ArgMatches,
-    matches: &clap::ArgMatches,
+    global_matches: &clap::ArgMatches<'_>,
+    matches: &clap::ArgMatches<'_>,
 ) -> Result<env_logger::Builder> {
     let mut builder = env_logger::Builder::new();
 

--- a/src/bin/cobalt/build.rs
+++ b/src/bin/cobalt/build.rs
@@ -11,7 +11,7 @@ pub fn build_command_args() -> clap::App<'static, 'static> {
         .args(&args::get_config_args())
 }
 
-pub fn build_command(matches: &clap::ArgMatches) -> Result<()> {
+pub fn build_command(matches: &clap::ArgMatches<'_>) -> Result<()> {
     let config = args::get_config(matches)?;
     let config = cobalt::cobalt_model::Config::from_config(config)?;
 
@@ -37,7 +37,7 @@ pub fn clean_command_args() -> clap::App<'static, 'static> {
         .args(&args::get_config_args())
 }
 
-pub fn clean_command(matches: &clap::ArgMatches) -> Result<()> {
+pub fn clean_command(matches: &clap::ArgMatches<'_>) -> Result<()> {
     let config = args::get_config(matches)?;
     let config = cobalt::cobalt_model::Config::from_config(config)?;
 
@@ -94,7 +94,7 @@ pub fn import_command_args() -> clap::App<'static, 'static> {
         )
 }
 
-pub fn import_command(matches: &clap::ArgMatches) -> Result<()> {
+pub fn import_command(matches: &clap::ArgMatches<'_>) -> Result<()> {
     let config = args::get_config(matches)?;
     let config = cobalt::cobalt_model::Config::from_config(config)?;
 

--- a/src/bin/cobalt/debug.rs
+++ b/src/bin/cobalt/debug.rs
@@ -23,7 +23,7 @@ pub fn debug_command_args() -> clap::App<'static, 'static> {
         )
 }
 
-pub fn debug_command(matches: &clap::ArgMatches) -> Result<()> {
+pub fn debug_command(matches: &clap::ArgMatches<'_>) -> Result<()> {
     match matches.subcommand() {
         ("config", _) => {
             let config = args::get_config(matches)?;

--- a/src/bin/cobalt/new.rs
+++ b/src/bin/cobalt/new.rs
@@ -424,7 +424,7 @@ fn prepend_date_to_filename(
         file_stem,
         file.extension()
             .and_then(|os| os.to_str())
-            .unwrap_or_else(|| &config
+            .unwrap_or_else(|| config
                 .page_extensions
                 .get(0)
                 .expect("at least one element is enforced by config validator"))
@@ -472,7 +472,7 @@ pub fn publish_document(config: &cobalt_model::Config, file: &path::Path) -> Res
     let doc = doc.to_string();
     cobalt_model::files::write_document_file(doc, file)?;
 
-    let file = move_from_drafts_to_posts(&config, &file)?;
+    let file = move_from_drafts_to_posts(config, file)?;
     let file = cobalt_core::SourcePath::from_root(&config.source, &file).ok_or_else(|| {
         failure::format_err!(
             "New file {} not project directory ({})",
@@ -500,7 +500,7 @@ pub fn publish_document(config: &cobalt_model::Config, file: &path::Path) -> Res
     };
 
     if collection.publish_date_in_filename {
-        prepend_date_to_filename(&config, &file.abs_path, &date)?;
+        prepend_date_to_filename(config, &file.abs_path, &date)?;
     }
     Ok(())
 }

--- a/src/bin/cobalt/new.rs
+++ b/src/bin/cobalt/new.rs
@@ -22,7 +22,7 @@ pub fn init_command_args() -> clap::App<'static, 'static> {
         )
 }
 
-pub fn init_command(matches: &clap::ArgMatches) -> Result<()> {
+pub fn init_command(matches: &clap::ArgMatches<'_>) -> Result<()> {
     let directory = matches.value_of("DIRECTORY").unwrap();
 
     create_new_project(&directory.to_string())
@@ -59,7 +59,7 @@ pub fn new_command_args() -> clap::App<'static, 'static> {
         )
 }
 
-pub fn new_command(matches: &clap::ArgMatches) -> Result<()> {
+pub fn new_command(matches: &clap::ArgMatches<'_>) -> Result<()> {
     let mut config = args::get_config(matches)?;
     config.include_drafts = true;
     let config = cobalt::cobalt_model::Config::from_config(config)?;
@@ -105,7 +105,7 @@ pub fn rename_command_args() -> clap::App<'static, 'static> {
         )
 }
 
-pub fn rename_command(matches: &clap::ArgMatches) -> Result<()> {
+pub fn rename_command(matches: &clap::ArgMatches<'_>) -> Result<()> {
     let mut config = args::get_config(matches)?;
     config.include_drafts = true;
     let config = cobalt::cobalt_model::Config::from_config(config)?;
@@ -137,7 +137,7 @@ pub fn publish_command_args() -> clap::App<'static, 'static> {
         )
 }
 
-pub fn publish_command(matches: &clap::ArgMatches) -> Result<()> {
+pub fn publish_command(matches: &clap::ArgMatches<'_>) -> Result<()> {
     let filename = matches
         .value_of("FILENAME")
         .expect("required parameters are present");

--- a/src/bin/cobalt/serve.rs
+++ b/src/bin/cobalt/serve.rs
@@ -145,7 +145,7 @@ fn serve(dest: &path::Path, ip: &str) -> Result<()> {
     let server = Server::http(ip).map_err(Error::from_boxed_compat)?;
 
     for request in server.incoming_requests() {
-        if let Err(e) = static_file_handler(&dest, request) {
+        if let Err(e) = static_file_handler(dest, request) {
             error!("{}", e);
         }
     }

--- a/src/bin/cobalt/serve.rs
+++ b/src/bin/cobalt/serve.rs
@@ -51,7 +51,7 @@ pub fn serve_command_args() -> clap::App<'static, 'static> {
         )
 }
 
-pub fn serve_command(matches: &clap::ArgMatches) -> Result<()> {
+pub fn serve_command(matches: &clap::ArgMatches<'_>) -> Result<()> {
     let host = matches.value_of("host").unwrap().to_string();
     let port = matches.value_of("port").unwrap().to_string();
     let ip = format!("{}:{}", host, port);

--- a/src/cobalt.rs
+++ b/src/cobalt.rs
@@ -5,6 +5,9 @@ use std::path;
 
 use failure::ResultExt;
 use jsonfeed::Feed;
+use log::debug;
+use log::trace;
+use log::warn;
 use sitemap::writer::SiteMapWriter;
 
 use crate::cobalt_model;

--- a/src/cobalt.rs
+++ b/src/cobalt.rs
@@ -169,7 +169,7 @@ fn generate_collections_var(
         liquid::model::Value::Array(posts_data.to_vec()),
     );
     let global_collection: liquid::Object = vec![(
-        context.posts.slug.clone().into(),
+        context.posts.slug.clone(),
         liquid::model::Value::Object(posts_variable),
     )]
     .into_iter()
@@ -278,7 +278,7 @@ fn generate_pages(posts: Vec<Document>, documents: Vec<Document>, context: &Cont
             generate_doc(
                 &mut doc,
                 context,
-                generate_collections_var(&posts_data, &context),
+                generate_collections_var(&posts_data, context),
             )?;
         };
     }
@@ -315,7 +315,7 @@ fn generate_posts(posts: &mut Vec<Document>, context: &Context) -> Result<()> {
         generate_doc(
             post,
             context,
-            generate_collections_var(&simple_posts_data, &context),
+            generate_collections_var(&simple_posts_data, context),
         )?;
     }
 
@@ -358,7 +358,6 @@ fn parse_drafts(
         let rel_src = file_path
             .rel_path
             .strip_prefix(drafts_dir)
-            .ok()
             .expect("file was found under the root");
         let new_path = dir.join(&rel_src);
 
@@ -543,7 +542,7 @@ pub fn classify_path<'s>(
     posts: &'s cobalt_model::Collection,
     page_extensions: &[kstring::KString],
 ) -> Option<(&'s str, bool)> {
-    if ext_contains(&page_extensions, &path) {
+    if ext_contains(page_extensions, path) {
         if path.starts_with(&posts.dir) {
             return Some((posts.slug.as_str(), false));
         }

--- a/src/cobalt_model/assets.rs
+++ b/src/cobalt_model/assets.rs
@@ -2,6 +2,8 @@ use std::ffi::OsStr;
 use std::path;
 
 use failure::ResultExt;
+use log::debug;
+use serde::{Deserialize, Serialize};
 
 use super::sass;
 use super::{files, Minify};

--- a/src/cobalt_model/config.rs
+++ b/src/cobalt_model/config.rs
@@ -1,6 +1,8 @@
 use std::fmt;
 use std::path;
 
+use log::debug;
+use serde::Serialize;
 use serde_yaml;
 
 use crate::error::*;
@@ -136,7 +138,7 @@ impl Default for Config {
 }
 
 impl fmt::Display for Config {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let mut converted = serde_yaml::to_string(self).map_err(|_| fmt::Error)?;
         converted.drain(..4);
         write!(f, "{}", converted)

--- a/src/cobalt_model/files.rs
+++ b/src/cobalt_model/files.rs
@@ -8,6 +8,8 @@ use crate::error::Result;
 use failure::ResultExt;
 use ignore::gitignore::{Gitignore, GitignoreBuilder};
 use ignore::Match;
+use log::debug;
+use log::trace;
 use normalize_line_endings::normalized;
 use walkdir::{DirEntry, WalkDir};
 
@@ -154,7 +156,7 @@ impl Files {
         self.includes_path(dir, is_dir)
     }
 
-    pub fn files(&self) -> FilesIterator {
+    pub fn files(&self) -> FilesIterator<'_> {
         FilesIterator::new(self)
     }
 

--- a/src/cobalt_model/frontmatter.rs
+++ b/src/cobalt_model/frontmatter.rs
@@ -3,6 +3,7 @@ use std::fmt;
 use cobalt_config::DateTime;
 use cobalt_config::SourceFormat;
 use liquid;
+use serde::Serialize;
 
 use super::pagination;
 use crate::error::Result;
@@ -99,7 +100,7 @@ impl Frontmatter {
 }
 
 impl fmt::Display for Frontmatter {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let converted = serde_yaml::to_string(self).expect("should always be valid");
         let subset = converted
             .strip_prefix("---")

--- a/src/cobalt_model/frontmatter.rs
+++ b/src/cobalt_model/frontmatter.rs
@@ -78,7 +78,7 @@ impl Frontmatter {
             tags,
             excerpt_separator: excerpt_separator.unwrap_or_else(|| "\n\n".into()),
             published_date,
-            format: format.unwrap_or_else(super::SourceFormat::default),
+            format: format.unwrap_or_default(),
             #[cfg(feature = "preview_unstable")]
             templated: templated.unwrap_or(false),
             #[cfg(not(feature = "preview_unstable"))]

--- a/src/cobalt_model/mark.rs
+++ b/src/cobalt_model/mark.rs
@@ -1,4 +1,5 @@
 use pulldown_cmark as cmark;
+use serde::Serialize;
 
 use crate::error::*;
 use crate::syntax_highlight::decorate_markdown;

--- a/src/cobalt_model/permalink.rs
+++ b/src/cobalt_model/permalink.rs
@@ -1,3 +1,4 @@
+use lazy_static::lazy_static;
 use liquid;
 
 use crate::error::*;

--- a/src/cobalt_model/sass.rs
+++ b/src/cobalt_model/sass.rs
@@ -3,6 +3,7 @@ use std::path;
 
 #[cfg(feature = "sass")]
 use sass_rs;
+use serde::{Deserialize, Serialize};
 
 use super::files;
 use crate::cobalt_model::Minify;

--- a/src/cobalt_model/site.rs
+++ b/src/cobalt_model/site.rs
@@ -11,6 +11,8 @@ use serde_json;
 use serde_yaml;
 use toml;
 
+use crate::error::*;
+
 use super::files;
 
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]

--- a/src/cobalt_model/site.rs
+++ b/src/cobalt_model/site.rs
@@ -2,13 +2,14 @@ use std::ffi::OsStr;
 use std::fs;
 use std::path;
 
+use crate::error::*;
 use failure::ResultExt;
 use liquid;
+use log::debug;
+use serde::{Deserialize, Serialize};
 use serde_json;
 use serde_yaml;
 use toml;
-
-use crate::error::*;
 
 use super::files;
 

--- a/src/cobalt_model/slug.rs
+++ b/src/cobalt_model/slug.rs
@@ -1,5 +1,6 @@
 use deunicode;
 use itertools::Itertools;
+use lazy_static::lazy_static;
 use regex::Regex;
 
 lazy_static! {

--- a/src/cobalt_model/template.rs
+++ b/src/cobalt_model/template.rs
@@ -5,6 +5,9 @@ use super::files;
 use crate::error::*;
 use crate::syntax_highlight;
 use liquid;
+use log::warn;
+use log::{debug, trace};
+use serde::Serialize;
 
 type Partials = liquid::partials::EagerCompiler<liquid::partials::InMemorySource>;
 
@@ -85,7 +88,7 @@ impl Liquid {
 }
 
 impl fmt::Debug for Liquid {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "Liquid{{}}")
     }
 }

--- a/src/cobalt_model/vwiki.rs
+++ b/src/cobalt_model/vwiki.rs
@@ -1,6 +1,6 @@
 use crate::error::*;
+use serde::{Deserialize, Serialize};
 use vimwiki::{HtmlCodeConfig, HtmlConfig, Language, Page, ParseError, ToHtmlString};
-
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct VimwikiBuilder {
@@ -32,9 +32,9 @@ impl Vimwiki {
         //
         //       Until then, we just convert to error display message and
         //       wrap that in a general failure error type
-        let page: Page = lang
-            .parse()
-            .map_err(|x: ParseError| failure::err_msg(format!("vimwiki parsing failed: {}", x)))?;
+        let page: Page<'_> = lang.parse().map_err(|x: ParseError<'_>| {
+            failure::err_msg(format!("vimwiki parsing failed: {}", x))
+        })?;
 
         let config = HtmlConfig {
             code: HtmlCodeConfig {

--- a/src/document.rs
+++ b/src/document.rs
@@ -42,7 +42,7 @@ fn minify_if_enabled(
     context: &RenderContext<'_>,
     file_path: &relative_path::RelativePath,
 ) -> Result<String> {
-    let extension = file_path.extension().unwrap_or_else(Default::default);
+    let extension = file_path.extension().unwrap_or_default();
     if context.minify.html && (extension == "html" || extension == "htm") {
         Ok(html_minifier::minify(html)?)
     } else {

--- a/src/document.rs
+++ b/src/document.rs
@@ -5,9 +5,11 @@ use std::path::Path;
 
 use chrono::{Datelike, Timelike};
 use failure::ResultExt;
+use lazy_static::lazy_static;
 use liquid::model::Value;
 use liquid::Object;
 use liquid::ValueView;
+use log::trace;
 use regex::Regex;
 
 use crate::cobalt_model;
@@ -37,7 +39,7 @@ fn minify_if_enabled(
 #[cfg(feature = "html-minifier")]
 fn minify_if_enabled(
     html: String,
-    context: &RenderContext,
+    context: &RenderContext<'_>,
     file_path: &relative_path::RelativePath,
 ) -> Result<String> {
     let extension = file_path.extension().unwrap_or_else(Default::default);
@@ -300,7 +302,7 @@ impl Document {
     /// Takes `content` string and returns rendered HTML. This function doesn't
     /// take `"extends"` attribute into account. This function can be used for
     /// rendering content or excerpt.
-    fn render_html(&self, content: &str, context: &RenderContext) -> Result<String> {
+    fn render_html(&self, content: &str, context: &RenderContext<'_>) -> Result<String> {
         let html = if self.front.templated {
             let template = context.parser.parse(content)?;
             template.render(context.globals)?
@@ -323,7 +325,7 @@ impl Document {
     /// given, or extracted from the content, if `excerpt_separator` is not
     /// empty. When neither condition applies, the excerpt is set to the `Nil`
     /// value.
-    pub fn render_excerpt(&mut self, context: &RenderContext) -> Result<()> {
+    pub fn render_excerpt(&mut self, context: &RenderContext<'_>) -> Result<()> {
         let value = if let Some(excerpt_str) = self.front.excerpt.as_ref() {
             let excerpt = self.render_html(excerpt_str, context)?;
             Value::scalar(excerpt)
@@ -346,7 +348,7 @@ impl Document {
     /// Renders the content and adds it to attributes of the document.
     ///
     /// When we say "content" we mean only this document without extended layout.
-    pub fn render_content(&mut self, context: &RenderContext) -> Result<()> {
+    pub fn render_content(&mut self, context: &RenderContext<'_>) -> Result<()> {
         let content_html = self.render_html(&self.content, context)?;
         self.attributes
             .insert("content".into(), Value::scalar(content_html));
@@ -360,7 +362,7 @@ impl Document {
     /// * layout may be inserted to layouts cache
     pub fn render(
         &mut self,
-        context: &RenderContext,
+        context: &RenderContext<'_>,
         layouts: &HashMap<String, String>,
     ) -> Result<String> {
         if let Some(ref layout) = self.front.layout {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,14 +1,5 @@
 #![warn(warnings)]
 
-#[macro_use]
-extern crate log;
-
-#[macro_use]
-extern crate lazy_static;
-
-#[macro_use]
-extern crate serde;
-
 pub use crate::cobalt::build;
 pub use crate::cobalt::classify_path;
 pub use crate::cobalt_model::Config;

--- a/src/pagination/categories.rs
+++ b/src/pagination/categories.rs
@@ -31,7 +31,7 @@ impl<'a> Category<'a> {
     }
 
     fn add_post(&mut self, post: &'a liquid::model::Value) {
-        self.posts.push(&post)
+        self.posts.push(post)
     }
 }
 
@@ -93,13 +93,13 @@ fn parse_categories_list<'a, 'b>(
         };
 
         if is_leaf_category(cur_idx, cur_post_categories) {
-            cur_cat.add_post(&post);
+            cur_cat.add_post(post);
         } else {
             parse_categories_list(
                 &mut cur_cat,
                 next_category(cur_idx),
-                &cur_post_categories,
-                &post,
+                cur_post_categories,
+                post,
             )?;
         }
     }
@@ -113,7 +113,7 @@ fn distribute_posts_by_categories<'a>(
     for post in all_posts {
         if let Some(categories) = extract_categories(post.as_view()) {
             let categories: Vec<_> = categories.values().collect();
-            parse_categories_list(&mut root, 1, categories.as_slice(), &post)?;
+            parse_categories_list(&mut root, 1, categories.as_slice(), post)?;
         }
     }
     Ok(root)
@@ -128,11 +128,11 @@ fn walk_categories<'a, 'b>(
 ) -> Result<Vec<Paginator>> {
     let mut cur_cat_paginators_holder: Vec<Paginator> = vec![];
     if !category.cat_path.is_empty() {
-        sort_posts(&mut category.posts, &config);
+        sort_posts(&mut category.posts, config);
         let cur_cat_paginators = create_all_paginators(
             &category.posts,
             doc,
-            &config,
+            config,
             Some(&liquid::model::Value::array(category.cat_path.clone())),
         )?;
         if !cur_cat_paginators.is_empty() {
@@ -148,7 +148,7 @@ fn walk_categories<'a, 'b>(
         cur_cat_paginators_holder.push(Paginator::default());
     }
     for mut c in &mut category.sub_cats {
-        let mut sub_paginators_holder = walk_categories(&mut c, &config, doc)?;
+        let mut sub_paginators_holder = walk_categories(&mut c, config, doc)?;
 
         if let Some(indexes) = cur_cat_paginators_holder[0].indexes.as_mut() {
             indexes.push(sub_paginators_holder[0].clone());
@@ -165,8 +165,8 @@ pub fn create_categories_paginators(
     doc: &Document,
     pagination_cfg: &PaginationConfig,
 ) -> Result<Vec<Paginator>> {
-    let mut root_cat = distribute_posts_by_categories(&all_posts)?;
-    let paginators_holder = walk_categories(&mut root_cat, &pagination_cfg, doc)?;
+    let mut root_cat = distribute_posts_by_categories(all_posts)?;
+    let paginators_holder = walk_categories(&mut root_cat, pagination_cfg, doc)?;
     Ok(paginators_holder)
 }
 

--- a/src/pagination/dates.rs
+++ b/src/pagination/dates.rs
@@ -39,8 +39,8 @@ pub fn create_dates_paginators(
     doc: &Document,
     pagination_cfg: &PaginationConfig,
 ) -> Result<Vec<Paginator>> {
-    let mut root_date = distribute_posts_by_dates(&all_posts, &pagination_cfg)?;
-    walk_dates(&mut root_date, &pagination_cfg, &doc, None)
+    let mut root_date = distribute_posts_by_dates(all_posts, pagination_cfg)?;
+    walk_dates(&mut root_date, pagination_cfg, doc, None)
 }
 
 fn format_date_holder(d: &DateIndexHolder<'_>) -> liquid::model::Value {
@@ -55,7 +55,7 @@ fn format_date_holder(d: &DateIndexHolder<'_>) -> liquid::model::Value {
 }
 
 fn date_fields_to_array(date: &[DateIndexHolder<'_>]) -> liquid::model::Array {
-    date.iter().map(|d| format_date_holder(&d)).collect()
+    date.iter().map(|d| format_date_holder(d)).collect()
 }
 
 fn walk_dates(
@@ -71,11 +71,11 @@ fn walk_dates(
         vec![]
     };
     if let Some(_field) = date_holder.field {
-        sort_posts(&mut date_holder.posts, &config);
+        sort_posts(&mut date_holder.posts, config);
         current_date.push(date_holder.clone());
         let index_title = liquid::model::Value::array(date_fields_to_array(&current_date));
         let cur_date_paginators =
-            create_all_paginators(&date_holder.posts, &doc, &config, Some(&index_title))?;
+            create_all_paginators(&date_holder.posts, doc, config, Some(&index_title))?;
         if !cur_date_paginators.is_empty() {
             cur_date_holder_paginators.extend(cur_date_paginators.into_iter());
         } else {
@@ -90,7 +90,7 @@ fn walk_dates(
     }
     for mut dh in &mut date_holder.sub_date {
         let mut sub_paginators_holder =
-            walk_dates(&mut dh, &config, &doc, Some(current_date.clone()))?;
+            walk_dates(&mut dh, config, doc, Some(current_date.clone()))?;
 
         if let Some(indexes) = cur_date_holder_paginators[0].indexes.as_mut() {
             indexes.push(sub_paginators_holder[0].clone());
@@ -108,7 +108,7 @@ fn find_or_create_date_holder_and_put_post<'a, 'b>(
     wanted_field: DateIndex,
     post: &'a liquid::model::Value,
 ) {
-    let value = get_date_field_value(&published_date, wanted_field);
+    let value = get_date_field_value(published_date, wanted_field);
     let mut not_found = true;
     for mut dh in date_holder.sub_date.iter_mut() {
         let dh_field = dh
@@ -117,13 +117,13 @@ fn find_or_create_date_holder_and_put_post<'a, 'b>(
         if dh_field < wanted_field {
             // not at the level we want but still need to find the correct parent
             // parent should have been created in a previous loop
-            let parent_value = get_date_field_value(&published_date, dh_field);
+            let parent_value = get_date_field_value(published_date, dh_field);
             if dh.value == parent_value {
                 find_or_create_date_holder_and_put_post(
                     &mut dh,
-                    &published_date,
+                    published_date,
                     wanted_field,
-                    &post,
+                    post,
                 );
                 not_found = false;
             }
@@ -164,7 +164,7 @@ fn distribute_posts_by_dates<'a>(
     for post in all_posts {
         if let Some(published_date) = extract_published_date(post.as_view()) {
             for idx in date_index {
-                find_or_create_date_holder_and_put_post(&mut root, &published_date, *idx, &post);
+                find_or_create_date_holder_and_put_post(&mut root, &published_date, *idx, post);
             }
         }
     }

--- a/src/pagination/dates.rs
+++ b/src/pagination/dates.rs
@@ -43,7 +43,7 @@ pub fn create_dates_paginators(
     walk_dates(&mut root_date, &pagination_cfg, &doc, None)
 }
 
-fn format_date_holder(d: &DateIndexHolder) -> liquid::model::Value {
+fn format_date_holder(d: &DateIndexHolder<'_>) -> liquid::model::Value {
     let field = d
         .field
         .expect("Should not be called with the root DateIndexHolder");
@@ -54,15 +54,15 @@ fn format_date_holder(d: &DateIndexHolder) -> liquid::model::Value {
     liquid::model::Value::scalar(formatted)
 }
 
-fn date_fields_to_array(date: &[DateIndexHolder]) -> liquid::model::Array {
+fn date_fields_to_array(date: &[DateIndexHolder<'_>]) -> liquid::model::Array {
     date.iter().map(|d| format_date_holder(&d)).collect()
 }
 
 fn walk_dates(
-    date_holder: &mut DateIndexHolder,
+    date_holder: &mut DateIndexHolder<'_>,
     config: &PaginationConfig,
     doc: &Document,
-    parent_dates: Option<Vec<DateIndexHolder>>,
+    parent_dates: Option<Vec<DateIndexHolder<'_>>>,
 ) -> Result<Vec<Paginator>> {
     let mut cur_date_holder_paginators: Vec<Paginator> = vec![];
     let mut current_date = if let Some(parent_dates) = parent_dates {

--- a/src/pagination/mod.rs
+++ b/src/pagination/mod.rs
@@ -32,12 +32,12 @@ pub fn generate_paginators(
     let mut all_posts: Vec<_> = posts_data.iter().collect();
     match config.include {
         Include::All => {
-            sort_posts(&mut all_posts, &config);
-            create_all_paginators(&all_posts, &doc, &config, None)
+            sort_posts(&mut all_posts, config);
+            create_all_paginators(&all_posts, doc, config, None)
         }
-        Include::Tags => tags::create_tags_paginators(&all_posts, &doc, &config),
-        Include::Categories => categories::create_categories_paginators(&all_posts, &doc, &config),
-        Include::Dates => dates::create_dates_paginators(&all_posts, &doc, &config),
+        Include::Tags => tags::create_tags_paginators(&all_posts, doc, config),
+        Include::Categories => categories::create_categories_paginators(&all_posts, doc, config),
+        Include::Dates => dates::create_dates_paginators(&all_posts, doc, config),
         Include::None => {
             unreachable!("PaginationConfigBuilder should have lead to a None for pagination.")
         }
@@ -62,9 +62,9 @@ fn create_all_paginators(
                 i,
                 total_indexes,
                 total_pages,
-                &pagination_cfg,
-                &doc,
-                &chunk,
+                pagination_cfg,
+                doc,
+                chunk,
                 index_title,
             )
         })
@@ -95,8 +95,8 @@ fn sort_posts(posts: &mut Vec<&liquid::model::Value>, config: &PaginationConfig)
         let mut cmp = Ordering::Less;
         for k in keys {
             cmp = match (
-                helpers::extract_scalar(a.as_view(), &k),
-                helpers::extract_scalar(b.as_view(), &k),
+                helpers::extract_scalar(a.as_view(), k),
+                helpers::extract_scalar(b.as_view(), k),
             ) {
                 (Some(a), Some(b)) => order(a, b),
                 (None, None) => Ordering::Equal,
@@ -158,9 +158,9 @@ fn interpret_permalink(
             || doc.url_path.clone(),
             |index| {
                 if pagination_root.is_empty() {
-                    index_to_string(&index)
+                    index_to_string(index)
                 } else {
-                    format!("{}/{}", pagination_root, index_to_string(&index))
+                    format!("{}/{}", pagination_root, index_to_string(index))
                 }
             },
         )
@@ -174,7 +174,7 @@ fn interpret_permalink(
                 }
                 "all".to_string()
             },
-            |index| index_to_string(&index),
+            |index| index_to_string(index),
         );
         if pagination_root.is_empty() {
             format!(

--- a/src/pagination/paginator.rs
+++ b/src/pagination/paginator.rs
@@ -46,7 +46,7 @@ impl Paginator {
         index_title: Option<&liquid::model::Value>,
     ) -> Result<()> {
         self.first_index_permalink = doc.url_path.to_string();
-        self.last_index_permalink = interpret_permalink(&config, &doc, total_pages, index_title)?;
+        self.last_index_permalink = interpret_permalink(config, doc, total_pages, index_title)?;
         Ok(())
     }
 
@@ -61,7 +61,7 @@ impl Paginator {
         self.index = index;
         self.pages = Some(all_pages.iter().map(|p| (*p).clone()).collect());
         self.index_title = index_title.cloned();
-        self.index_permalink = interpret_permalink(&config, &doc, index, index_title)?;
+        self.index_permalink = interpret_permalink(config, doc, index, index_title)?;
         Ok(())
     }
 
@@ -76,7 +76,7 @@ impl Paginator {
         if index > 1 {
             // we have a previous index
             self.previous_index_permalink =
-                Some(interpret_permalink(&config, &doc, index - 1, index_title)?);
+                Some(interpret_permalink(config, doc, index - 1, index_title)?);
             self.previous_index = index - 1;
         }
 
@@ -84,7 +84,7 @@ impl Paginator {
             // we have a next index
             self.next_index = index + 1;
             self.next_index_permalink =
-                Some(interpret_permalink(&config, &doc, index + 1, index_title)?);
+                Some(interpret_permalink(config, doc, index + 1, index_title)?);
         }
         Ok(())
     }
@@ -102,9 +102,9 @@ pub fn create_paginator(
     let index = i + 1;
     let mut paginator = Paginator::new(total_indexes, total_pages);
 
-    paginator.set_first_last(&doc, &config, total_indexes, index_title)?;
-    paginator.set_current_index_info(index, &all_posts, &config, &doc, index_title)?;
-    paginator.set_previous_next_info(index, total_indexes, &doc, &config, index_title)?;
+    paginator.set_first_last(doc, config, total_indexes, index_title)?;
+    paginator.set_current_index_info(index, all_posts, config, doc, index_title)?;
+    paginator.set_previous_next_info(index, total_indexes, doc, config, index_title)?;
 
     Ok(paginator)
 }

--- a/src/pagination/tags.rs
+++ b/src/pagination/tags.rs
@@ -40,17 +40,17 @@ pub fn create_tags_paginators(
     doc: &Document,
     pagination_cfg: &PaginationConfig,
 ) -> Result<Vec<Paginator>> {
-    let mut per_tags = distribute_posts_by_tags(&all_posts)?;
+    let mut per_tags = distribute_posts_by_tags(all_posts)?;
 
     // create all other paginators
     let mut tag_paginators: TagPaginators = per_tags
         .iter_mut()
         .try_fold(TagPaginators::default(), |mut acc, (tag, posts)| {
-            sort_posts(posts, &pagination_cfg);
+            sort_posts(posts, pagination_cfg);
             let cur_tag_paginators = create_all_paginators(
                 posts,
                 doc,
-                &pagination_cfg,
+                pagination_cfg,
                 Some(&liquid::model::Value::scalar(tag.to_owned())),
             )?;
             acc.firsts_of_tags.push(cur_tag_paginators[0].clone());

--- a/src/syntax_highlight/syntect.rs
+++ b/src/syntax_highlight/syntect.rs
@@ -1,6 +1,8 @@
 use std::io::Write;
 
+use crate::error;
 use itertools::Itertools;
+use lazy_static::lazy_static;
 use liquid_core::error::ResultLiquidReplaceExt;
 use liquid_core::parser::TryMatchToken;
 use liquid_core::Language;
@@ -16,8 +18,6 @@ use syntect::html::{
     highlighted_html_for_string, start_highlighted_html_snippet, IncludeBackground,
 };
 use syntect::parsing::{SyntaxReference, SyntaxSet};
-
-use crate::error;
 
 struct Setup {
     syntax_set: SyntaxSet,
@@ -123,8 +123,8 @@ impl liquid_core::ParseBlock for CodeBlockParser {
 
     fn parse(
         &self,
-        mut arguments: TagTokenIter,
-        mut tokens: TagBlock,
+        mut arguments: TagTokenIter<'_>,
+        mut tokens: TagBlock<'_, '_>,
         _options: &Language,
     ) -> Result<Box<dyn Renderable>, liquid_core::Error> {
         let lang = arguments

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -1,5 +1,3 @@
-
-
 use std::process;
 
 use assert_cmd::prelude::*;

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -1,4 +1,4 @@
-use assert_fs;
+
 
 use std::process;
 

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -1,6 +1,4 @@
-extern crate assert_cmd;
-extern crate assert_fs;
-extern crate predicates;
+use assert_fs;
 
 use std::process;
 


### PR DESCRIPTION
This PR hopes to fix #940 
Also cleaned up a few leftovers (the macro use statements) as these were removed in the `2018` edition.

I've ran:
`cargo fix --edition`
`cargo fix --edition-idioms`

Is it possible that this fixes the docs build?
I've also checked if docs are being built for all crates in the workspace:

`cargo doc --all`
`cargo doc --all --all-features`

also double-checked with nightly:

`cargo +nightly doc --all`
`cargo +nightly doc --all --all-features`

```
elpiel@kracho:~/PROJECTS/Personal/cobalt.rs$ cargo fix --edition
note: Switching to Edition 2021 will enable the use of the version 2 feature resolver in Cargo.
This may cause some dependencies to be built with fewer features enabled than previously.
More information about the resolver changes may be found at https://doc.rust-lang.org/nightly/edition-guide/rust-2021/default-cargo-resolver.html
When building the following dependencies, the given features will no longer be used:

  bstr v0.2.17 removed features: default, lazy_static, regex-automata, unicode
  num-integer v0.1.44 removed features: i128, std
  num-traits v0.2.14 removed features: i128

    Checking cobalt-bin v0.17.4 (/home/elpiel/PROJECTS/Personal/cobalt.rs)
   Migrating src/lib.rs from 2018 edition to 2021
   Migrating tests/cli.rs from 2018 edition to 2021
   Migrating src/bin/cobalt/main.rs from 2018 edition to 2021
   Migrating tests/mod.rs from 2018 edition to 2021
    Finished dev [unoptimized + debuginfo] target(s) in 4.50s
```