### PR TITLE
use / as base url instead of host addr in serve cmd

### DIFF
--- a/src/bin/cobalt/serve.rs
+++ b/src/bin/cobalt/serve.rs
@@ -47,7 +47,7 @@ impl ServeArgs {
 
         let mut config = self.config.load_config()?;
         debug!("Overriding config `site.base_url` with `{}`", server.addr());
-        config.site.base_url = Some(format!("http://{}", server.addr()).into());
+        config.site.base_url = Some("/".into());
         let mut config = cobalt::cobalt_model::Config::from_config(config)?;
         debug!(
             "Overriding config `destination` with `{}`",

--- a/src/bin/cobalt/serve.rs
+++ b/src/bin/cobalt/serve.rs
@@ -46,7 +46,7 @@ impl ServeArgs {
         let server = server.build();
 
         let mut config = self.config.load_config()?;
-        debug!("Overriding config `site.base_url` with `{}`", server.addr());
+        debug!("Overriding config `site.base_url` with `/`");
         config.site.base_url = Some("/".into());
         let mut config = cobalt::cobalt_model::Config::from_config(config)?;
         debug!(


### PR DESCRIPTION
Why? Tunneling! For example GitHub Codespaces will tunnel your port 1234 on your codespace's localhost to https://sometunnel-1234.githubcodespaces.example.org/. if you try to get `http://localhost:1234/style.css` then it fails since its not on localhost; its on a completely separate domain

ex:
```html
<link rel=stylesheet href="{{ site.base_url }}/style.css">
```

This pr (hopefully) would fix that by turning the HTML from this:

```html
<link rel=stylesheet href="http://localhost:1234/style.css">
```
into this which works across localhost and tunnels
```html
<link rel=stylesheet href="/style.css">
```