### PR TITLE
fix(build): Binary files stop build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,7 @@ jobs:
     name: Test
     needs: smoke
     strategy:
+      fail-fast: false
       matrix:
         os: ["ubuntu-latest", "windows-latest", "macos-latest"]
         rust: ["stable"]

--- a/.github/workflows/rust-next.yml
+++ b/.github/workflows/rust-next.yml
@@ -6,6 +6,7 @@ jobs:
   test:
     name: Test
     strategy:
+      fail-fast: false
       matrix:
         os: ["ubuntu-latest", "windows-latest", "macos-latest"]
         rust: ["stable", "beta"]

--- a/src/cobalt_model/template.rs
+++ b/src/cobalt_model/template.rs
@@ -26,8 +26,14 @@ fn load_partials_from_path(root: path::PathBuf) -> Result<Partials> {
             .expect("only UTF-8 characters supported in paths")
             .to_owned();
         trace!("Loading snippet `{}`", rel_path);
-        let content = files::read_file(file_path)?;
-        source.add(rel_path, content);
+        match files::read_file(file_path) {
+            Ok(content) => {
+                source.add(rel_path, content);
+            }
+            Err(err) => {
+                warn!("Ignoring snippet {}: {}", rel_path, err);
+            }
+        }
     }
     Ok(source)
 }


### PR DESCRIPTION
Instead of failing, we should ignore and move on.  Ideally, we'd do the
same as `EagerCompiler` and error on access but this is good enough for
now.

Fixes #1022