### PR TITLE
refactor: Inject highlighting into markdown/liquid

### DIFF
--- a/src/bin/cobalt/debug.rs
+++ b/src/bin/cobalt/debug.rs
@@ -26,8 +26,14 @@ pub enum DebugCommands {
 
 #[derive(Clone, Debug, PartialEq, Eq, clap::Subcommand)]
 pub enum HighlightCommands {
-    Themes {},
-    Syntaxes {},
+    Themes {
+        #[clap(flatten, next_help_heading = "CONFIG")]
+        config: args::ConfigArgs,
+    },
+    Syntaxes {
+        #[clap(flatten, next_help_heading = "CONFIG")]
+        config: args::ConfigArgs,
+    },
 }
 
 impl DebugCommands {
@@ -38,13 +44,17 @@ impl DebugCommands {
                 let config = cobalt::cobalt_model::Config::from_config(config)?;
                 println!("{}", config);
             }
-            Self::Highlight(HighlightCommands::Themes {}) => {
-                for name in cobalt::list_syntax_themes() {
+            Self::Highlight(HighlightCommands::Themes { config }) => {
+                let config = config.load_config()?;
+                let config = cobalt::cobalt_model::Config::from_config(config)?;
+                for name in config.syntax.themes() {
                     println!("{}", name);
                 }
             }
-            Self::Highlight(HighlightCommands::Syntaxes {}) => {
-                for name in cobalt::list_syntaxes() {
+            Self::Highlight(HighlightCommands::Syntaxes { config }) => {
+                let config = config.load_config()?;
+                let config = cobalt::cobalt_model::Config::from_config(config)?;
+                for name in config.syntax.syntaxes() {
                     println!("{}", name);
                 }
             }

--- a/src/cobalt.rs
+++ b/src/cobalt.rs
@@ -51,6 +51,7 @@ impl Context {
             liquid,
             markdown,
             vimwiki,
+            syntax: _,
             assets,
             minify,
         } = config;

--- a/src/cobalt_model/config.rs
+++ b/src/cobalt_model/config.rs
@@ -13,8 +13,9 @@ use super::mark;
 use super::site;
 use super::template;
 use super::vwiki;
+use crate::SyntaxHighlight;
 
-#[derive(Debug, Clone, PartialEq, Serialize)]
+#[derive(Debug, Clone, Serialize)]
 #[serde(deny_unknown_fields, default)]
 pub struct Config {
     pub source: path::PathBuf,
@@ -96,13 +97,17 @@ impl Config {
         let includes_path = source.join(includes_dir);
         let layouts_path = source.join(layouts_dir);
 
+        let syntax = std::sync::Arc::new(SyntaxHighlight::new());
+
         let liquid = template::LiquidBuilder {
             includes_path,
+            syntax: syntax.clone(),
             theme: syntax_highlight
                 .enabled
                 .then(|| syntax_highlight.theme.clone()),
         };
         let markdown = mark::MarkdownBuilder {
+            syntax: syntax.clone(),
             theme: syntax_highlight
                 .enabled
                 .then(|| syntax_highlight.theme.clone()),

--- a/src/cobalt_model/config.rs
+++ b/src/cobalt_model/config.rs
@@ -30,6 +30,8 @@ pub struct Config {
     pub liquid: template::LiquidBuilder,
     pub markdown: mark::MarkdownBuilder,
     pub vimwiki: vwiki::VimwikiBuilder,
+    #[serde(skip)]
+    pub syntax: std::sync::Arc<SyntaxHighlight>,
     pub assets: assets::AssetsBuilder,
     pub minify: cobalt_config::Minify,
 }
@@ -130,6 +132,7 @@ impl Config {
             liquid,
             markdown,
             vimwiki,
+            syntax,
             assets,
             minify,
         };

--- a/src/cobalt_model/mark.rs
+++ b/src/cobalt_model/mark.rs
@@ -4,21 +4,27 @@ use serde::Serialize;
 use crate::error::*;
 use crate::syntax_highlight::decorate_markdown;
 
-#[derive(Debug, Clone, PartialEq, Serialize)]
+#[derive(Debug, Clone, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct MarkdownBuilder {
     pub theme: Option<liquid::model::KString>,
+    #[serde(skip)]
+    pub syntax: std::sync::Arc<crate::SyntaxHighlight>,
 }
 
 impl MarkdownBuilder {
     pub fn build(self) -> Markdown {
-        Markdown { theme: self.theme }
+        Markdown {
+            theme: self.theme,
+            syntax: self.syntax,
+        }
     }
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone)]
 pub struct Markdown {
     theme: Option<liquid::model::KString>,
+    syntax: std::sync::Arc<crate::SyntaxHighlight>,
 }
 
 impl Markdown {
@@ -29,7 +35,10 @@ impl Markdown {
             | cmark::Options::ENABLE_STRIKETHROUGH
             | cmark::Options::ENABLE_TASKLISTS;
         let parser = cmark::Parser::new_ext(content, options);
-        cmark::html::push_html(&mut buf, decorate_markdown(parser, self.theme.as_deref())?);
+        cmark::html::push_html(
+            &mut buf,
+            decorate_markdown(parser, self.syntax.clone(), self.theme.as_deref())?,
+        );
         Ok(buf)
     }
 }

--- a/src/cobalt_model/mark.rs
+++ b/src/cobalt_model/mark.rs
@@ -29,7 +29,7 @@ impl Markdown {
             | cmark::Options::ENABLE_STRIKETHROUGH
             | cmark::Options::ENABLE_TASKLISTS;
         let parser = cmark::Parser::new_ext(content, options);
-        cmark::html::push_html(&mut buf, decorate_markdown(parser, self.theme.as_deref()));
+        cmark::html::push_html(&mut buf, decorate_markdown(parser, self.theme.as_deref())?);
         Ok(buf)
     }
 }

--- a/src/cobalt_model/template.rs
+++ b/src/cobalt_model/template.rs
@@ -67,24 +67,7 @@ impl LiquidBuilder {
     fn highlight(
         theme: Option<liquid::model::KString>,
     ) -> Result<Box<dyn liquid_core::ParseBlock>> {
-        let theme = if let Some(theme) = theme {
-            let result: Result<()> = match syntax_highlight::has_syntax_theme(&theme) {
-                Ok(true) => Ok(()),
-                Ok(false) => Err(failure::format_err!(
-                    "Syntax theme '{}' is unsupported",
-                    theme
-                )),
-                Err(err) => {
-                    warn!("Syntax theme named '{}' ignored. Reason: {}", theme, err);
-                    Ok(())
-                }
-            };
-            result?;
-            theme
-        } else {
-            "".into()
-        };
-        let block = syntax_highlight::CodeBlockParser::new(theme);
+        let block = syntax_highlight::CodeBlockParser::new(theme)?;
         Ok(Box::new(block))
     }
 }

--- a/src/cobalt_model/template.rs
+++ b/src/cobalt_model/template.rs
@@ -38,16 +38,19 @@ fn load_partials_from_path(root: path::PathBuf) -> Result<Partials> {
     Ok(source)
 }
 
-#[derive(Debug, Clone, PartialEq, Serialize)]
+#[derive(Debug, Clone, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct LiquidBuilder {
     pub includes_path: path::PathBuf,
     pub theme: Option<liquid::model::KString>,
+    #[serde(skip)]
+    pub syntax: std::sync::Arc<crate::SyntaxHighlight>,
 }
 
 impl LiquidBuilder {
     pub fn build(self) -> Result<Liquid> {
-        let highlight = Self::highlight(self.theme)?;
+        let highlight = syntax_highlight::CodeBlockParser::new(self.syntax, self.theme)?;
+        let highlight: Box<dyn liquid_core::ParseBlock> = Box::new(highlight);
         let parser = liquid::ParserBuilder::with_stdlib()
             .filter(liquid_lib::extra::DateInTz)
             .filter(liquid_lib::shopify::Pluralize)
@@ -62,13 +65,6 @@ impl LiquidBuilder {
             .block(highlight)
             .build()?;
         Ok(Liquid { parser })
-    }
-
-    fn highlight(
-        theme: Option<liquid::model::KString>,
-    ) -> Result<Box<dyn liquid_core::ParseBlock>> {
-        let block = syntax_highlight::CodeBlockParser::new(theme)?;
-        Ok(Box::new(block))
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,4 +14,5 @@ mod document;
 mod pagination;
 mod syntax_highlight;
 
+pub use crate::syntax_highlight::SyntaxHighlight;
 pub use crate::syntax_highlight::{list_syntax_themes, list_syntaxes};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,4 +15,3 @@ mod pagination;
 mod syntax_highlight;
 
 pub use crate::syntax_highlight::SyntaxHighlight;
-pub use crate::syntax_highlight::{list_syntax_themes, list_syntaxes};

--- a/src/syntax_highlight.rs
+++ b/src/syntax_highlight.rs
@@ -321,7 +321,7 @@ mod test_raw {
     fn codeblock_renders_rust() {
         let syntax = std::sync::Arc::new(SyntaxHighlight::new());
         let highlight: Box<dyn liquid_core::ParseBlock> =
-            Box::new(CodeBlockParser::new(syntax, "base16-ocean.dark".into()));
+            Box::new(CodeBlockParser::new(syntax, Some("base16-ocean.dark".into())).unwrap());
         let parser = liquid::ParserBuilder::new()
             .block(highlight)
             .build()
@@ -359,7 +359,7 @@ mod test_raw {
         let syntax = std::sync::Arc::new(SyntaxHighlight::new());
         cmark::html::push_html(
             &mut buf,
-            decorate_markdown(parser, syntax, Some("base16-ocean.dark")),
+            decorate_markdown(parser, syntax, Some("base16-ocean.dark")).unwrap(),
         );
         assert_eq!(buf, MARKDOWN_RENDERED);
     }

--- a/src/syntax_highlight.rs
+++ b/src/syntax_highlight.rs
@@ -23,16 +23,16 @@ lazy_static! {
 }
 
 #[cfg(feature = "syntax-highlight")]
-pub fn has_syntax_theme(name: &str) -> error::Result<bool> {
+fn has_syntax_theme(name: &str) -> error::Result<bool> {
     Ok(HIGHLIGHT.has_theme(name))
 }
 
 #[cfg(not(feature = "syntax-highlight"))]
-pub fn has_syntax_theme(name: &str) -> error::Result<bool> {
+fn has_syntax_theme(name: &str) -> error::Result<bool> {
     failure::bail!("Themes are unsupported in this build.");
 }
 
-pub fn verify_theme(theme: Option<&str>) -> error::Result<()> {
+fn verify_theme(theme: Option<&str>) -> error::Result<()> {
     if let Some(theme) = &theme {
         match has_syntax_theme(theme) {
             Ok(true) => {}

--- a/src/syntax_highlight.rs
+++ b/src/syntax_highlight.rs
@@ -2,7 +2,6 @@ use std::io::Write;
 
 use crate::error;
 use itertools::Itertools;
-use lazy_static::lazy_static;
 use liquid_core::error::ResultLiquidReplaceExt;
 use liquid_core::parser::TryMatchToken;
 use liquid_core::Language;
@@ -17,10 +16,6 @@ use pulldown_cmark::Event::{self, End, Html, Start, Text};
 pub use engarde::Raw as SyntaxHighlight;
 #[cfg(feature = "syntax-highlight")]
 pub use engarde::Syntax as SyntaxHighlight;
-
-lazy_static! {
-    static ref HIGHLIGHT: SyntaxHighlight = SyntaxHighlight::new();
-}
 
 #[cfg(feature = "syntax-highlight")]
 fn has_syntax_theme(syntax: &SyntaxHighlight, name: &str) -> error::Result<bool> {
@@ -43,14 +38,6 @@ fn verify_theme(syntax: &SyntaxHighlight, theme: Option<&str>) -> error::Result<
         };
     }
     Ok(())
-}
-
-pub fn list_syntax_themes() -> Vec<String> {
-    HIGHLIGHT.themes().collect()
-}
-
-pub fn list_syntaxes() -> Vec<String> {
-    HIGHLIGHT.syntaxes().collect()
 }
 
 #[derive(Clone, Debug)]


### PR DESCRIPTION
This will make it easier for the config to have an impact on syntax highlighting rather.