### PR TITLE
Release AArch64 for macOS instead of x86-64

### DIFF
--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -67,7 +67,7 @@ jobs:
         - build: macos
           os: macos-latest
           rust: stable
-          target: x86_64-apple-darwin
+          target: aarch64-apple-darwin
         - build: win-msvc
           os: windows-2019
           rust: stable


### PR DESCRIPTION
For the last several release builds the macOS x86-64 build has failed. See this example:
