### PR TITLE
fix(cli): Serve from temp dir

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -349,6 +349,7 @@ dependencies = [
  "similar-asserts",
  "sitemap",
  "syntect",
+ "tempfile",
  "tiny_http",
  "toml",
  "vimwiki",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,6 +55,7 @@ concolor-clap = { version = "0.0.8", features = ["api_unstable"] }
 human-panic = "1"
 scrawl = "1.0"
 kstring = "1.0"
+tempfile = "3.0"
 relative-path = { version = "1", features = ["serde"] }
 liquid = "0.23"
 liquid-core = "0.23"


### PR DESCRIPTION
Because we override the config to work better for serve, we shouldn't
override the users copy of the files which they might publish, thinking
they are prestine.

Fixes #834