### PR TITLE
feat: add an updated_date to the frontmatter

### DIFF
--- a/crates/config/src/frontmatter.rs
+++ b/crates/config/src/frontmatter.rs
@@ -27,6 +27,8 @@ pub struct Frontmatter {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub published_date: Option<DateTime>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub updated_date: Option<DateTime>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub format: Option<SourceFormat>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub templated: Option<bool>,
@@ -103,6 +105,7 @@ impl Frontmatter {
             tags,
             excerpt_separator,
             published_date,
+            updated_date,
             format,
             templated,
             layout,
@@ -122,6 +125,7 @@ impl Frontmatter {
             tags: tags.or_else(|| other.tags.clone()),
             excerpt_separator: excerpt_separator.or_else(|| other.excerpt_separator.clone()),
             published_date: published_date.or(other.published_date),
+            updated_date: updated_date.or(other.updated_date),
             format: format.or(other.format),
             templated: templated.or(other.templated),
             layout: layout.or_else(|| other.layout.clone()),

--- a/src/cobalt_model/frontmatter.rs
+++ b/src/cobalt_model/frontmatter.rs
@@ -20,6 +20,7 @@ pub struct Frontmatter {
     pub tags: Vec<liquid::model::KString>,
     pub excerpt_separator: liquid::model::KString,
     pub published_date: Option<DateTime>,
+    pub updated_date: Option<DateTime>,
     pub format: SourceFormat,
     pub templated: bool,
     pub layout: Option<liquid::model::KString>,
@@ -42,6 +43,7 @@ impl Frontmatter {
             tags,
             excerpt_separator,
             published_date,
+            updated_date,
             format,
             templated,
             layout,
@@ -73,6 +75,7 @@ impl Frontmatter {
             tags: tags.unwrap_or_default(),
             excerpt_separator: excerpt_separator.unwrap_or_else(|| "\n\n".into()),
             published_date,
+            updated_date,
             format: format.unwrap_or_default(),
             #[cfg(feature = "preview_unstable")]
             templated: templated.unwrap_or(false),


### PR DESCRIPTION
This commit simply adds an `updated_date` to the frontmatter; it's a common feature of static sites generators. It thus adresses issue #1207 .
The targeted scenario is this one : 
* someone writes a post and publishes it
* in a later period, the same persons updates the post, and adds an `updated_date` value to the frontmatter
* the website can now mention, despite the date of original posting, when it was later updated

This PR does not implement #197 . If the main maintainers are interested in this maybe I can look into it myself.

I can also update the documentation in cobalt-org/cobalt-org.github.io, when needed.

Thank you for this cool software !