### PR TITLE
Coverage fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -172,7 +172,7 @@ jobs:
     - name: Install cargo-tarpaulin
       run: cargo install cargo-tarpaulin
     - name: Gather coverage
-      run: cargo tarpaulin --output-dir coverage --out lcov
+      run: cargo tarpaulin --output-dir coverage --out lcov --timeout 300
     - name: Publish to Coveralls
       uses: coverallsapp/github-action@master
       with:

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 target
+coverage


### PR DESCRIPTION
Fix the coverage CI job by allowing more time to run the tests under code coverage.

Also: add the `coverage `folder generated by tarpaulin to `.gitignore`