### PR TITLE
Allow calling a custom executable to process Markdown, rather than using pulldown_cmark.

### DIFF
--- a/crates/config/src/config.rs
+++ b/crates/config/src/config.rs
@@ -30,6 +30,8 @@ pub struct Config {
     pub includes_dir: &'static str,
     pub assets: Assets,
     pub minify: Minify,
+    pub custom_markdown_executable: Option<String>,
+    pub custom_markdown_executable_args: Vec<String>,
 }
 
 impl Default for Config {
@@ -51,6 +53,8 @@ impl Default for Config {
             includes_dir: "_includes",
             assets: Assets::default(),
             minify: Minify::default(),
+            custom_markdown_executable: None,
+            custom_markdown_executable_args: vec![],
         }
     }
 }

--- a/src/cobalt.rs
+++ b/src/cobalt.rs
@@ -30,7 +30,7 @@ struct Context {
     pub site_attributes: liquid::Object,
     pub layouts: HashMap<String, String>,
     pub liquid: cobalt_model::Liquid,
-    pub markdown: cobalt_model::Markdown,
+    pub markdown: Box<dyn cobalt_model::AbstractMarkdown>,
     pub vimwiki: cobalt_model::Vimwiki,
     pub assets: cobalt_model::Assets,
     pub minify: Minify,

--- a/src/cobalt_model/config.rs
+++ b/src/cobalt_model/config.rs
@@ -55,6 +55,8 @@ impl Config {
             includes_dir,
             assets,
             minify,
+            custom_markdown_executable,
+            custom_markdown_executable_args,
         } = source;
 
         if include_drafts {
@@ -115,6 +117,8 @@ impl Config {
                 .then(|| syntax_highlight.theme.clone()),
         };
         let markdown = mark::MarkdownBuilder {
+            custom_executable: custom_markdown_executable.clone(),
+            custom_executable_args: custom_markdown_executable_args.clone(),
             syntax: syntax.clone(),
             theme: syntax_highlight
                 .enabled

--- a/src/cobalt_model/mark.rs
+++ b/src/cobalt_model/mark.rs
@@ -74,9 +74,11 @@ impl AbstractMarkdown for CustomMarkdown {
             .spawn()
             .unwrap();
 
-        let stdin = child.stdin.as_mut().unwrap();
-        stdin.write_all(content.as_bytes()).unwrap();
-        std::mem::drop(stdin);
+        {
+          let mut stdin = child.stdin.take().unwrap();
+          stdin.write_all(content.as_bytes()).unwrap();
+          // EOF gets sent here.
+        }
 
         let stdout = child.stdout.as_mut().unwrap();
         let mut html = String::new();

--- a/src/cobalt_model/mark.rs
+++ b/src/cobalt_model/mark.rs
@@ -7,18 +7,31 @@ use crate::syntax_highlight::decorate_markdown;
 #[derive(Debug, Clone, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct MarkdownBuilder {
+    pub custom_executable: Option<String>,
+    pub custom_executable_args: Vec<String>,
     pub theme: Option<liquid::model::KString>,
     #[serde(skip)]
     pub syntax: std::sync::Arc<crate::SyntaxHighlight>,
 }
 
 impl MarkdownBuilder {
-    pub fn build(self) -> Markdown {
-        Markdown {
-            theme: self.theme,
-            syntax: self.syntax,
+    pub fn build(self) -> Box<dyn AbstractMarkdown> {
+        if let Some(cmd) = self.custom_executable {
+            Box::new(CustomMarkdown {
+                cmd,
+                args: self.custom_executable_args,
+            })
+        } else {
+            Box::new(Markdown {
+                theme: self.theme,
+                syntax: self.syntax,
+            })
         }
     }
+}
+
+pub trait AbstractMarkdown {
+    fn parse(&self, content: &str) -> Result<String>;
 }
 
 #[derive(Debug, Clone)]
@@ -27,8 +40,8 @@ pub struct Markdown {
     syntax: std::sync::Arc<crate::SyntaxHighlight>,
 }
 
-impl Markdown {
-    pub fn parse(&self, content: &str) -> Result<String> {
+impl AbstractMarkdown for Markdown {
+    fn parse(&self, content: &str) -> Result<String> {
         let mut buf = String::new();
         let options = cmark::Options::ENABLE_FOOTNOTES
             | cmark::Options::ENABLE_TABLES
@@ -40,5 +53,43 @@ impl Markdown {
             decorate_markdown(parser, self.syntax.clone(), self.theme.as_deref())?,
         );
         Ok(buf)
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct CustomMarkdown {
+    cmd: String,
+    args: Vec<String>,
+}
+
+impl AbstractMarkdown for CustomMarkdown {
+    fn parse(&self, content: &str) -> Result<String> {
+        use std::io::{Read, Write};
+        use std::process::{Command, Stdio};
+        let mut child = Command::new(&self.cmd)
+            .args(&self.args)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .unwrap();
+
+        let stdin = child.stdin.as_mut().unwrap();
+        stdin.write_all(content.as_bytes()).unwrap();
+        std::mem::drop(stdin);
+
+        let stdout = child.stdout.as_mut().unwrap();
+        let mut html = String::new();
+        stdout.read_to_string(&mut html).unwrap();
+
+        let stderr = child.stderr.as_mut().unwrap();
+        let mut errlog = String::new();
+        stderr.read_to_string(&mut errlog).unwrap();
+
+        if !child.wait().unwrap().success() {
+            failure::bail!("Custom markdown processor exited with error:\n{}", &errlog);
+        }
+
+        Ok(html)
     }
 }

--- a/src/cobalt_model/mod.rs
+++ b/src/cobalt_model/mod.rs
@@ -26,6 +26,7 @@ pub use self::assets::AssetsBuilder;
 pub use self::collection::Collection;
 pub use self::config::Config;
 pub use self::frontmatter::Frontmatter;
+pub use self::mark::AbstractMarkdown;
 pub use self::mark::Markdown;
 pub use self::mark::MarkdownBuilder;
 pub use self::sass::SassBuilder;

--- a/src/document.rs
+++ b/src/document.rs
@@ -20,7 +20,7 @@ use crate::error::*;
 
 pub struct RenderContext<'a> {
     pub parser: &'a cobalt_model::Liquid,
-    pub markdown: &'a cobalt_model::Markdown,
+    pub markdown: &'a Box<dyn cobalt_model::AbstractMarkdown>,
     pub vimwiki: &'a cobalt_model::Vimwiki,
     pub globals: &'a Object,
     pub minify: Minify,


### PR DESCRIPTION
This is a proof-of-concept PR.

Custom usage:

```yaml
...
custom_markdown_executable: "/usr/local/bin/mmark"
custom_markdown_executable_args: ["--ext-mathjax", "--ext-skylighting"]
...
```

This allows me to have the niceties of [mmark](https://github.com/mmark-md/mmark) which strives to notify me of my goofy fat fingerish typos rather than silently swallowing those and breaking the render.

Please let me know if you want to merge this, and what things I should clean up before we do. I'd imagine in that case you will have opinions on how to structure the additional part of the configuration, what to call the new structs / traits, etc.

Cheers!