### PR TITLE
Better error message when failing to parse front matter on post

### DIFF
--- a/src/document.rs
+++ b/src/document.rs
@@ -188,7 +188,7 @@ impl Document {
     ) -> Result<Document> {
         trace!("Parsing {:?}", rel_path);
         let content = files::read_file(src_path)?;
-        let builder = cobalt_config::Document::parse(&content)?;
+        let builder = cobalt_config::Document::parse(&content).map_err_with_sources()?;
         let (front, content) = builder.into_parts();
         let front = front.merge_path(rel_path).merge(&default_front);
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,2 +1,57 @@
+use std::fmt;
+use std::fmt::Display;
+
 pub use failure::Error;
 pub type Result<T> = std::result::Result<T, Error>;
+
+#[derive(Debug)]
+struct SourceWrapper {
+    message: String,
+}
+
+impl Display for SourceWrapper {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        Display::fmt(&self.message, f)
+    }
+}
+
+impl std::error::Error for SourceWrapper {}
+
+#[derive(Debug)]
+struct StatusWrapper {
+    status: cobalt_config::Status,
+    cause: SourceWrapper,
+}
+
+impl Display for StatusWrapper {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        Display::fmt(&self.status, f)
+    }
+}
+
+impl failure::Fail for StatusWrapper {
+    fn cause(&self) -> Option<&dyn failure::Fail> {
+        Some(&self.cause)
+    }
+}
+
+pub trait HasSource<T> {
+    fn map_err_with_sources(self) -> Result<T>;
+}
+
+impl<T> HasSource<T> for cobalt_config::Result<T> {
+    fn map_err_with_sources(self) -> Result<T> {
+        self.map_err(|status| {
+            let cause: Option<SourceWrapper> =
+                status.sources().next().map(|source| SourceWrapper {
+                    message: format!("{}", source),
+                });
+
+            if let Some(cause) = cause {
+                return failure::Error::from(StatusWrapper { status, cause });
+            }
+
+            failure::Error::from(status)
+        })
+    }
+}

--- a/tests/cmd/yaml_error.md
+++ b/tests/cmd/yaml_error.md
@@ -15,5 +15,6 @@ Error: Failed to parse index.liquid
 Info: caused by Failed to parse frontmatter
 
 
+Info: caused by found character that cannot start any token, while scanning for the next token
 
 ```


### PR DESCRIPTION
This PR is probably not really ready to merge, as it does not solve the more general problem. I'd like some feedback before I go further.

# User facing problem

If you have a syntax error in the front matter of a post, the error message does not give you any hint which part might be wrong:

```
Building from `d:\src\awise.us\input` into `E:\externsrc\cobalt.rs\_site`
Error: Failed to parse posts/2005-10-24-starting-up.md
Info: caused by Failed to parse frontmatter
```

After the changes in this PR, a slightly more helpful error message is printed:

```
Building from `d:\src\awise.us\input` into `E:\externsrc\cobalt.rs\_site`
Error: Failed to parse posts/2005-10-24-starting-up.md
Info: caused by Failed to parse frontmatter


Info: caused by the 'offset minute' component could not be parsed
```

You can see me fixing the problem with timezones in `published_date` in this commit: https://github.com/AustinWise/austinwise.github.com/commit/54f574916f0a8b7715f1bf49740088a8b1682424

# Cause

Cobalt's `config` sub-crate uses the `status` crate for errors. The main Cobalt crate uses the `failure` crate for errors. When translating from `status::Status` to `failure::Error`, the `source` of `Status` is lost. This contains the lower level failure information, such as why parsing the front matter failed.

# Possible solutions

I can think of 3 possible solutions, the first of which I implemented in this PR:

1. Customize conversion from `status::Status` to `failure::Error`. I have implemented this in the PR for the one location that is effected by front matter parsing. Many other locations could potentially benefit from the extra source information.
2. Define a custom error type for Cobalt instead of `failure::Error`. Define a `From` implementation that preserves the sources on a `status::Status`. I'm not sure how disruptive to programs that use Cobalt as a crate programmatically, but it would cover every occurrence of the problem.
3. Unify the error type across all crates, instead of having to convert between `status::Status` to `failure::Error` at crate boundaries.

# Where to go from here?

Does it make sense to add a new error type to Cobalt to ensure that all lower-level errors are surfaced? Or are more targeted fixes desired.

Also, I'm not sure if there is a nicer way to implement these error structs.