### PR TITLE
fix: Define a default drafts_dir

### DIFF
--- a/crates/config/src/collection.rs
+++ b/crates/config/src/collection.rs
@@ -93,7 +93,7 @@ impl Default for PostCollection {
             title: Default::default(),
             description: Default::default(),
             dir: RelPath::from_unchecked("posts"),
-            drafts_dir: Default::default(),
+            drafts_dir: Some(RelPath::from_unchecked("_drafts")),
             order: Default::default(),
             rss: Default::default(),
             jsonfeed: Default::default(),


### PR DESCRIPTION
The documentation specifies that the default drafts_dir is '_drafts' but it wasn't the case in the code.

<img width="251" height="188" alt="image" src="https://github.com/user-attachments/assets/cd4f540b-3a99-4f6e-b894-4d051b4c7329" />
