### PR TITLE
fix: Respect enabled with liquid syntax highlighting 

### DIFF
--- a/src/cobalt_model/config.rs
+++ b/src/cobalt_model/config.rs
@@ -98,11 +98,14 @@ impl Config {
 
         let liquid = template::LiquidBuilder {
             includes_path,
-            theme: syntax_highlight.theme.clone(),
+            theme: syntax_highlight
+                .enabled
+                .then(|| syntax_highlight.theme.clone()),
         };
         let markdown = mark::MarkdownBuilder {
-            theme: syntax_highlight.theme.clone(),
-            syntax_highlight_enabled: syntax_highlight.enabled,
+            theme: syntax_highlight
+                .enabled
+                .then(|| syntax_highlight.theme.clone()),
         };
         let vimwiki = vwiki::VimwikiBuilder {
             theme: syntax_highlight.theme,

--- a/src/cobalt_model/mark.rs
+++ b/src/cobalt_model/mark.rs
@@ -7,23 +7,18 @@ use crate::syntax_highlight::decorate_markdown;
 #[derive(Debug, Clone, PartialEq, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct MarkdownBuilder {
-    pub theme: kstring::KString,
-    pub syntax_highlight_enabled: bool,
+    pub theme: Option<kstring::KString>,
 }
 
 impl MarkdownBuilder {
     pub fn build(self) -> Markdown {
-        Markdown {
-            theme: self.theme,
-            syntax_highlight_enabled: self.syntax_highlight_enabled,
-        }
+        Markdown { theme: self.theme }
     }
 }
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct Markdown {
-    theme: kstring::KString,
-    syntax_highlight_enabled: bool,
+    theme: Option<kstring::KString>,
 }
 
 impl Markdown {
@@ -34,11 +29,7 @@ impl Markdown {
             | cmark::Options::ENABLE_STRIKETHROUGH
             | cmark::Options::ENABLE_TASKLISTS;
         let parser = cmark::Parser::new_ext(content, options);
-        if self.syntax_highlight_enabled {
-            cmark::html::push_html(&mut buf, decorate_markdown(parser, &self.theme));
-        } else {
-            cmark::html::push_html(&mut buf, parser);
-        }
+        cmark::html::push_html(&mut buf, decorate_markdown(parser, self.theme.as_deref()));
         Ok(buf)
     }
 }

--- a/src/cobalt_model/vwiki.rs
+++ b/src/cobalt_model/vwiki.rs
@@ -1,6 +1,7 @@
 use crate::error::*;
 use serde::{Deserialize, Serialize};
 use vimwiki::{HtmlCodeConfig, HtmlConfig, Language, Page, ParseError, ToHtmlString};
+
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct VimwikiBuilder {

--- a/src/syntax_highlight.rs
+++ b/src/syntax_highlight.rs
@@ -131,13 +131,13 @@ impl liquid_core::ParseBlock for CodeBlockParser {
 
 pub struct DecoratedParser<'a> {
     parser: cmark::Parser<'a, 'a>,
-    theme: &'a str,
+    theme: Option<&'a str>,
     lang: Option<String>,
     code: Option<Vec<pulldown_cmark::CowStr<'a>>>,
 }
 
 impl<'a> DecoratedParser<'a> {
-    pub fn new(parser: cmark::Parser<'a, 'a>, theme: &'a str) -> Self {
+    pub fn new(parser: cmark::Parser<'a, 'a>, theme: Option<&'a str>) -> Self {
         DecoratedParser {
             parser,
             theme,
@@ -172,9 +172,9 @@ impl<'a> Iterator for DecoratedParser<'a> {
             Some(End(cmark::Tag::CodeBlock(_))) => {
                 let html = if let Some(code) = self.code.as_deref() {
                     let code = code.iter().join("\n");
-                    HIGHLIGHT.format(&code, self.lang.as_deref(), Some(self.theme))
+                    HIGHLIGHT.format(&code, self.lang.as_deref(), self.theme)
                 } else {
-                    HIGHLIGHT.format("", self.lang.as_deref(), Some(self.theme))
+                    HIGHLIGHT.format("", self.lang.as_deref(), self.theme)
                 };
                 // reset highlighter
                 self.lang = None;
@@ -189,7 +189,7 @@ impl<'a> Iterator for DecoratedParser<'a> {
 
 pub fn decorate_markdown<'a>(
     parser: cmark::Parser<'a, 'a>,
-    theme_name: &'a str,
+    theme_name: Option<&'a str>,
 ) -> DecoratedParser<'a> {
     DecoratedParser::new(parser, theme_name)
 }
@@ -267,7 +267,10 @@ mod test_syntsx {
 
         let mut buf = String::new();
         let parser = cmark::Parser::new(&html);
-        cmark::html::push_html(&mut buf, decorate_markdown(parser, "base16-ocean.dark"));
+        cmark::html::push_html(
+            &mut buf,
+            decorate_markdown(parser, Some("base16-ocean.dark")),
+        );
         similar_asserts::assert_eq!(MARKDOWN_RENDERED, &buf);
     }
 }
@@ -331,7 +334,10 @@ mod test_raw {
 
         let mut buf = String::new();
         let parser = cmark::Parser::new(&html);
-        cmark::html::push_html(&mut buf, decorate_markdown(parser, "base16-ocean.dark"));
+        cmark::html::push_html(
+            &mut buf,
+            decorate_markdown(parser, Some("base16-ocean.dark")),
+        );
         assert_eq!(buf, MARKDOWN_RENDERED);
     }
 }

--- a/tests/cli_tests.rs
+++ b/tests/cli_tests.rs
@@ -1,5 +1,10 @@
 #[test]
 #[cfg(feature = "syntax-highlight")]
 fn cli_tests() {
-    trycmd::TestCases::new().case("tests/cmd/*.md");
+    let t = trycmd::TestCases::new();
+    t.case("tests/cmd/*.md");
+    #[cfg(not(feature = "serve"))]
+    {
+        t.skip("tests/cmd/errors.md");
+    }
 }

--- a/tests/cli_tests.rs
+++ b/tests/cli_tests.rs
@@ -1,8 +1,12 @@
 #[test]
-#[cfg(feature = "syntax-highlight")]
 fn cli_tests() {
     let t = trycmd::TestCases::new();
     t.case("tests/cmd/*.md");
+    #[cfg(not(feature = "syntax-highlight"))]
+    {
+        t.skip("tests/cmd/init.md");
+        t.skip("tests/cmd/log_level.md");
+    }
     #[cfg(not(feature = "serve"))]
     {
         t.skip("tests/cmd/errors.md");

--- a/tests/cmd/publish_draft.in/_cobalt.yml
+++ b/tests/cmd/publish_draft.in/_cobalt.yml
@@ -6,3 +6,5 @@ posts:
   drafts_dir: _drafts
   rss: rss.xml
   publish_date_in_filename: false
+syntax_highlight:
+  enabled: false

--- a/tests/cmd/publish_post.in/_cobalt.yml
+++ b/tests/cmd/publish_post.in/_cobalt.yml
@@ -5,3 +5,5 @@ site:
 posts:
   rss: rss.xml
   publish_date_in_filename: false
+syntax_highlight:
+  enabled: false

--- a/tests/cmd/publish_post_with_date.in/_cobalt.yml
+++ b/tests/cmd/publish_post_with_date.in/_cobalt.yml
@@ -5,3 +5,5 @@ site:
 posts:
   rss: rss.xml
   publish_date_in_filename: true
+syntax_highlight:
+  enabled: false

--- a/tests/cmd/rename_page.in/_cobalt.yml
+++ b/tests/cmd/rename_page.in/_cobalt.yml
@@ -5,3 +5,5 @@ site:
   base_url: http://example.com
 posts:
   rss: rss.xml
+syntax_highlight:
+  enabled: false

--- a/tests/fixtures/init/_cobalt.yml
+++ b/tests/fixtures/init/_cobalt.yml
@@ -5,3 +5,5 @@ site:
   base_url: http://example.com
 posts:
   rss: rss.xml
+syntax_highlight:
+  enabled: false


### PR DESCRIPTION
My goal is to run more tests with `--no-default-features`.  When I tried
it, a lot of CLI tests failed because we were logging that the theme
wasn't supported. I decided to disable syntax highlighting to make my
life easier, but the warning persisted, uncovering this bug.