### PR TITLE
feat(file-serve)!: Allow graceful shutdown of server

### DIFF
--- a/crates/file-serve/README.md
+++ b/crates/file-serve/README.md
@@ -3,8 +3,8 @@
 > HTTP Static File Server
 
 [![Documentation](https://img.shields.io/badge/docs-master-blue.svg)][Documentation]
-![License](https://img.shields.io/crates/l/engarde.svg)
-[![Crates Status](https://img.shields.io/crates/v/engarde.svg)](https://crates.io/crates/engarde)
+![License](https://img.shields.io/crates/l/file-serve.svg)
+[![Crates Status](https://img.shields.io/crates/v/file-serve.svg)][Crates.io]
 
 ## About
 
@@ -27,5 +27,5 @@ submitted for inclusion in the work by you, as defined in the Apache-2.0
 license, shall be dual licensed as above, without any additional terms or
 conditions.
 
-[Crates.io]: https://crates.io/crates/engarde
-[Documentation]: https://docs.rs/engarde
+[Crates.io]: https://crates.io/crates/file-serve
+[Documentation]: https://docs.rs/file-serve

--- a/crates/file-serve/src/lib.rs
+++ b/crates/file-serve/src/lib.rs
@@ -18,7 +18,10 @@
 
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
-use std::str::FromStr;
+use std::{
+    str::FromStr,
+    sync::{RwLock, TryLockError},
+};
 
 /// Custom server settings
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -66,19 +69,20 @@ impl ServerBuilder {
         Server {
             source,
             addr: format!("{}:{}", hostname, port),
+            server: RwLock::new(None),
         }
     }
 
     /// Start the webserver
-    pub fn serve(&self) -> Result<std::convert::Infallible, Error> {
+    pub fn serve(&self) -> Result<(), Error> {
         self.build().serve()
     }
 }
 
-#[derive(Debug)]
 pub struct Server {
     source: std::path::PathBuf,
     addr: String,
+    server: RwLock<Option<tiny_http::Server>>,
 }
 
 impl Server {
@@ -100,17 +104,45 @@ impl Server {
         self.addr.as_str()
     }
 
-    /// Start the webserver
-    pub fn serve(&self) -> Result<std::convert::Infallible, Error> {
-        // attempts to create a server
-        let server = tiny_http::Server::http(self.addr()).map_err(Error::new)?;
+    /// Whether the server was running at the instant the call happened
+    pub fn is_running(&self) -> bool {
+        matches!(self.server.read().as_deref(), Ok(Some(_)))
+    }
 
-        for request in server.incoming_requests() {
-            if let Err(e) = static_file_handler(self.source(), request) {
-                log::error!("{}", e);
+    /// Start the webserver
+    pub fn serve(&self) -> Result<(), Error> {
+        match self.server.try_write().as_deref_mut() {
+            Ok(server @ None) => {
+                // attempts to create a server
+                *server = Some(tiny_http::Server::http(self.addr()).map_err(Error::new)?);
+            }
+            Ok(Some(_)) | Err(TryLockError::WouldBlock) => {
+                return Err(Error::new("the server is running"))
+            }
+            Err(error @ TryLockError::Poisoned(_)) => return Err(Error::new(error)),
+        }
+
+        {
+            let server = self.server.read().map_err(Error::new)?;
+            // unwrap is safe here
+            for request in server.as_ref().unwrap().incoming_requests() {
+                // handles the request
+                if let Err(e) = static_file_handler(self.source(), request) {
+                    log::error!("{}", e);
+                }
             }
         }
-        unreachable!("`incoming_requests` never stops")
+
+        *self.server.write().map_err(Error::new)? = None;
+
+        Ok(())
+    }
+
+    /// Closes the server gracefully
+    pub fn close(&self) {
+        if let Ok(Some(server)) = self.server.read().as_deref() {
+            server.unblock();
+        }
     }
 }
 

--- a/src/bin/cobalt/serve.rs
+++ b/src/bin/cobalt/serve.rs
@@ -83,7 +83,7 @@ impl ServeArgs {
     }
 }
 
-fn serve(server: &file_serve::Server) -> Result<std::convert::Infallible> {
+fn serve(server: &file_serve::Server) -> Result<()> {
     info!(
         "Serving {} through static file server",
         server.source().display()


### PR DESCRIPTION
Assume that someone was developing an App which would serve some files temporarily, the server should be closed when it was no longer needed. But the server was just blocked for handling incoming requests, there were no valid methods to close it.

So a method for graceful shutdown of the server is introduced in this PR, also a method for checking whether a sever is running.

BREAKING CHANGE: `Server.serve()` returns `Result<(), Error>` instead of `Result<Infallible, Error>` because the server can be closed.
Remove `Debug` trait of `Server`.