### PR TITLE
fix(serve): Avoid port conflicts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -319,6 +319,7 @@ dependencies = [
  "env_logger",
  "exitfailure",
  "failure",
+ "file-serve",
  "html-minifier",
  "human-panic",
  "ignore",
@@ -330,7 +331,6 @@ dependencies = [
  "liquid-core",
  "liquid-lib",
  "log",
- "mime_guess",
  "normalize-line-endings",
  "notify",
  "open",
@@ -349,7 +349,6 @@ dependencies = [
  "sitemap",
  "syntect",
  "tempfile",
- "tiny_http",
  "toml",
  "vimwiki",
  "walkdir",
@@ -763,6 +762,15 @@ checksum = "9d6b8560a05112eb52f04b00e5d3790c0dd75d9d980eb8a122fb23b92a623ccf"
 dependencies = [
  "bit-set",
  "regex",
+]
+
+[[package]]
+name = "file-serve"
+version = "0.1.0"
+dependencies = [
+ "log",
+ "mime_guess",
+ "tiny_http",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,9 +83,8 @@ sitemap = "0.4"
 open = "2.0"
 vimwiki = { version = "0.1", features = ["html"] }
 
-tiny_http = { version = "0.9.0", optional = true }
+file-serve = { version = "0.1.0", path = "crates/file-serve", optional = true }
 notify = { version = "4", optional = true }
-mime_guess = { version = "2", optional = true }
 
 sass-rs = { version = "0.2", optional = true }
 
@@ -108,7 +107,7 @@ default = ["syntax-highlight", "sass", "serve", "html-minifier"]
 unstable = []
 preview_unstable = ["cobalt-config/preview_unstable"]
 
-serve = ["tiny_http", "notify", "mime_guess"]
+serve = ["file-serve", "notify"]
 syntax-highlight = ["syntect"]
 sass = ['sass-rs']
 

--- a/crates/file-serve/Cargo.toml
+++ b/crates/file-serve/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "file-serve"
+version = "0.1.0"
+description = "HTTP Static File Server"
+license = "MIT OR Apache-2.0"
+repository = "https://github.com/cobalt-org/cobalt.rs"
+documentation = "docs.srs/file-serve"
+readme = "README.md"
+categories = ["development-tools::testing", "web-programming::http-server"]
+keywords = ["serve", "http-server", "static-files", "http", "server"]
+edition = "2018"
+include = [
+  "build.rs",
+  "src/**/*",
+  "Cargo.toml",
+  "LICENSE*",
+  "README.md",
+  "benches/**/*",
+  "examples/**/*"
+]
+
+[dependencies]
+tiny_http = "0.9.0"
+mime_guess = "2"
+log = "0.4"

--- a/crates/file-serve/src/lib.rs
+++ b/crates/file-serve/src/lib.rs
@@ -1,0 +1,146 @@
+use std::str::FromStr;
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ServerBuilder {
+    source: std::path::PathBuf,
+    hostname: Option<String>,
+    port: Option<u16>,
+}
+
+impl ServerBuilder {
+    pub fn new(source: impl Into<std::path::PathBuf>) -> Self {
+        Self {
+            source: source.into(),
+            hostname: None,
+            port: None,
+        }
+    }
+
+    pub fn hostname(&mut self, hostname: impl Into<String>) -> &mut Self {
+        self.hostname = Some(hostname.into());
+        self
+    }
+
+    pub fn port(&mut self, port: u16) -> &mut Self {
+        self.port = Some(port);
+        self
+    }
+
+    pub fn build(&self) -> Server {
+        let source = self.source.clone();
+        let hostname = self.hostname.as_deref().unwrap_or("localhost");
+        let port = self.port.unwrap_or(3000);
+
+        Server {
+            source,
+            addr: format!("{}:{}", hostname, port),
+        }
+    }
+
+    pub fn serve(&self) -> Result<(), Error> {
+        self.build().serve()
+    }
+}
+
+#[derive(Debug)]
+pub struct Server {
+    source: std::path::PathBuf,
+    addr: String,
+}
+
+impl Server {
+    pub fn new(source: impl Into<std::path::PathBuf>) -> Self {
+        ServerBuilder::new(source).build()
+    }
+
+    pub fn source(&self) -> &std::path::Path {
+        self.source.as_path()
+    }
+
+    pub fn addr(&self) -> &str {
+        self.addr.as_str()
+    }
+
+    pub fn serve(&self) -> Result<(), Error> {
+        // attempts to create a server
+        let server = tiny_http::Server::http(self.addr()).map_err(Error::new)?;
+
+        for request in server.incoming_requests() {
+            if let Err(e) = static_file_handler(self.source(), request) {
+                log::error!("{}", e);
+            }
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug)]
+pub struct Error {
+    message: String,
+}
+
+impl Error {
+    fn new(message: impl ToString) -> Self {
+        Self {
+            message: message.to_string(),
+        }
+    }
+}
+
+impl std::fmt::Display for Error {
+    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.message.fmt(fmt)
+    }
+}
+
+impl std::error::Error for Error {}
+
+fn static_file_handler(dest: &std::path::Path, req: tiny_http::Request) -> Result<(), Error> {
+    // grab the requested path
+    let mut req_path = req.url().to_string();
+
+    // strip off any querystrings so path.is_file() matches and doesn't stick index.html on the end
+    // of the path (querystrings often used for cachebusting)
+    if let Some(position) = req_path.rfind('?') {
+        req_path.truncate(position);
+    }
+
+    // find the path of the file in the local system
+    // (this gets rid of the '/' in `p`, so the `join()` will not replace the path)
+    let path = dest.to_path_buf().join(&req_path[1..]);
+
+    let serve_path = if path.is_file() {
+        // try to point the serve path to `path` if it corresponds to a file
+        path
+    } else {
+        // try to point the serve path into a "index.html" file in the requested
+        // path
+        path.join("index.html")
+    };
+
+    // if the request points to a file and it exists, read and serve it
+    if serve_path.exists() {
+        let file = std::fs::File::open(&serve_path).map_err(Error::new)?;
+        let mut response = tiny_http::Response::from_file(file);
+        if let Some(mime) = mime_guess::MimeGuess::from_path(&serve_path).first_raw() {
+            let content_type = format!("Content-Type:{}", mime);
+            let content_type =
+                tiny_http::Header::from_str(&content_type).expect("formatted correctly");
+            response.add_header(content_type);
+        }
+        req.respond(response).map_err(Error::new)?;
+    } else {
+        // write a simple body for the 404 page
+        req.respond(
+            tiny_http::Response::from_string("<h1> <center> 404: Page not found </center> </h1>")
+                .with_status_code(404)
+                .with_header(
+                    tiny_http::Header::from_str("Content-Type: text/html")
+                        .expect("formatted correctly"),
+                ),
+        )
+        .map_err(Error::new)?;
+    }
+
+    Ok(())
+}

--- a/src/bin/cobalt/serve.rs
+++ b/src/bin/cobalt/serve.rs
@@ -24,8 +24,8 @@ pub struct ServeArgs {
     pub host: String,
 
     /// Port to serve from
-    #[clap(short = 'P', long, value_name = "NUM", default_value_t = 3000)]
-    pub port: u16,
+    #[clap(short = 'P', long, value_name = "NUM")]
+    pub port: Option<u16>,
 
     /// Disable rebuilding on change
     #[clap(long)]
@@ -41,7 +41,9 @@ impl ServeArgs {
 
         let mut server = file_serve::ServerBuilder::new(dest.path());
         server.hostname(&self.host);
-        server.port(self.port);
+        if let Some(port) = self.port {
+            server.port(port);
+        }
         let server = server.build();
 
         let mut config = self.config.load_config()?;


### PR DESCRIPTION
We'll now auto-discover a port to host from, rather than using a hard
coded default.