### PR TITLE
fix: cobalt serve work correctly with sitemap

### DIFF
--- a/src/bin/cobalt/serve.rs
+++ b/src/bin/cobalt/serve.rs
@@ -47,14 +47,14 @@ impl ServeArgs {
 
         let mut config = self.config.load_config()?;
         debug!("Overriding config `site.base_url` with `/`");
-        config.site.base_url = Some("/".into());
+        let host = format!("http://{}/", server.addr());
+        config.site.base_url = Some(host.into());
         let mut config = cobalt_model::Config::from_config(config)?;
         debug!(
             "Overriding config `destination` with `{}`",
             dest.path().display()
         );
         config.destination = dest.path().to_owned();
-
         build::build(config.clone())?;
 
         if self.open {


### PR DESCRIPTION
Hi,

In the last release `cobalt serve` fail if sitemap is enabled, this is because sitemap require a full url and so the required base_url should be full, the serve replace the base_url with a '/' which cause the problem, this just replace the "/" with the current addr of the server. 