### PR TITLE
feat: Add a 'css' theme for syntax highlighting

### DIFF
--- a/crates/engarde/src/syntax.rs
+++ b/crates/engarde/src/syntax.rs
@@ -3,7 +3,7 @@ use syntect::easy::HighlightLines;
 use syntect::highlighting::ThemeSet;
 use syntect::html::{
     ClassStyle, ClassedHTMLGenerator, IncludeBackground, append_highlighted_html_for_styled_line,
-    start_highlighted_html_snippet,
+    css_for_theme_with_class_style, start_highlighted_html_snippet,
 };
 use syntect::parsing::{SyntaxReference, SyntaxSet};
 use syntect::util::LinesWithEndings;
@@ -34,6 +34,10 @@ impl Syntax {
         self.syntax_set = builder.build();
     }
 
+    pub fn css_theme_name() -> &'static str {
+        CSS_THEME
+    }
+
     pub fn has_theme(&self, name: &str) -> bool {
         name == CSS_THEME || self.theme_set.themes.contains_key(name)
     }
@@ -44,6 +48,16 @@ impl Syntax {
         themes.sort_by_key(|a| a.to_ascii_lowercase());
 
         themes.into_iter()
+    }
+
+    fn css_class_style() -> ClassStyle {
+        ClassStyle::SpacedPrefixed { prefix: "c-" }
+    }
+
+    /// Get the content of a css file to apply the specified color theme when using the 'css' theme
+    pub fn css_for_theme(&self, name: &str) -> String {
+        let theme = &self.theme_set.themes[name];
+        css_for_theme_with_class_style(theme, Self::css_class_style()).unwrap()
     }
 
     pub fn syntaxes(&self) -> impl Iterator<Item = String> + '_ {
@@ -101,7 +115,7 @@ impl Syntax {
         let mut html_generator = ClassedHTMLGenerator::new_with_class_style(
             syntax,
             &self.syntax_set,
-            ClassStyle::SpacedPrefixed { prefix: "c-" },
+            Self::css_class_style(),
         );
 
         for line in LinesWithEndings::from(code) {

--- a/crates/engarde/src/syntax.rs
+++ b/crates/engarde/src/syntax.rs
@@ -66,32 +66,38 @@ impl Syntax {
         self.default_theme = Some(theme.into());
     }
 
+
+    fn format_inline_theme(&self, code: &str, theme: &str, syntax: &SyntaxReference) -> String {
+        let theme = &self.theme_set.themes[theme];
+
+        // Essentially the same as `syntect::html::highlighted_html_for_string`,
+        // but adding <code> tags between the <pre> tags
+        // See: https://docs.rs/syntect/5.0.0/src/syntect/html.rs.html#269
+        let mut highlighter = HighlightLines::new(syntax, theme);
+        let (mut output, bg) = start_highlighted_html_snippet(theme);
+        output.push_str("<code>");
+
+        for line in LinesWithEndings::from(code) {
+            let regions = highlighter.highlight_line(line, &self.syntax_set).unwrap();
+            append_highlighted_html_for_styled_line(
+                &regions[..],
+                IncludeBackground::IfDifferent(bg),
+                &mut output,
+            )
+            .unwrap();
+        }
+
+        output.push_str("</code></pre>\n");
+        output
+    }
+
     pub fn format(&self, code: &str, lang: Option<&str>, theme: Option<&str>) -> String {
         if let Some(theme) = theme.or_else(|| self.default_theme()) {
-            let theme = &self.theme_set.themes[theme];
-
             let syntax = lang
                 .and_then(|l| self.syntax_set.find_syntax_by_token(l))
                 .unwrap_or_else(|| self.syntax_set.find_syntax_plain_text());
 
-            // Essentially the same as `syntect::html::highlighted_html_for_string`,
-            // but adding <code> tags between the <pre> tags
-            // See: https://docs.rs/syntect/5.0.0/src/syntect/html.rs.html#269
-            let mut highlighter = HighlightLines::new(syntax, theme);
-            let (mut output, bg) = start_highlighted_html_snippet(theme);
-            output.push_str("<code>");
-
-            for line in LinesWithEndings::from(code) {
-                let regions = highlighter.highlight_line(line, &self.syntax_set).unwrap();
-                append_highlighted_html_for_styled_line(
-                    &regions[..],
-                    IncludeBackground::IfDifferent(bg),
-                    &mut output,
-                )
-                .unwrap();
-            }
-            output.push_str("</code></pre>\n");
-            output
+            self.format_inline_theme(code, theme, syntax)
         } else {
             crate::Raw::new().format(code, lang, theme)
         }

--- a/src/bin/cobalt/debug.rs
+++ b/src/bin/cobalt/debug.rs
@@ -1,5 +1,7 @@
 use crate::args;
 use crate::error::Result;
+#[cfg(feature = "syntax-highlight")]
+use std::path::PathBuf;
 
 /// Print site debug information
 #[derive(Clone, Debug, PartialEq, Eq, clap::Subcommand)]
@@ -34,6 +36,19 @@ pub(crate) enum HighlightCommands {
         #[command(flatten, next_help_heading = "Config")]
         config: args::ConfigArgs,
     },
+
+    /// Save the css file for a theme
+    #[cfg(feature = "syntax-highlight")]
+    SaveThemeCss {
+        #[command(flatten, next_help_heading = "Config")]
+        config: args::ConfigArgs,
+
+        /// Name of the theme to generate a css file for
+        name: String,
+
+        /// Path of the css file
+        path: PathBuf,
+    },
 }
 
 impl DebugCommands {
@@ -57,6 +72,23 @@ impl DebugCommands {
                 for name in config.syntax.syntaxes() {
                     println!("{name}");
                 }
+            }
+            #[cfg(feature = "syntax-highlight")]
+            Self::Highlight(HighlightCommands::SaveThemeCss { config, name, path }) => {
+                let config = config.load_config()?;
+                let config = cobalt::cobalt_model::Config::from_config(config)?;
+                if name == engarde::Syntax::css_theme_name() || !config.syntax.has_theme(name) {
+                    return Err(anyhow::anyhow!("Unknown theme: {name}"));
+                }
+
+                let css = config.syntax.css_for_theme(name);
+
+                std::fs::write(path, css)?;
+
+                println!(
+                    "CSS theme '{name}' successfully saved to: {}",
+                    path.display()
+                );
             }
             Self::Files { collection, config } => {
                 let config = config.load_config()?;

--- a/tests/cli_tests.rs
+++ b/tests/cli_tests.rs
@@ -11,6 +11,7 @@ fn cli_tests() {
         t.skip("tests/cmd/custom_syntax_highlighting.md");
         t.skip("tests/cmd/syntax_highlighting.md");
         t.skip("tests/cmd/syntax_highlighting_disabled.md");
+        t.skip("tests/cmd/syntax_highlighting_css.md");
     }
     #[cfg(not(feature = "serve"))]
     {

--- a/tests/cli_tests.rs
+++ b/tests/cli_tests.rs
@@ -9,6 +9,8 @@ fn cli_tests() {
         t.skip("tests/cmd/log_level.md");
         t.skip("tests/cmd/vimwiki_not_templated.md");
         t.skip("tests/cmd/custom_syntax_highlighting.md");
+        t.skip("tests/cmd/syntax_highlighting.md");
+        t.skip("tests/cmd/syntax_highlighting_disabled.md");
     }
     #[cfg(not(feature = "serve"))]
     {

--- a/tests/cmd/syntax_highlighting.in/_layouts/default.liquid
+++ b/tests/cmd/syntax_highlighting.in/_layouts/default.liquid
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>test</title>
+    </head>
+    <body>
+        <h1>{{ page.permalink }}</h1>
+
+        {{ page.content }}
+    </body>
+</html>
+

--- a/tests/cmd/syntax_highlighting.in/_layouts/posts.liquid
+++ b/tests/cmd/syntax_highlighting.in/_layouts/posts.liquid
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>My blog - {{ page.title }}</title>
+    </head>
+    <body>
+        {{ page.content }}
+    </body>
+</html>
+

--- a/tests/cmd/syntax_highlighting.in/index.liquid
+++ b/tests/cmd/syntax_highlighting.in/index.liquid
@@ -1,0 +1,8 @@
+---
+layout: default.liquid
+---
+This is my Index page!
+
+{% for post in collections.posts.pages %}
+ <a href="{{post.permalink}}">{{ post.title }}</a>
+{% endfor %}

--- a/tests/cmd/syntax_highlighting.in/posts/2022-08-23-my-first-post.md
+++ b/tests/cmd/syntax_highlighting.in/posts/2022-08-23-my-first-post.md
@@ -1,0 +1,25 @@
+---
+title: Some rust code
+published_date: 2022-08-23 22:01:41 +0000
+layout: default.liquid
+---
+# Some rust code
+
+```rust
+// This is a comment, and is ignored by the compiler.
+// You can test this code by clicking the "Run" button over there ->
+// or if you prefer to use your keyboard, you can use the "Ctrl + Enter"
+// shortcut.
+
+// This code is editable, feel free to hack it!
+// You can always return to the original code by clicking the "Reset" button ->
+
+// This is the main function.
+fn main() {
+    // Statements here are executed when the compiled binary is called.
+
+    // Print text to the console.
+    println!("Hello World!");
+}
+```
+

--- a/tests/cmd/syntax_highlighting.md
+++ b/tests/cmd/syntax_highlighting.md
@@ -1,0 +1,15 @@
+```console
+$ cobalt -v build --destination _dest
+WARN: No _cobalt.yml file found in current directory, using default config.
+Building from `.` into `[CWD]/_dest`
+DEBUG: glob converted to regex: Glob { glob: "**/.*", re: "(?-u)^(?:/?|.*/)//.[^/]*$", opts: GlobOptions { case_insensitive: false, literal_separator: true, backslash_escape: true, empty_alternates: false }, tokens: Tokens([RecursivePrefix, Literal('.'), ZeroOrMore]) }
+DEBUG: glob converted to regex: Glob { glob: "**/_*", re: "(?-u)^(?:/?|.*/)_[^/]*$", opts: GlobOptions { case_insensitive: false, literal_separator: true, backslash_escape: true, empty_alternates: false }, tokens: Tokens([RecursivePrefix, Literal('_'), ZeroOrMore]) }
+DEBUG: built glob set; 5 literals, 0 basenames, 0 extensions, 0 prefixes, 0 suffixes, 0 required extensions, 2 regexes
+DEBUG: Loading data from `./_data`
+DEBUG: glob converted to regex: Glob { glob: "**/.*", re: "(?-u)^(?:/?|.*/)//.[^/]*$", opts: GlobOptions { case_insensitive: false, literal_separator: true, backslash_escape: true, empty_alternates: false }, tokens: Tokens([RecursivePrefix, Literal('.'), ZeroOrMore]) }
+DEBUG: glob converted to regex: Glob { glob: "**/_*", re: "(?-u)^(?:/?|.*/)_[^/]*$", opts: GlobOptions { case_insensitive: false, literal_separator: true, backslash_escape: true, empty_alternates: false }, tokens: Tokens([RecursivePrefix, Literal('_'), ZeroOrMore]) }
+DEBUG: built glob set; 0 literals, 0 basenames, 0 extensions, 0 prefixes, 0 suffixes, 0 required extensions, 2 regexes
+DEBUG: Loading snippets from `./_includes`
+Build successful
+
+```

--- a/tests/cmd/syntax_highlighting.out/_dest/index.html
+++ b/tests/cmd/syntax_highlighting.out/_dest/index.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>test</title>
+    </head>
+    <body>
+        <h1>index.html</h1>
+
+        This is my Index page!
+
+
+ <a href="posts/2022-08-23-my-first-post.html">Some rust code</a>
+
+
+    </body>
+</html>
+

--- a/tests/cmd/syntax_highlighting.out/_dest/posts/2022-08-23-my-first-post.html
+++ b/tests/cmd/syntax_highlighting.out/_dest/posts/2022-08-23-my-first-post.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>test</title>
+    </head>
+    <body>
+        <h1>posts/2022-08-23-my-first-post.html</h1>
+
+        <h1>Some rust code</h1>
+<pre style="background-color:#2b303b;">
+<code><span style="color:#65737e;">// This is a comment, and is ignored by the compiler.
+</span><span style="color:#65737e;">// You can test this code by clicking the &quot;Run&quot; button over there -&gt;
+</span><span style="color:#65737e;">// or if you prefer to use your keyboard, you can use the &quot;Ctrl + Enter&quot;
+</span><span style="color:#65737e;">// shortcut.
+</span><span style="color:#c0c5ce;">
+</span><span style="color:#65737e;">// This code is editable, feel free to hack it!
+</span><span style="color:#65737e;">// You can always return to the original code by clicking the &quot;Reset&quot; button -&gt;
+</span><span style="color:#c0c5ce;">
+</span><span style="color:#65737e;">// This is the main function.
+</span><span style="color:#b48ead;">fn </span><span style="color:#8fa1b3;">main</span><span style="color:#c0c5ce;">() {
+</span><span style="color:#c0c5ce;">    </span><span style="color:#65737e;">// Statements here are executed when the compiled binary is called.
+</span><span style="color:#c0c5ce;">
+</span><span style="color:#c0c5ce;">    </span><span style="color:#65737e;">// Print text to the console.
+</span><span style="color:#c0c5ce;">    println!(&quot;</span><span style="color:#a3be8c;">Hello World!</span><span style="color:#c0c5ce;">&quot;);
+</span><span style="color:#c0c5ce;">}
+</span></code></pre>
+
+    </body>
+</html>
+

--- a/tests/cmd/syntax_highlighting_css.in/_cobalt.yml
+++ b/tests/cmd/syntax_highlighting_css.in/_cobalt.yml
@@ -1,0 +1,2 @@
+syntax_highlight:
+  theme: "css"

--- a/tests/cmd/syntax_highlighting_css.in/_layouts/default.liquid
+++ b/tests/cmd/syntax_highlighting_css.in/_layouts/default.liquid
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>test</title>
+    </head>
+    <body>
+        <h1>{{ page.permalink }}</h1>
+
+        {{ page.content }}
+    </body>
+</html>
+

--- a/tests/cmd/syntax_highlighting_css.in/_layouts/posts.liquid
+++ b/tests/cmd/syntax_highlighting_css.in/_layouts/posts.liquid
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>My blog - {{ page.title }}</title>
+    </head>
+    <body>
+        {{ page.content }}
+    </body>
+</html>
+

--- a/tests/cmd/syntax_highlighting_css.in/index.liquid
+++ b/tests/cmd/syntax_highlighting_css.in/index.liquid
@@ -1,0 +1,8 @@
+---
+layout: default.liquid
+---
+This is my Index page!
+
+{% for post in collections.posts.pages %}
+ <a href="{{post.permalink}}">{{ post.title }}</a>
+{% endfor %}

--- a/tests/cmd/syntax_highlighting_css.in/posts/2022-08-23-my-first-post.md
+++ b/tests/cmd/syntax_highlighting_css.in/posts/2022-08-23-my-first-post.md
@@ -1,0 +1,25 @@
+---
+title: Some rust code
+published_date: 2022-08-23 22:01:41 +0000
+layout: default.liquid
+---
+# Some rust code
+
+```rust
+// This is a comment, and is ignored by the compiler.
+// You can test this code by clicking the "Run" button over there ->
+// or if you prefer to use your keyboard, you can use the "Ctrl + Enter"
+// shortcut.
+
+// This code is editable, feel free to hack it!
+// You can always return to the original code by clicking the "Reset" button ->
+
+// This is the main function.
+fn main() {
+    // Statements here are executed when the compiled binary is called.
+
+    // Print text to the console.
+    println!("Hello World!");
+}
+```
+

--- a/tests/cmd/syntax_highlighting_css.md
+++ b/tests/cmd/syntax_highlighting_css.md
@@ -1,0 +1,15 @@
+```console
+$ cobalt -v build --destination _dest
+WARN: No _cobalt.yml file found in current directory, using default config.
+Building from `.` into `[CWD]/_dest`
+DEBUG: glob converted to regex: Glob { glob: "**/.*", re: "(?-u)^(?:/?|.*/)//.[^/]*$", opts: GlobOptions { case_insensitive: false, literal_separator: true, backslash_escape: true, empty_alternates: false }, tokens: Tokens([RecursivePrefix, Literal('.'), ZeroOrMore]) }
+DEBUG: glob converted to regex: Glob { glob: "**/_*", re: "(?-u)^(?:/?|.*/)_[^/]*$", opts: GlobOptions { case_insensitive: false, literal_separator: true, backslash_escape: true, empty_alternates: false }, tokens: Tokens([RecursivePrefix, Literal('_'), ZeroOrMore]) }
+DEBUG: built glob set; 5 literals, 0 basenames, 0 extensions, 0 prefixes, 0 suffixes, 0 required extensions, 2 regexes
+DEBUG: Loading data from `./_data`
+DEBUG: glob converted to regex: Glob { glob: "**/.*", re: "(?-u)^(?:/?|.*/)//.[^/]*$", opts: GlobOptions { case_insensitive: false, literal_separator: true, backslash_escape: true, empty_alternates: false }, tokens: Tokens([RecursivePrefix, Literal('.'), ZeroOrMore]) }
+DEBUG: glob converted to regex: Glob { glob: "**/_*", re: "(?-u)^(?:/?|.*/)_[^/]*$", opts: GlobOptions { case_insensitive: false, literal_separator: true, backslash_escape: true, empty_alternates: false }, tokens: Tokens([RecursivePrefix, Literal('_'), ZeroOrMore]) }
+DEBUG: built glob set; 0 literals, 0 basenames, 0 extensions, 0 prefixes, 0 suffixes, 0 required extensions, 2 regexes
+DEBUG: Loading snippets from `./_includes`
+Build successful
+
+```

--- a/tests/cmd/syntax_highlighting_css.md
+++ b/tests/cmd/syntax_highlighting_css.md
@@ -1,6 +1,6 @@
 ```console
 $ cobalt -v build --destination _dest
-WARN: No _cobalt.yml file found in current directory, using default config.
+DEBUG: Using config file `./_cobalt.yml`
 Building from `.` into `[CWD]/_dest`
 DEBUG: glob converted to regex: Glob { glob: "**/.*", re: "(?-u)^(?:/?|.*/)//.[^/]*$", opts: GlobOptions { case_insensitive: false, literal_separator: true, backslash_escape: true, empty_alternates: false }, tokens: Tokens([RecursivePrefix, Literal('.'), ZeroOrMore]) }
 DEBUG: glob converted to regex: Glob { glob: "**/_*", re: "(?-u)^(?:/?|.*/)_[^/]*$", opts: GlobOptions { case_insensitive: false, literal_separator: true, backslash_escape: true, empty_alternates: false }, tokens: Tokens([RecursivePrefix, Literal('_'), ZeroOrMore]) }

--- a/tests/cmd/syntax_highlighting_css.out/_dest/index.html
+++ b/tests/cmd/syntax_highlighting_css.out/_dest/index.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>test</title>
+    </head>
+    <body>
+        <h1>index.html</h1>
+
+        This is my Index page!
+
+
+ <a href="posts/2022-08-23-my-first-post.html">Some rust code</a>
+
+
+    </body>
+</html>
+

--- a/tests/cmd/syntax_highlighting_css.out/_dest/posts/2022-08-23-my-first-post.html
+++ b/tests/cmd/syntax_highlighting_css.out/_dest/posts/2022-08-23-my-first-post.html
@@ -7,24 +7,22 @@
         <h1>posts/2022-08-23-my-first-post.html</h1>
 
         <h1>Some rust code</h1>
-<pre style="background-color:#2b303b;">
-<code><span style="color:#65737e;">// This is a comment, and is ignored by the compiler.
-</span><span style="color:#65737e;">// You can test this code by clicking the &quot;Run&quot; button over there -&gt;
-</span><span style="color:#65737e;">// or if you prefer to use your keyboard, you can use the &quot;Ctrl + Enter&quot;
-</span><span style="color:#65737e;">// shortcut.
-</span><span style="color:#c0c5ce;">
-</span><span style="color:#65737e;">// This code is editable, feel free to hack it!
-</span><span style="color:#65737e;">// You can always return to the original code by clicking the &quot;Reset&quot; button -&gt;
-</span><span style="color:#c0c5ce;">
-</span><span style="color:#65737e;">// This is the main function.
-</span><span style="color:#b48ead;">fn </span><span style="color:#8fa1b3;">main</span><span style="color:#c0c5ce;">() {
-</span><span style="color:#c0c5ce;">    </span><span style="color:#65737e;">// Statements here are executed when the compiled binary is called.
-</span><span style="color:#c0c5ce;">
-</span><span style="color:#c0c5ce;">    </span><span style="color:#65737e;">// Print text to the console.
-</span><span style="color:#c0c5ce;">    println!(&quot;</span><span style="color:#a3be8c;">Hello World!</span><span style="color:#c0c5ce;">&quot;);
-</span><span style="color:#c0c5ce;">}
+<pre class="language-rust highlighter-syntect"><code class="highlight"><span class="c-source c-rust"><span class="c-comment c-line c-double-slash c-rust"><span class="c-punctuation c-definition c-comment c-rust">//</span> This is a comment, and is ignored by the compiler.
+</span><span class="c-comment c-line c-double-slash c-rust"><span class="c-punctuation c-definition c-comment c-rust">//</span> You can test this code by clicking the &quot;Run&quot; button over there -&gt;
+</span><span class="c-comment c-line c-double-slash c-rust"><span class="c-punctuation c-definition c-comment c-rust">//</span> or if you prefer to use your keyboard, you can use the &quot;Ctrl + Enter&quot;
+</span><span class="c-comment c-line c-double-slash c-rust"><span class="c-punctuation c-definition c-comment c-rust">//</span> shortcut.
+</span>
+<span class="c-comment c-line c-double-slash c-rust"><span class="c-punctuation c-definition c-comment c-rust">//</span> This code is editable, feel free to hack it!
+</span><span class="c-comment c-line c-double-slash c-rust"><span class="c-punctuation c-definition c-comment c-rust">//</span> You can always return to the original code by clicking the &quot;Reset&quot; button -&gt;
+</span>
+<span class="c-comment c-line c-double-slash c-rust"><span class="c-punctuation c-definition c-comment c-rust">//</span> This is the main function.
+</span><span class="c-meta c-function c-rust"><span class="c-meta c-function c-rust"><span class="c-storage c-type c-function c-rust">fn</span> </span><span class="c-entity c-name c-function c-rust">main</span></span><span class="c-meta c-function c-rust"><span class="c-meta c-function c-parameters c-rust"><span class="c-punctuation c-section c-parameters c-begin c-rust">(</span></span><span class="c-meta c-function c-rust"><span class="c-meta c-function c-parameters c-rust"><span class="c-punctuation c-section c-parameters c-end c-rust">)</span></span></span></span><span class="c-meta c-function c-rust"> </span><span class="c-meta c-function c-rust"><span class="c-meta c-block c-rust"><span class="c-punctuation c-section c-block c-begin c-rust">{</span>
+    <span class="c-comment c-line c-double-slash c-rust"><span class="c-punctuation c-definition c-comment c-rust">//</span> Statements here are executed when the compiled binary is called.
+</span>
+    <span class="c-comment c-line c-double-slash c-rust"><span class="c-punctuation c-definition c-comment c-rust">//</span> Print text to the console.
+</span>    <span class="c-support c-macro c-rust">println!</span><span class="c-meta c-group c-rust"><span class="c-punctuation c-section c-group c-begin c-rust">(</span></span><span class="c-meta c-group c-rust"><span class="c-string c-quoted c-double c-rust"><span class="c-punctuation c-definition c-string c-begin c-rust">&quot;</span>Hello World!<span class="c-punctuation c-definition c-string c-end c-rust">&quot;</span></span></span><span class="c-meta c-group c-rust"><span class="c-punctuation c-section c-group c-end c-rust">)</span></span><span class="c-punctuation c-terminator c-rust">;</span>
+</span><span class="c-meta c-block c-rust"><span class="c-punctuation c-section c-block c-end c-rust">}</span></span></span>
 </span></code></pre>
-
     </body>
 </html>
 

--- a/tests/cmd/syntax_highlighting_css.out/_dest/posts/2022-08-23-my-first-post.html
+++ b/tests/cmd/syntax_highlighting_css.out/_dest/posts/2022-08-23-my-first-post.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>test</title>
+    </head>
+    <body>
+        <h1>posts/2022-08-23-my-first-post.html</h1>
+
+        <h1>Some rust code</h1>
+<pre style="background-color:#2b303b;">
+<code><span style="color:#65737e;">// This is a comment, and is ignored by the compiler.
+</span><span style="color:#65737e;">// You can test this code by clicking the &quot;Run&quot; button over there -&gt;
+</span><span style="color:#65737e;">// or if you prefer to use your keyboard, you can use the &quot;Ctrl + Enter&quot;
+</span><span style="color:#65737e;">// shortcut.
+</span><span style="color:#c0c5ce;">
+</span><span style="color:#65737e;">// This code is editable, feel free to hack it!
+</span><span style="color:#65737e;">// You can always return to the original code by clicking the &quot;Reset&quot; button -&gt;
+</span><span style="color:#c0c5ce;">
+</span><span style="color:#65737e;">// This is the main function.
+</span><span style="color:#b48ead;">fn </span><span style="color:#8fa1b3;">main</span><span style="color:#c0c5ce;">() {
+</span><span style="color:#c0c5ce;">    </span><span style="color:#65737e;">// Statements here are executed when the compiled binary is called.
+</span><span style="color:#c0c5ce;">
+</span><span style="color:#c0c5ce;">    </span><span style="color:#65737e;">// Print text to the console.
+</span><span style="color:#c0c5ce;">    println!(&quot;</span><span style="color:#a3be8c;">Hello World!</span><span style="color:#c0c5ce;">&quot;);
+</span><span style="color:#c0c5ce;">}
+</span></code></pre>
+
+    </body>
+</html>
+

--- a/tests/cmd/syntax_highlighting_disabled.in/_cobalt.yml
+++ b/tests/cmd/syntax_highlighting_disabled.in/_cobalt.yml
@@ -1,0 +1,2 @@
+syntax_highlight:
+  enabled: false

--- a/tests/cmd/syntax_highlighting_disabled.in/_layouts/default.liquid
+++ b/tests/cmd/syntax_highlighting_disabled.in/_layouts/default.liquid
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>test</title>
+    </head>
+    <body>
+        <h1>{{ page.permalink }}</h1>
+
+        {{ page.content }}
+    </body>
+</html>
+

--- a/tests/cmd/syntax_highlighting_disabled.in/_layouts/posts.liquid
+++ b/tests/cmd/syntax_highlighting_disabled.in/_layouts/posts.liquid
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>My blog - {{ page.title }}</title>
+    </head>
+    <body>
+        {{ page.content }}
+    </body>
+</html>
+

--- a/tests/cmd/syntax_highlighting_disabled.in/index.liquid
+++ b/tests/cmd/syntax_highlighting_disabled.in/index.liquid
@@ -1,0 +1,8 @@
+---
+layout: default.liquid
+---
+This is my Index page!
+
+{% for post in collections.posts.pages %}
+ <a href="{{post.permalink}}">{{ post.title }}</a>
+{% endfor %}

--- a/tests/cmd/syntax_highlighting_disabled.in/posts/2022-08-23-my-first-post.md
+++ b/tests/cmd/syntax_highlighting_disabled.in/posts/2022-08-23-my-first-post.md
@@ -1,0 +1,25 @@
+---
+title: Some rust code
+published_date: 2022-08-23 22:01:41 +0000
+layout: default.liquid
+---
+# Some rust code
+
+```rust
+// This is a comment, and is ignored by the compiler.
+// You can test this code by clicking the "Run" button over there ->
+// or if you prefer to use your keyboard, you can use the "Ctrl + Enter"
+// shortcut.
+
+// This code is editable, feel free to hack it!
+// You can always return to the original code by clicking the "Reset" button ->
+
+// This is the main function.
+fn main() {
+    // Statements here are executed when the compiled binary is called.
+
+    // Print text to the console.
+    println!("Hello World!");
+}
+```
+

--- a/tests/cmd/syntax_highlighting_disabled.md
+++ b/tests/cmd/syntax_highlighting_disabled.md
@@ -1,0 +1,15 @@
+```console
+$ cobalt -v build --destination _dest
+DEBUG: Using config file `./_cobalt.yml`
+Building from `.` into `[CWD]/_dest`
+DEBUG: glob converted to regex: Glob { glob: "**/.*", re: "(?-u)^(?:/?|.*/)//.[^/]*$", opts: GlobOptions { case_insensitive: false, literal_separator: true, backslash_escape: true, empty_alternates: false }, tokens: Tokens([RecursivePrefix, Literal('.'), ZeroOrMore]) }
+DEBUG: glob converted to regex: Glob { glob: "**/_*", re: "(?-u)^(?:/?|.*/)_[^/]*$", opts: GlobOptions { case_insensitive: false, literal_separator: true, backslash_escape: true, empty_alternates: false }, tokens: Tokens([RecursivePrefix, Literal('_'), ZeroOrMore]) }
+DEBUG: built glob set; 5 literals, 0 basenames, 0 extensions, 0 prefixes, 0 suffixes, 0 required extensions, 2 regexes
+DEBUG: Loading data from `./_data`
+DEBUG: glob converted to regex: Glob { glob: "**/.*", re: "(?-u)^(?:/?|.*/)//.[^/]*$", opts: GlobOptions { case_insensitive: false, literal_separator: true, backslash_escape: true, empty_alternates: false }, tokens: Tokens([RecursivePrefix, Literal('.'), ZeroOrMore]) }
+DEBUG: glob converted to regex: Glob { glob: "**/_*", re: "(?-u)^(?:/?|.*/)_[^/]*$", opts: GlobOptions { case_insensitive: false, literal_separator: true, backslash_escape: true, empty_alternates: false }, tokens: Tokens([RecursivePrefix, Literal('_'), ZeroOrMore]) }
+DEBUG: built glob set; 0 literals, 0 basenames, 0 extensions, 0 prefixes, 0 suffixes, 0 required extensions, 2 regexes
+DEBUG: Loading snippets from `./_includes`
+Build successful
+
+```

--- a/tests/cmd/syntax_highlighting_disabled.out/_dest/index.html
+++ b/tests/cmd/syntax_highlighting_disabled.out/_dest/index.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>test</title>
+    </head>
+    <body>
+        <h1>index.html</h1>
+
+        This is my Index page!
+
+
+ <a href="posts/2022-08-23-my-first-post.html">Some rust code</a>
+
+
+    </body>
+</html>
+

--- a/tests/cmd/syntax_highlighting_disabled.out/_dest/posts/2022-08-23-my-first-post.html
+++ b/tests/cmd/syntax_highlighting_disabled.out/_dest/posts/2022-08-23-my-first-post.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>test</title>
+    </head>
+    <body>
+        <h1>posts/2022-08-23-my-first-post.html</h1>
+
+        <h1>Some rust code</h1>
+<pre><code class="language-rust">// This is a comment, and is ignored by the compiler.
+// You can test this code by clicking the &quot;Run&quot; button over there -&gt;
+// or if you prefer to use your keyboard, you can use the &quot;Ctrl + Enter&quot;
+// shortcut.
+
+// This code is editable, feel free to hack it!
+// You can always return to the original code by clicking the &quot;Reset&quot; button -&gt;
+
+// This is the main function.
+fn main() {
+    // Statements here are executed when the compiled binary is called.
+
+    // Print text to the console.
+    println!(&quot;Hello World!&quot;);
+}
+</code></pre>
+
+    </body>
+</html>
+


### PR DESCRIPTION
This theme doesn't specify any color but uses the `ClassedHTMLGenerator` to generate CSS classes instead. This allow to have per-color-scheme themes and to easily edit themes manually.

This is similar to Zola [classed-highlighting](https://www.getzola.org/documentation/content/syntax-highlighting/#inline-vs-classed-highlighting) feature except with a `c-` prefix instead of a `z-` one.

It generates css classes like that (whitespace modified for readibility):

```html
<pre class="language-rust highlighter-syntect">
  <code class="highlight"><span class="c-source c-rust">
    <span class="c-support c-macro c-rust">println!</span>
    <span class="c-meta c-group c-rust">
      <span class="c-punctuation c-section c-group c-begin c-rust">(</span>
    </span>
    <span class="c-meta c-group c-rust">
      <span class="c-string c-quoted c-double c-rust">
        <span class="c-punctuation c-definition c-string c-begin c-rust">&quot;</span>
        Hello World!
        <span class="c-punctuation c-definition c-string c-end c-rust">&quot;</span>
      </span>
    </span>
    <span class="c-meta c-group c-rust">
      <span class="c-punctuation c-section c-group c-end c-rust">)</span>
    </span>
    <span class="c-punctuation c-terminator c-rust">;</span>
  </code>
</pre>
```